### PR TITLE
Announcement bar have an height bug, it's the fix

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -205,7 +205,7 @@ h2 > [class^='ti-'] {
 }
 
 [class*='announcementBar_'] {
-  height: auto !important;
+  min-height: 52px;
 }
 
 [class*='property_'] .hash-link {


### PR DESCRIPTION
Hey I notice a bug on the height of the announcement bar

![image](https://user-images.githubusercontent.com/32040951/114467028-8cfce000-9be9-11eb-9407-4911f5162291.png)

And when it's fixed

![image](https://user-images.githubusercontent.com/32040951/114467120-b7e73400-9be9-11eb-8aed-7f3dc370795d.png)
