### PR TITLE
Fix "Platform-specific" md header

### DIFF
--- a/docs/api/js/classes/window.WebviewWindow.md
+++ b/docs/api/js/classes/window.WebviewWindow.md
@@ -527,7 +527,7 @@ see `UserAttentionType` for details.
 Providing `null` will unset the request for user attention. Unsetting the request for
 user attention might not be done automatically by the WM when the window receives input.
 
-## Platform-specific
+#### Platform-specific
 
 - **macOS:** `null` has no effect.
 


### PR DESCRIPTION
The "Platform-specific" header was a level 2 header, but it probably should be a level 4 header.