### PR TITLE
fix(docs): -- is necessary for `npm run` to pass options to underlying command

### DIFF
--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -10,13 +10,21 @@ const types = [
   { label: 'Global', value: 'tauri ' },
 ]
 
+function insertDashDashBeforeOption (value, name) {
+  const idx = name.indexOf('--')
+  if (idx === -1) {
+    return value + name
+  }
+  return value + name.slice(0, idx) + '-- ' + name.slice(idx)
+}
+
 export default ({ name }) => {
   return (
     <Tabs groupId="installMode" defaultValue="yarn" values={types}>
       {types.map((type) => (
         <TabItem value={type.value}>
           <CodeBlock className="language-sh">
-            {type.value + name}
+            {type.label !== 'npm' ? type.value + name : insertDashDashBeforeOption(type.value, name)}
           </CodeBlock>
         </TabItem>
       ))}

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -20,7 +20,7 @@ function insertDashDashBeforeOption (value, name) {
 
 export default ({ name }) => {
   return (
-    <Tabs groupId="installMode" defaultValue="yarn" values={types}>
+    <Tabs groupId="installMode" defaultValue="Yarn" values={types}>
       {types.map((type) => (
         <TabItem value={type.value}>
           <CodeBlock className="language-sh">


### PR DESCRIPTION
In documentation, `--debug` option is passed to `npm run` as follows:

```
npm run tauri build --debug
```

https://tauri.studio/en/docs/development/debugging

However, this does not pass the `--debug` option to underlying `tauri` command. It runs `tauri build` command and release mode is used to bundle the app. This is because the `--debug` option is consumed by `npm run` command. To pass the option to the underlying command, `--` must be put before the option.

```
npm run tauri build -- --debug
```

I confirmed that it works as intended on my local today. This PR fixes the point.