### PR TITLE
fix(docs): add wget and squashfs-tools dependency

### DIFF
--- a/docs/en/getting-started/setup-linux.md
+++ b/docs/en/getting-started/setup-linux.md
@@ -25,6 +25,7 @@ values={[
 $ sudo apt update && sudo apt install libwebkit2gtk-4.0-dev \
     build-essential \
     curl \
+    wget \
     libssl-dev \
     appmenu-gtk3-module \
     libgtk-3-dev
@@ -37,6 +38,7 @@ $ sudo apt update && sudo apt install libwebkit2gtk-4.0-dev \
 $ sudo pacman -Syy && sudo pacman -S  webkit2gtk \
     base-devel \
     curl \
+    wget \
     openssl \
     appmenu-gtk-module \
     gtk3 \
@@ -50,6 +52,7 @@ $ sudo pacman -Syy && sudo pacman -S  webkit2gtk \
 $ sudo dnf check-update && sudo dnf install webkit2gtk3-devel.x86_64 \
     openssl-devel \
     curl \
+    wget \
     && sudo dnf group install "C Development Tools and Libraries"
 ```
 

--- a/docs/en/getting-started/setup-linux.md
+++ b/docs/en/getting-started/setup-linux.md
@@ -28,7 +28,8 @@ $ sudo apt update && sudo apt install libwebkit2gtk-4.0-dev \
     wget \
     libssl-dev \
     appmenu-gtk3-module \
-    libgtk-3-dev
+    libgtk-3-dev \
+    squashfs-tools
 ```
 
 </TabItem>
@@ -53,6 +54,7 @@ $ sudo dnf check-update && sudo dnf install webkit2gtk3-devel.x86_64 \
     openssl-devel \
     curl \
     wget \
+    squashfs-tools \
     && sudo dnf group install "C Development Tools and Libraries"
 ```
 


### PR DESCRIPTION
Appimages build will fail if wget and squashfs-tools isn't installed which might be the case for a lot of users that use minimal linux installations.