### PR TITLE
Fix footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,8 +122,8 @@ const siteConfig = {
               to: 'docs/get-started/intro',
             },
             {
-              label: t.navbar.usage,
-              to: 'docs/usage/intro',
+              label: t.navbar.api,
+              to: 'docs/api/config/',
             },
             {
               to: 'release-notes',


### PR DESCRIPTION
There is no longer a "usage" page, replacing this with a link to the API page in the footer.