### PR TITLE
shift over update-docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Copy JS docs
         run: cp -r tauri/tooling/api/docs/* tauri-docs/docs/api/js/
 
+      # this doesn't really need to be run on the content generation and PR opening
+      # should this be removed and run at the same time as our netlify publish sequence
       # Indexing
       # - name: meilisearch indexation
       #   uses: tauri-apps/docusaurus-meilisearch-indexer@v1

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,140 @@
+# Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+name: update-docs
+
+on:
+  pull_request:
+  repository_dispatch:
+    types: [update-docs]
+  workflow_dispatch:
+    inputs:
+      gitName:
+        description: 'git name for PR'
+        required: false
+        default: 'tauri-bot'
+      gitEmail:
+        description: 'git email for PR'
+        required: false
+        default: 'tauri-bot@tauri.studio'
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - name: checkout tauri
+        uses: actions/checkout@v2
+        with:
+          repository: tauri-apps/tauri
+          path: tauri
+      - name: checkout tauri-docs
+        uses: actions/checkout@v2
+        with:
+          repository: tauri-apps/tauri-docs
+          path: tauri-docs
+      # - name: checkout tauri-search-bot
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: tauri-apps/tauri-search-bot
+      #     path: tauri-search-bot
+
+      # Any Rust documentation is currently disabled while we're falling back to docs.rs
+
+      # TODO do we need to run this?
+      # - name: install webkit2gtk
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+
+      # # Rust
+      # - name: generate rust docs
+      #   working-directory: ./tauri/core/tauri
+      #   run: cargo doc --no-deps
+      # - name: run rustdocusaurus
+      #   uses: tauri-apps/rustdocusaurus/github-action@v1
+      #   with:
+      #     originPath: ./tauri/target/doc/
+      #     targetPath: ./tauri-docs/docs/en/api/rust/
+      #     sidebarPath: "${{ github.workspace }}/tauri-docs/sidebars/rustdoc.json"
+      #     linksRoot: ""
+      #     cratesToProcess: "tauri"
+
+      - name: Generate JS docs
+        working-directory: ./tauri/tooling/api
+        run: yarn && yarn generate-docs
+
+      - name: Copy JS docs
+        run: cp -r tauri/tooling/api/docs/* tauri-docs/docs/api/js/
+
+      # Indexing
+      # - name: meilisearch indexation
+      #   uses: tauri-apps/docusaurus-meilisearch-indexer@v1
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   with:
+      #     version: ${{ github.event.inputs.version || github.event.release.tag_name }}
+      #     docusaurusPath: "${{ github.workspace }}/tauri-docs"
+      #     host: https://search.tauri.studio
+      #     apiKey: ${{ secrets.MEILISEARCH_APIKEY }}
+      #     docs: "Getting started,Usage,API"
+
+      # Applying Version for Release Notes
+      # - name: set docs' Tauri version
+      #   working-directory: ./tauri-docs
+      #   run: echo ${{ github.event.inputs.version || github.event.release.tag_name }} > version.txt
+      # - name: set bot's Tauri version
+      #   working-directory: ./tauri-search-bot
+      #   run: echo ${{ github.event.inputs.version || github.event.release.tag_name }} > version.txt
+
+      # Sets up envs for the search bot and the search indexing
+      # - uses: iamsauravsharma/create-dotenv@v1.1.0
+      #   with:
+      #     directory: './tauri-search-bot'
+      #   env:
+      #     ENV_KEY_DISCORD_BOT_SECRET: ${{ secrets.DISCORD_BOT_SECRET }}
+      #     ENV_KEY_PREFIX: \!
+      #     ENV_KEY_SITE: tauri.studio
+      #     ENV_KEY_ICON: https://i.imgur.com/UzDERvw.png
+      #     ENV_KEY_LIMIT: 5
+      #     ENV_KEY_SEARCH_INDEX: ${{ github.event.release.tag_name }}
+      #     ENV_KEY_MEILISEARCH_PUBLIC_KEY: ea0105f56bb5a2111ed28c7a0c637fc0bed07273f571dc7cb1f73900e44f8e7f
+
+      # TODO do we even need to do a bot deploy here?
+      # Bot Deployment
+      # - name: scp bot
+      #   uses: appleboy/scp-action@master
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   with:
+      #     host: ${{ secrets.DISCORD_BOT_HOST }}
+      #     username: ${{ secrets.DISCORD_BOT_SSH_USER }}
+      #     key: ${{ secrets.DISCORD_BOT_SSH_KEY }}
+      #     source: "${{ github.workspace }}/tauri-search-bot"
+      #     target: "~/tauri-search-bot"
+      # - name: restart the bot
+      #   uses: appleboy/ssh-action@master
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   with:
+      #     host: ${{ secrets.DISCORD_BOT_HOST }}
+      #     username: ${{ secrets.DISCORD_BOT_SSH_USER }}
+      #     key: ${{ secrets.DISCORD_BOT_SSH_KEY }}
+      #     script: cd ~/tauri-search-bot/github/workspace/tauri-search-bot/ && yarn && forever stopall && forever start ./src/index.js
+
+      # tauri-docs PR
+      - name: git config
+        run: |
+          git config --global user.name "${{ github.event.inputs.gitName }}"
+          git config --global user.email "${{ github.event.inputs.gitEmail }}"
+      - name: create pull request for updated docs
+        # soft fork of https://github.com/peter-evans/create-pull-request for security purposes
+        uses: tauri-apps/create-pull-request@v3.4.1
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          token: ${{ secrets.TAURI_BOT_PAT }}
+          commit-message: 'chore(docs): Update Rust & TS docs'
+          branch: docs/release
+          path: tauri-docs
+          title: Update Docs
+          labels: 'new release'
+          body: |
+            These are the updated docs from the most recent release.

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,7 +7,7 @@ name: update-docs
 on:
   pull_request:
   repository_dispatch:
-    types: [update-docs]
+    types: [update-docs, test-update-docs]
   workflow_dispatch:
     inputs:
       gitName:


### PR DESCRIPTION
Shifting over the `update-docs.yml` workflow to serve as a single source of truth. The main Tauri repo and any plugin repos (or anything requiring documentation really) can then trigger this workflow via a webhook (or action) with a specific payload to customize it.