### PR TITLE
fix: HttpOptions type

### DIFF
--- a/docs/api/js.md
+++ b/docs/api/js.md
@@ -350,21 +350,19 @@ This type only lives in the docs for now.
 
 ```ts
 type HttpOptions = {
-  options: {
-    method: string
-    url: string
-    headers?: object
-    properties?: object
-    body?: string | object | Binary
-  }
+  method: string
+  url: string
+  params?: object
+  headers?: object
+  body?: string | object | Binary
   followRedirects: boolean // whether to follow redirects or not
   maxRedirections: number // max number of redirections
   connectTimeout: number // request connect timeout
   readTimeout: number // request read timeout
   timeout: number // request timeout
   allowCompression: boolean
-  responseType?: ResponseType
   bodyType?: BodyType
+  responseType?: ResponseType
 }
 ```
 


### PR DESCRIPTION
Compared against
```rust
/// The configuration object of an HTTP request
pub struct HttpRequestOptions {
  /// The request method (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, CONNECT or TRACE)
  pub method: String,
  /// The request URL
  pub url: String,
  /// The request query params
  pub params: Option<HashMap<String, Value>>,
  /// The request headers
  pub headers: Option<HashMap<String, Value>>,
  /// The request body
  pub body: Option<Value>,
  /// Whether to follow redirects or not
  pub follow_redirects: Option<bool>,
  /// Max number of redirections to follow
  pub max_redirections: Option<u32>,
  /// Connect timeout for the request
  pub connect_timeout: Option<u64>,
  /// Read timeout for the request
  pub read_timeout: Option<u64>,
  /// Timeout for the whole request
  pub timeout: Option<u64>,
  /// Whether the request will announce that it accepts compression
  pub allow_compression: Option<bool>,
  /// The body type (defaults to Auto)
  pub body_type: Option<BodyType>,
  /// The response type (defaults to Json)
  pub response_type: Option<ResponseType>,
}
```