### PR TITLE
fix(icon): webrtc icon display

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -112,7 +112,7 @@ const Roadmap = ({ siteConfig }) => {
       color: COLORS.green,
       targetQuarter: 'Q4 2019',
     },
-    {      
+    {
       label: 'Alpha Release',
       icon: 'ti-flag-alt',
       color: COLORS.green,
@@ -240,7 +240,7 @@ const Roadmap = ({ siteConfig }) => {
     },
     {
       label: 'WebRTC',
-      icon: 'ti-phone',
+      icon: 'ti-microphone',
       color: COLORS.blue,
       targetQuarter: '2021',
     },


### PR DESCRIPTION
An icon for WebRTC in the roadmap is missing.

### Before
![image](https://user-images.githubusercontent.com/1271617/128926451-d3c24109-920e-4dad-8ba1-59d9d0abc5cf.png)

`ti-phone` doesn't appear to exist in the icons: https://themify.me/themify-icons

I saw that you had a `ti-microphone` defined in your stylesheet but it's unused, so I assumed that must be the icon you intended to use:
https://github.com/tauri-apps/tauri-docs/blob/24a57497525a65d061c65b78a3ddc7f5bd4fe6f4/src/css/themify-icons.css#L450

### After
![image](https://user-images.githubusercontent.com/1271617/128926900-a59155e3-aebb-46e6-8344-eab9d3ecbbe7.png)

And my editor removed a whitespace...