### PR TITLE
define npx

### DIFF
--- a/docs/getting-started/intro.md
+++ b/docs/getting-started/intro.md
@@ -33,7 +33,7 @@ We are assuming that you know what the command line is, how to install packages 
 
 ### Initializing an App
 
-The `tauri init` command creates the `src-tauri` folder with a few template files in your project directory. The most important file that it creates is the `src-tauri/tauri.conf.json` file, as this is where you manage the configuration of your project. You can read more about this here:
+The `npx tauri init` command creates the `src-tauri` folder with a few template files in your project directory. The most important file that it creates is the `src-tauri/tauri.conf.json` file, as this is where you manage the configuration of your project. You can read more about this here:
 
 - [Tauri Integration](../usage/integration)
 


### PR DESCRIPTION
when going through the docs I was wondering where `tauri init` comes from. I peeked into the discord and saw someone else run into the same issue. Amending `Initializing an App` section to specify npx