### PR TITLE
fix: update netlify.yml to remove deprecated key for command

### DIFF
--- a/netlify.yml
+++ b/netlify.yml
@@ -1,5 +1,4 @@
 build:
   base: website
   publish: build
-  lifecycle:
-    onBuild: yarn build
+  command: yarn build


### PR DESCRIPTION
They deprecated the `onBuild` in favor of `command`. Updating it to clear the current warning and future breakages.