### PR TITLE
Fix gtksourceview3 Fedora package name

### DIFF
--- a/docs/en/getting-started/setup-linux.md
+++ b/docs/en/getting-started/setup-linux.md
@@ -71,7 +71,7 @@ $ sudo dnf group install "C Development Tools and Libraries" && \
         openssl-devel \
         gtk3 \
         webkit2gtk3-devel.x86_64 \
-        gtksourceview-3.0 \
+        gtksourceview3 \
         libappindicator-devel
 ```
 


### PR DESCRIPTION
The proper package name in the setup instructions is `gtksourceview3`, instead of `gtksourceview-3.0`.

Verified on Fedora 34.