### PR TITLE
Add a REAL Introduction copied from Architecture.

### DIFF
--- a/docs/en/getting-started/intro.md
+++ b/docs/en/getting-started/intro.md
@@ -4,7 +4,15 @@ title: Introduction
 
 import OSList from '@theme/OSList'
 
-Welcome to Tauri! This guide will help you create your first Tauri app. It should only take about 10 minutes, although it could take longer if you have a slower internet connection.
+Welcome to Tauri! 
+
+Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of [Rust](https://www.rust-lang.org/) tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing.
+
+**Developers can even extend the default API** with their own functionality and bridge the Webview and Rust-based backend easily!
+
+The Architecture is more fully described in [Architecture](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md).
+
+This guide will help you create your first Tauri app. It should only take about 10 minutes, although it could take longer if you have a slower internet connection.
 
 If you find an error or something unclear, or would like to propose an improvement, you have several options:
 


### PR DESCRIPTION
... if we want, or if we think scrolling down on first Intro page has content gap, then later we can move the Setup part, into a new page itself titled just "Setup", which will flow nicely with the navigation like so

- Getting started
  - Introduction
  - Setup
  - Setup for Linux
  - Setup for macOS
  ...