### PR TITLE
Fix beta badge

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -316,5 +316,5 @@ html[data-theme="light"] .navbar__brand {
 
 .badge--warning,
 .badge--warning:hover {
-  color: var(--ifm-button-color);
+  color: var(--ifm-button-color) !important;
 }


### PR DESCRIPTION
This _should_ fix the "beta" button link colour. Need to have it build and deploy to netlify test because I wasn't able to replicate it locally and it only showed up after the upgrade deploy. 

Current:
<img width="121" alt="Screenshot 2022-01-12 at 16 13 01" src="https://user-images.githubusercontent.com/15347255/149178131-fe752ff3-81c7-4a4b-b51b-c9614fcc4b50.png">
Dev:
<img width="117" alt="Screenshot 2022-01-12 at 16 13 16" src="https://user-images.githubusercontent.com/15347255/149178182-b551ca5a-c3b1-42cf-8a6e-dd8d9ca263ad.png">

