### PR TITLE
fix(copy): remove leading $ in command blocks, fixes #113

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -134,7 +134,7 @@ export default ({ children, className: languageClassName, title }) => {
 
     if (button.current) {
       clipboard = new Clipboard(button.current, {
-        target: () => target.current,
+        text: () => target.current.textContent.replace(/^\$ /gm, ''),
       })
     }
 


### PR DESCRIPTION
Uses a regex to replace out the `$` at the beginning of a line.