### PR TITLE
Update setup-windows.md

### DIFF
--- a/docs/en/getting-started/setup-windows.md
+++ b/docs/en/getting-started/setup-windows.md
@@ -101,7 +101,7 @@ If you have installed <a href="https://developer.microsoft.com/en-us/microsoft-e
 
 ## 7. Optional WebView2 (Chromium)
 
-If you want to use front-end features that aren't supported by the Windows Edge Webview, you can download and use the newer Edge <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">WebView2</a>. Edge WebView2 uses the chromium rendering engine for web content. Certain animations like the one found in the Create-React-App example are better supported in WebView2. Compare Browser features <a href="https://caniuse.com/?compare=ie+10,ie+11,edge+80,firefox+74,chrome+80&compareCats=all" target="_blank">here</a>.
+If you want to use front-end features that aren't supported by the Windows Edge Webview, you can download and use the newer Edge <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">WebView2</a>. Edge WebView2 uses the chromium rendering engine for web content. Certain animations like the one found in the Create-React-App example are better supported in WebView2. Compare Browser features <a href="https://caniuse.com/?compare=ie+10,ie+11,edge+80,firefox+74,chrome+80&compareCats=all" target="_blank">here</a>. Keep in mind that users of your app may still be using the old Edge Weview, so your app shouldn't rely on the new browser features in Webview2.
 
 - <a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section" target="_blank">Download</a>
 

--- a/docs/en/getting-started/setup-windows.md
+++ b/docs/en/getting-started/setup-windows.md
@@ -99,6 +99,12 @@ If you need help take a look at the <a href="https://docs.microsoft.com/en-us/mi
 If you have installed <a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">WebView2</a>, you do not need to install Edge Devtools. Instead, just right click inside the Tauri window and select "Inspect" to open devtools. If there is no right click menu, it is likely you are just using Devtools 1 and you should follow the instructions above.
 </Alert>
 
+## 7. Optional WebView2 (Chromium)
+
+If you want to use front-end features that aren't supported by the Windows Edge Webview, you can download and use the newer Edge <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">WebView2</a>. Edge WebView2 uses the chromium rendering engine for web content. Certain animations like the one found in the Create-React-App example are better supported in WebView2. Compare Browser features <a href="https://caniuse.com/?compare=ie+10,ie+11,edge+80,firefox+74,chrome+80&compareCats=all" target="_blank">here</a>.
+
+- <a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section" target="_blank">Download</a>
+
 ## Continue
 
 Now that you have set up the Windows-specific dependencies for Tauri, learn how to [add Tauri to your project](/docs/usage/development/integration).


### PR DESCRIPTION
#33. I am relatively new to Rust, coming from Node/React/Electron background. I've found that using the WebView2 it is easier to port my front-end React code from Electron to Tauri since Electron is also chromium based. It seems to me that WebView2 will eventually become default on Windows but I'm not sure when that will be the case. I see that WebView2 is already linked, but it is something that I missed when going through Tauri my first time.