### PR TITLE
Updated broken link.

### DIFF
--- a/docs/guides/command.md
+++ b/docs/guides/command.md
@@ -105,7 +105,7 @@ invoke('my_custom_command')
 ## Async Commands
 
 <Alert title="Note">
-Async commands are executed on a separate thread using the <a href="https://tauri.studio/en/docs/api/rust/tauri/async_runtime/fn.spawn">async runtime</a>.
+Async commands are executed on a separate thread using the <a href="https://docs.rs/tauri/1.0.0-beta.8/tauri/async_runtime/fn.spawn.html">async runtime</a>.
 Commands without the <i>async</i> keyword are executed on the main thread, unless defined with <i>#[tauri::command(async)]</i>.
 </Alert>
 

--- a/docs/guides/window-customization.md
+++ b/docs/guides/window-customization.md
@@ -10,7 +10,7 @@ There are three ways to change the window configuration:
 
 - [Through tauri.conf.json](https://tauri.studio/en/docs/api/config/#tauri.windows)
 - [Through the JS API](https://tauri.studio/en/docs/api/js/classes/window.windowmanager)
-- [Through the Window in Rust](https://tauri.studio/en/docs/api/rust/tauri/window/struct.window)
+- [Through the Window in Rust](https://docs.rs/tauri/1.0.0-beta.8/tauri/window/struct.Window.html)
 
 ## Creating a Custom Titlebar
 


### PR DESCRIPTION
Updated broken link in `docs > guides > window-customization` pointing to the Window struct for Rust.