### PR TITLE
fix(docs): fix minor typo

### DIFF
--- a/docs/api/js/modules/os.md
+++ b/docs/api/js/modules/os.md
@@ -4,7 +4,7 @@
 
 Provides operating system-related utility methods and properties.
 
-This package is also accessible with `window.__TAURI__.fs` when `tauri.conf.json > build > withGlobalTauri` is set to true.
+This package is also accessible with `window.__TAURI__.os` when `tauri.conf.json > build > withGlobalTauri` is set to true.
 
 The APIs must be allowlisted on `tauri.conf.json`:
 ```json


### PR DESCRIPTION
This existed on the main repo [comments](https://github.com/tauri-apps/tauri/blob/52723ee8a1/tooling/api/src/os.ts#L8) too but I believe that this should be `os` instead of `fs` based on the rest of the modules descriptions.