### PR TITLE
Removed tauri-hotkey-rs from External Crates list.

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,6 @@ Cross-platform application window creation library in Rust that supports all maj
 WRY is a cross-platform WebView rendering library in Rust that supports all major desktop platforms like Windows, macOS, and Linux.
 Tauri uses WRY as the abstract layer responsible to determine which webview is used (and how interactions are made).
 
-## [tauri-hotkey-rs](https://github.com/tauri-apps/tauri-hotkey-rs)
-We needed to fix hotkey to work on all platforms, because upstream was not being responsive.
-
 # Additional tooling
 
 ## [binary-releases](https://github.com/tauri-apps/binary-releases)


### PR DESCRIPTION
The tauri-hotkey-rs repo is archived, and no longer relevant
to the Architecture document.

Not 100% sure about this — but assuming the archived status means it's not in development any more. 

Q: Does there need to be some replacement, or an updated reference, rather than removal? 

Thanks. 