### PR TITLE
Adjust hero Tauri logo size for large screens

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -387,7 +387,7 @@ function Home() {
     >
       <header className={classnames('hero hero--dark', styles.heroBanner)}>
         <div className="container">
-          <lottie-player src="tauri-splash.json" background="transparent" speed="1" autoplay></lottie-player>
+            <lottie-player src="tauri-splash.json" background="transparent" speed="1" style={{width: "75%", margin: "auto"}} autoplay></lottie-player>
           <p
             className="hero__subtitle"
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
Previously the tauri Lottie animation took up a lot of space on wide displays. 
Before:
<img width="1624" alt="Screenshot 2022-01-11 at 14 31 52" src="https://user-images.githubusercontent.com/15347255/148962060-c55d8a86-b5f1-4145-9ac6-379d2c8fe92d.png">

Now it takes up 75% width of the container: 
<img width="1624" alt="Screenshot 2022-01-11 at 14 31 59" src="https://user-images.githubusercontent.com/15347255/148962113-10f4b555-4062-4595-9ff2-63da8c94ef7b.png">

Also looked at smaller screen sizes to make sure it still looks okay for mobile:
<img width="686" alt="Screenshot 2022-01-11 at 14 33 15" src="https://user-images.githubusercontent.com/15347255/148962224-a9e8de14-5ebc-4dd8-ab3a-b3bba0854291.png">

