### PR TITLE
add `height: 100%;` to showcase cards

### DIFF
--- a/src/pages/showcase.js
+++ b/src/pages/showcase.js
@@ -108,7 +108,7 @@ function Showcase() {
                   style={{
                     textAlign: 'center',
                     backgroundColor: '#303846',
-                    color: '#ffffff',',
+                    color: '#ffffff',
                     height: '100%',
                   }}
                 >

--- a/src/pages/showcase.js
+++ b/src/pages/showcase.js
@@ -108,7 +108,8 @@ function Showcase() {
                   style={{
                     textAlign: 'center',
                     backgroundColor: '#303846',
-                    color: '#ffffff',
+                    color: '#ffffff',',
+                    height: '100%',
                   }}
                 >
                   <div


### PR DESCRIPTION
add `height: 100%;` to cards so they fill the grid nicely.

### before: 
![image](https://user-images.githubusercontent.com/13529535/126858276-da2c697e-46fe-445f-b6b0-8c6845badcce.png)

### after: 
![image](https://user-images.githubusercontent.com/13529535/126858271-94c87e4f-884e-400a-900d-78d1154fa38a.png)
