### PR TITLE
Add `--locked` To CLI Installation Instructions

### DIFF
--- a/docs/development/integration.md
+++ b/docs/development/integration.md
@@ -65,7 +65,7 @@ If you decide to use Tauri as a local package with npm (not yarn), you will have
 This will install `tauri-cli` as a Cargo subcommand on the cargo binary folder (by default on `$HOME/.cargo/bin`):
 
 ```bash
-cargo install tauri-cli --version ^1.0.0-beta
+cargo install tauri-cli --locked --version ^1.0.0-beta
 ```
 
 For more installation options, see [`cargo install`](https://doc.rust-lang.org/cargo/commands/cargo-install.html#description)


### PR DESCRIPTION
I was following the instructions on the site and the CLI failed to build when I didn't provide the locked flag. Not many users will know about that flag so hopefully this helps!