### PR TITLE
Enable option to display the last update time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,6 +167,7 @@ const siteConfig = {
         docs: {
           path: './docs/' + language,
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           editUrl: 'https://github.com/tauri-apps/tauri-docs/edit/dev/',
         },
         theme: {


### PR DESCRIPTION
Prior this PR, there was no way to tell if we are reading a new version of the docs besides reading it entirely.

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148666590-d097a1fb-60e3-492b-a71e-d3e705c32373.png)