### PR TITLE
The default terminal is now zsh

### DIFF
--- a/docs/en/getting-started/setup-macos.md
+++ b/docs/en/getting-started/setup-macos.md
@@ -30,7 +30,7 @@ $ xcode-select --install
 We recommend using nvm to manage your Node.js runtime. It allows you to easily switch versions and update Node.js.
 
 ```sh
-$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | zsh
 ```
 
 <Alert title="Note">


### PR DESCRIPTION
On a Mac, executing this fails if running zsh, which is now the default:
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
Whereas this seems to work:
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | zsh

PS: This is my first public PR, so I hope I did it correctly!