### PR TITLE
Fix copy to clipboard

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -198,21 +198,19 @@ export default ({ children, className: languageClassName, title }) => {
     setTimeout(() => setShowCopied(false), 2000)
   }
   return (
-    <div ref={target} className={styles.codeBlockContainer}>
-      {title && (
-        <div className={styles.codeBlockTitle}>
-          {title}
-        </div>
-      )}
-      <Highlight
-        className={classnames(language, 'codeBlockContent')}
-        {...defaultProps}
-        key={mounted}
-        code={code}
-        language={language}
-      >
-        {code}
-      </Highlight>
+    <div className={styles.codeBlockContainer}>
+      {title && <div className={styles.codeBlockTitle}>{title}</div>}
+      <div ref={target}>
+        <Highlight
+          className={classnames(language, 'codeBlockContent')}
+          {...defaultProps}
+          key={mounted}
+          code={code}
+          language={language}
+        >
+          {code}
+        </Highlight>
+      </div>
       <button
         ref={button}
         type="button"


### PR DESCRIPTION
On https://tauri.studio/en/docs/api/config clicking copy would copy the following into your clipboard:
```
Example"build": {
  "distDir": "../dist",
  "devPath": "http://localhost:4000",
  "beforeDevCommand": "npm run dev",
  "beforeBuildCommand": "npm run build",
  "withGlobalTauri": false
}Copy
```

This PR fixes this, filling your clipboard only with the code:
```
"build": {
  "distDir": "../dist",
  "devPath": "http://localhost:4000",
  "beforeDevCommand": "npm run dev",
  "beforeBuildCommand": "npm run build",
  "withGlobalTauri": false
}
```