### PR TITLE
documentation: fix typo

### DIFF
--- a/docs/en/api/rust/tauri/struct.AppBuilder.md
+++ b/docs/en/api/rust/tauri/struct.AppBuilder.md
@@ -14,7 +14,7 @@ The App builder.
 
 #### `pub fn new() -> Self`
 
-Creates a new App bulder.
+Creates a new App builder.
 
 #### `pub fn invoke_handler<F: FnMut(&mut Webview, &str) -> Result<(), String> + 'static>( self, invoke_handler: F ) -> Self`
 


### PR DESCRIPTION
Just a little typo in API documentation 👍 