### PR TITLE
chore(roadmap): remove wasm as that won't be implemented

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -219,11 +219,6 @@ const Roadmap = ({ siteConfig }) => {
       targetQuarter: 'Planned',
     },
     {
-      icon: 'ti-bolt',
-      color: COLORS.blue,
-      targetQuarter: 'Planned',
-    },
-    {
       icon: 'ti-panel',
       color: COLORS.blue,
       targetQuarter: 'Planned',

--- a/translations/en.json
+++ b/translations/en.json
@@ -155,10 +155,6 @@
             "description": "Run a command that is no longer available after first run."
           },
           {
-            "label": "WASM Bundler",
-            "description": "Manufacture WASM bundler for use in websites."
-          },
-          {
             "label": "App Tray",
             "description": "Desktop Cross-platform Icon Tray."
           },


### PR DESCRIPTION
The core team decided that we won't be working on this feature in the foreseeable future, so we should remove it from the roadmap.