### PR TITLE
fix heading levels

### DIFF
--- a/docs/api/js/modules/window.md
+++ b/docs/api/js/modules/window.md
@@ -44,7 +44,7 @@ The APIs must be allowlisted on `tauri.conf.json`:
 ```
 It is recommended to allowlist only the APIs you use for optimal bundle size and security.
 
-# Window events
+## Window events
 
 Events can be listened using `appWindow.listen`:
 ```typescript

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,106 +1,136 @@
 # The Tauri Architecture
 
 ## Introduction
+
 Tauri is a polyglot and generic toolkit that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the OS's webview. They do not ship a runtime, since the final binary is compiled from Rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## What Tauri is NOT
+
 - Tauri is not a lightweight kernel wrapper...instead it directly uses [WRY](#wry) and [TAO](#tao) to do the heavy-lifting in making system calls to the OS.
 - Tauri is not a VM or virtualized environment...instead it is an application toolkit that allows making Webview OS applications.
 
 ## Major Components
+
 The following section briefly describes the roles of the various parts of Tauri.
+
 ### Tauri Core [STABLE RUST]
+
 #### [tauri](https://github.com/tauri-apps/tauri/tree/dev/core/tauri)
+
 This is the major crate that holds everything together. It brings the runtimes, macros, utilities and API into one final product. It reads the `tauri.conf.json` file at compile time in order to bring in features and undertake actual configuration of the app (and even the `Cargo.toml` file in the project's folder). It handles script injection (for polyfills / prototype revision) at runtime, hosts the API for systems interaction, and even manages updating.
 
 #### [tauri-build](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-build)
+
 Apply the macros at build-time in order to rig some special features needed by `cargo`.
 
 #### [tauri-codegen](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-codegen)
+
 - Embed, hash, and compress assets, including icons for the app as well as the system-tray.
 - Parse `tauri.conf.json` at compile time and generate the Config struct.
 
 #### [tauri-macros](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-macros)
+
 Create macros for the context, handler, and commands by leveraging the `tauri-codegen` crate.
 
 #### [tauri-runtime](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-runtime)
+
 This is the glue layer between tauri itself and lower level webview libraries.
 
 #### [tauri-runtime-wry](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-runtime-wry)
+
 This crate opens up direct systems-level interactions specifically for WRY, such as printing, monitor detection, and other windowing related tasks. `tauri-runtime` implementation for WRY.
 
 #### [tauri-utils](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-utils)
+
 This is common code that is reused in many places and offers useful utilities like parsing configuration files, detecting platform triples, injecting the CSP, and managing assets.
 
-
 ### Tauri Tooling
+
 #### [api](https://github.com/tauri-apps/tauri/tree/dev/tooling/api) [TS -> JS]
+
 A typescript library that creates `cjs` and `esm` Javascript endpoints for you to import into your Frontend framework so that the Webview can call and listen to backend activity. We also ship the pure typescript, because for some frameworks this is more optimal. It uses the message passing of webviews to their hosts.
 
 #### [bundler](https://github.com/tauri-apps/tauri/tree/dev/tooling/bundler) [RUST / SHELL]
+
 The bundler is a library that builds a Tauri App for the platform triple it detects / is told. At the moment it currently supports macOS, Windows and Linux - but in the near future will support mobile platforms as well. May be used outside of Tauri projects.
 
 #### [cli.js](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli.js) [JS]
+
 Written in Typescript and packaged such that it can be used with `npm`, `pnpm`, and `yarn`, this library provides a node.js runner for common tasks when using Tauri, like `yarn tauri dev`. For the most part it is a wrapper around [cli.rs](https://github.com/tauri-apps/tauri/blob/dev/tooling/cli).
 
 #### [cli.rs](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli) [RUST]
+
 This rust executable provides the full interface to all of the required activities for which the CLI is required. It will run on macOS, Windows, and Linux.
 
 #### [create-tauri-app](https://github.com/tauri-apps/tauri/tree/dev/tooling/create-tauri-app) [JS]
+
 This is a toolkit that will enable engineering teams to rapidly scaffold out a new tauri-apps project using the frontend framework of their choice (as long as it has been configured).
 
-# External Crates
+## External Crates
+
 The Tauri-Apps organisation maintains two "upstream" crates from Tauri, namely TAO for creating and managing application windows, and WRY for interfacing with the Webview that lives within the window.
 
-## [TAO](https://github.com/tauri-apps/tao)
+### [TAO](https://github.com/tauri-apps/tao)
+
 Cross-platform application window creation library in Rust that supports all major platforms like Windows, macOS, Linux, iOS and Android. Written in Rust, it is a fork of [winit](https://github.com/rust-windowing/winit) that we have extended for our own needs like menu bar and system tray.
 
+### [WRY](https://github.com/tauri-apps/wry)
 
-## [WRY](https://github.com/tauri-apps/wry)
 WRY is a cross-platform WebView rendering library in Rust that supports all major desktop platforms like Windows, macOS, and Linux.
 Tauri uses WRY as the abstract layer responsible to determine which webview is used (and how interactions are made).
 
-## [tauri-hotkey-rs](https://github.com/tauri-apps/tauri-hotkey-rs)
+### [tauri-hotkey-rs](https://github.com/tauri-apps/tauri-hotkey-rs)
+
 We needed to fix hotkey to work on all platforms, because upstream was not being responsive.
 
-# Additional tooling
+## Additional tooling
 
-## [binary-releases](https://github.com/tauri-apps/binary-releases)
+### [binary-releases](https://github.com/tauri-apps/binary-releases)
+
 This is the delivery mechanism for tauri prebuilt binaries: currently the cli.rs (used by cli.js) and rustup binaries (used by the deps install command of cli.js). These artifacts are automatically created on release.
 
-## [tauri-action](https://github.com/tauri-apps/tauri-action)
+### [tauri-action](https://github.com/tauri-apps/tauri-action)
+
 This is a github workflow that builds tauri binaries for all platforms. It is not the fastest out there, but it gets the job done and is highly configurable. Even allowing you to create a (very basic) tauri app even if tauri is not setup.
 
-## [create-pull-request](https://github.com/tauri-apps/create-pull-request)
+### [create-pull-request](https://github.com/tauri-apps/create-pull-request)
+
 Because this is a very risky (potentially destructive) github action, we forked it in order to have strong guarantees that the code we think is running is actually the code that is running.
 
-## [vue-cli-plugin-tauri](https://github.com/tauri-apps/vue-cli-plugin-tauri)
+### [vue-cli-plugin-tauri](https://github.com/tauri-apps/vue-cli-plugin-tauri)
+
 This plugin allows you to very quickly install tauri in a vue-cli project.
 
-## [tauri-vscode](https://github.com/tauri-apps/tauri-vscode)
+### [tauri-vscode](https://github.com/tauri-apps/tauri-vscode)
+
 This project enhances the VS Code interface with several nice-to-have features.
 
-# Tauri Plugins [documentation](https://tauri.studio/en/docs/guides/plugin)
+## Tauri Plugins [documentation](https://tauri.studio/en/docs/guides/plugin)
 
 Generally speaking, plugins are authored by third parties (even though there may be official, supported plugins). A plugin generally does 3 things:
+
 1. It provides rust code to do "something".
 2. It provides interface glue to make it easy to integrate into an app.
 3. It provides a JS API for interfacing with the rust code.
 
 Here are several examples of Tauri Plugins:
+
 - https://github.com/tauri-apps/tauri-plugin-sql
 - https://github.com/tauri-apps/tauri-plugin-stronghold
 - https://github.com/tauri-apps/tauri-plugin-authenticator
 
-# Workflows
-## What does the Development flow look like?
+## Workflows
+
+### What does the Development flow look like?
+
 A developer must first install the prerequisite toolchains for creating a Tauri app. At the very least this will entail installing rust & cargo, and most likely also a modern version of node.js and potentially another package manager. Some platforms may also require other tooling and libraries, but this has been documented carefully in the respective platform docs.
 
 Because of the many ways to build front-ends, we will stick with a common node.js based approach for development. (Note: Tauri does not by default ship a node.js runtime.)
 
 The easiest way to do this is to run the following:
+
 ```
 npx create-tauri-app
 ```
@@ -110,16 +140,19 @@ Which will ask you a bunch of questions about the framework you want to install 
 > If you don't use this process, you will have to manually install the tauri cli, initialise tauri and manually configure the `tauri.conf.json` file.
 
 Once everything is installed, you can run:
+
 ```
 yarn tauri dev
 -or-
 npm run tauri dev
 ```
+
 This will do several things:
+
 1. start the JS Framework devserver
 2. begin the long process of downloading and compiling the rust libraries
 3. open an application window with devtools enabled
-4. keep a long-lived console alive 
+4. keep a long-lived console alive
 
 If you change your HTML/CSS/TS/JS, your framework devserver should give you its best shot at instant hot module reloading and you will see the changes instantly.
 
@@ -131,29 +164,32 @@ If you need to get deeper insight into your current project, or triage requires 
 yarn tauri info
 ```
 
-
-## What does the Release flow look like?
+### What does the Release flow look like?
 
 The release flow begins with proper configuration in the `tauri.conf.json` file. In this file, the developer can configure not only the basic behaviour of the application (like window size and decoration), they can also provide settings for signing and updating.
 
 Depending upon the operating system that the developer (or CI) is building the application on, there will be an app built for them for that system. (Cross compilation is not currently available, however there is an official [GitHub Action](https://github.com/tauri-apps/tauri-action) that can be used to build for all platforms.)
 
 To kick off this process, just:
+
 ```
 yarn tauri build
 ```
 
 After some time, the process will end and you can see the results in the `./src-tauri/target/release` folder.
 
-## What does the End-User flow look like?
+### What does the End-User flow look like?
+
 End users will be provided with binaries in ways that are appropriate for their systems. Whether macOS, Linux, or Windows, direct download or store installations - they will be able to follow procedures for installing and removing that they are used to.
 
-## What does the Updating flow look like?
-When a new version is ready, the developer publishes the new signed artifacts to a server (that they have configured within `tauri.conf.json`). 
+### What does the Updating flow look like?
+
+When a new version is ready, the developer publishes the new signed artifacts to a server (that they have configured within `tauri.conf.json`).
 
 The application can poll this server to see if there is a new release. When there is a new release, the user is prompted to update. The application update is downloaded, verified (checksum & signature), updated, closed, and restarted.
 
 ## License
+
 Tauri itself is licensed under MIT or Apache-2.0. If you repackage it and modify any source code, it is your responsibility to verify that you are complying with all upstream licenses. Tauri is provided AS-IS with no explicit claim for suitability for any purpose.
 
 Here you may peruse our [Software Bill of Materials](https://app.fossa.com/projects/git%2Bgithub.com%2Ftauri-apps%2Ftauri).

--- a/docs/building/debian.md
+++ b/docs/building/debian.md
@@ -6,11 +6,11 @@ import Alert from '@theme/Alert'
 
 Tauri allows your app to be packaged as a `.deb` (Debian package) file.
 
-# Bootstrapper
+## Bootstrapper
 
 Instead of launching the app directly, you can configure the bundled app to run a script that tries to expose the environment variables to the app; without that you'll have trouble using system programs because the `PATH` environment variable isn't correct. Enable it with the <a href="/docs/api/config#tauri.bundle.deb.useBootstrapper">`useBootstrapper`</a> config.
 
-# Custom files
+## Custom files
 
 To include custom files to the debian package, you can configure a mapping on `tauri.conf.json > tauri > bundle > deb > files` as follows:
 

--- a/docs/distribution/sign-windows.md
+++ b/docs/distribution/sign-windows.md
@@ -5,26 +5,26 @@ sidebar_label: Windows Code Signing
 
 import Alert from '@theme/Alert'
 
-# Intro
+## Intro
 
 Code-signing will add a level of authenticity to your application, while it is not required it can often improve the user experience for your users.
 
-# Prerequisites
+## Prerequisites
 
 - Windows - you can likely use other platforms, but this tutorial is using Powershell native features.
 - Code signing certificate - you can aqquire one of these on services such as Digicert.com, Comodo.com, & Godaddy.com. In this guide we are using Comodo.com
 - A working tauri application
 
-
-# Getting Started
+## Getting Started
 
 There are a few things we will have to do to get our windows installation prepared for code signing. This includes converting our certificate to a speific format, installing this certificate, & then decoding required information from certificate that is required by tauri.
 
-## A. Convert your `.cer` to `.pfx`
+### A. Convert your `.cer` to `.pfx`
 
 1. You will need the following:
-	- certificate file (mine is `cert.cer`)
-	- private key file (mine is `private-key.key`)
+
+   - certificate file (mine is `cert.cer`)
+   - private key file (mine is `private-key.key`)
 
 2. Open up a command prompt and change to your current directory using `cd Documents/Certs`
 
@@ -32,7 +32,7 @@ There are a few things we will have to do to get our windows installation prepar
 
 4. You will be prompted to enter an export password **DON'T FORGET IT!**
 
-## B. Import your `.pfx` file into the keystore.
+### B. Import your `.pfx` file into the keystore.
 
 We will now need to import our `.pfx` file.
 
@@ -40,9 +40,10 @@ We will now need to import our `.pfx` file.
 
 2. Now Import the certificate using `Import-PfxCertificate -FilePath Certs/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)`
 
-## C. Prepare Variables
+### C. Prepare Variables
 
 1. We will need the SHA-1 thumbprint of the certificate, you can get this using `openssl pkcs12 -info -in certificate.pfx` and look under for following
+
 ```
 Bag Attributes
     localKeyID: A1 B1 A2 B2 A3 B3 A4 B4 A5 B5 A6 B6 A7 B7 A8 B8 A9 B9 A0 B0
@@ -54,11 +55,12 @@ Bag Attributes
 
 4. We will also need a timestamp url, this is a time server used to verify the time of the certificate signing. Im using `http://timestamp.comodoca.com` but whoever you got your certificate from likely has one aswell.
 
-# Prepare `tauri.conf.json` file
+## Prepare `tauri.conf.json` file
 
 1. Now that we have our `certificateThumbprint`, `digestAlgorithm`, & `timestampUrl` we will open up the `tauri.conf.json`.
 
 2. In the `tauri.conf.json` you will look for the `tauri` -> `bundle` -> `windows` section. You will see there are three variable for the information we have captured. Fill it out like below.
+
 ```
 "windows": {
         "certificateThumbprint": "A1B1A2B2A3B3A4B4A5B5A6B6A7B7A8B8A9B9A0B0",
@@ -66,6 +68,7 @@ Bag Attributes
         "timestampUrl": "http://timestamp.comodoca.com"
 }
 ```
+
 3. Save, and run `yarn | yarn build`
 
 4. In the console output you will see the following output.
@@ -80,32 +83,33 @@ which shows you have successfully signed the `.exe`.
 
 And thats it! You have successfully signed your .exe file.
 
-# BONUS: Sign your application with GitHub Actions.
+## BONUS: Sign your application with GitHub Actions.
 
 We can also create a workflow to sign the application with GitHub actions, this will help automate your Publish time.
 
-## GitHub Secrets
+### GitHub Secrets
 
 We will need to add a few GitHub secrets for the proper configuration of the GitHub Action. These can be named however you would like.
+
 - You can view [this](https://docs.github.com/en/actions/reference/encrypted-secrets) guide for how to add GitHub secrets.
 
 The secrets we used are as follows
 
-| GitHub Secrets | Value for Variable |
-|     :---:      |        :---:            |
-|WINDOWS_CERTIFICATE| Base64 encoded version of your .pfx certificate, can be done using this command `certutil -encode certificate.pfx base64cert.txt` |
-|WINDOWS_CERTIFICATE_PASSWORD|Certificate export password used on creation of certificate .pfx|
+|        GitHub Secrets        |                                                        Value for Variable                                                         |
+| :--------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
+|     WINDOWS_CERTIFICATE      | Base64 encoded version of your .pfx certificate, can be done using this command `certutil -encode certificate.pfx base64cert.txt` |
+| WINDOWS_CERTIFICATE_PASSWORD |                                 Certificate export password used on creation of certificate .pfx                                  |
 
-## Workflow Modifications
-
+### Workflow Modifications
 
 1. We will need to add a step in the workflow to properly import the certificate into the windows environment. This work flow accomplishes the following
-    1. Assign GitHub secrets to environment variables
-    2. Create a new `certificate` directory
-    3. Import `WINDOWS_CERTIFICATE` into tempCert.txt
-    4. Use `certutil` to decode the tempCert.txt from base64 into a `.pfx` file.
-    5. Remove tempCert.txt
-    6. Import the `.pfx` file into the Cert store of Windows & convert the `WINDOWS_CERTIFICATE_PASSWORD` to a secure string to be used in the import command.
+
+   1. Assign GitHub secrets to environment variables
+   2. Create a new `certificate` directory
+   3. Import `WINDOWS_CERTIFICATE` into tempCert.txt
+   4. Use `certutil` to decode the tempCert.txt from base64 into a `.pfx` file.
+   5. Remove tempCert.txt
+   6. Import the `.pfx` file into the Cert store of Windows & convert the `WINDOWS_CERTIFICATE_PASSWORD` to a secure string to be used in the import command.
 
 2. We will be using the tauri-action publish template available [here](https://github.com/tauri-apps/tauri-action)
 
@@ -167,6 +171,7 @@ jobs:
         Remove-Item -path certificate -include tempCert.txt
         Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
 ```
+
 4. Save, and push to your repo.
 
 5. You workflow will now be able to import your windows certificate and import it into the github runner, allowing for automated code-signing!

--- a/docs/distribution/updater.md
+++ b/docs/distribution/updater.md
@@ -2,7 +2,7 @@
 title: Updater
 ---
 
-# Configuration
+## Configuration
 
 Once you have your Tauri project ready, you need to configure the updater.
 
@@ -28,7 +28,7 @@ The required keys are "active" and "endpoints", others are optional.
 
 "pubkey" if present must be a valid public-key generated with Tauri cli. See [Signing updates](#signing-updates).
 
-## Update Requests
+### Update Requests
 
 Tauri is indifferent to the request the client application provides for update checking.
 
@@ -42,7 +42,7 @@ It may also include other identifying criteria such as operating system version,
 
 How you include the version identifier or other criteria is specific to the server that you are requesting updates from. A common approach is to use query parameters, [Configuration](#configuration) shows an example of this.
 
-## Built-in dialog
+### Built-in dialog
 
 By default, updater uses a built-in dialog API from Tauri.
 
@@ -52,7 +52,7 @@ The dialog release notes is represented by the update `note` provided by the [se
 
 If the user accepts, the download and install are initialized. The user will be then prompted to restart the application.
 
-## Javascript API
+### Javascript API
 
 **Attention, you need to _disable built-in dialog_ in your [tauri configuration](#configuration), otherwise, events aren't emitted and the javascript API will NOT work.**
 
@@ -73,30 +73,30 @@ try {
 }
 ```
 
-## Events
+### Events
 
 **Attention, you need to _disable built-in dialog_ in your [tauri configuration](#configuration), otherwise, events aren't emitted.**
 
 To know when an update is ready to be installed, you can subscribe to these events:
 
-### Initialize updater and check if a new version is available
+#### Initialize updater and check if a new version is available
 
-#### If a new version is available, the event `tauri://update-available` is emitted.
+##### If a new version is available, the event `tauri://update-available` is emitted.
 
 Event: `tauri://update`
 
-### Rust
+#### Rust
 ```rust
 window.emit("tauri://update".to_string(), None);
 ```
 
-### Javascript
+#### Javascript
 ```js
 import { emit } from "@tauri-apps/api/event";
 emit("tauri://update");
 ```
 
-### Listen New Update Available
+#### Listen New Update Available
 
 Event: `tauri://update-available`
 
@@ -107,14 +107,14 @@ date       Date announced by the server
 body       Note announced by the server
 ```
 
-### Rust
+#### Rust
 ```rust
 window.listen("tauri://update-available".to_string(), move |msg| {
   println!("New version available: {:?}", msg);
 })
 ```
 
-### Javascript
+#### Javascript
 ```js
 import { listen } from "@tauri-apps/api/event";
 listen("tauri://update-available", function (res) {
@@ -122,24 +122,24 @@ listen("tauri://update-available", function (res) {
 });
 ```
 
-### Emit Install and Download
+#### Emit Install and Download
 
 You need to emit this event to initialize the download and listen to the [install progress](#listen-install-progress).
 
 Event: `tauri://update-install`
 
-### Rust
+#### Rust
 ```rust
 window.emit("tauri://update-install".to_string(), None);
 ```
 
-### Javascript
+#### Javascript
 ```js
 import { emit } from "@tauri-apps/api/event";
 emit("tauri://update-install");
 ```
 
-### Listen Install Progress
+#### Listen Install Progress
 
 Event: `tauri://update-status`
 
@@ -153,14 +153,14 @@ PENDING is emitted when the download is started and DONE when the install is com
 
 ERROR is emitted when there is an error with the updater. We suggest to listen to this event even if the dialog is enabled.
 
-### Rust
+#### Rust
 ```rust
 window.listen("tauri://update-status".to_string(), move |msg| {
   println!("New status: {:?}", msg);
 })
 ```
 
-### Javascript
+#### Javascript
 ```js
 import { listen } from "@tauri-apps/api/event";
 listen("tauri://update-status", function (res) {
@@ -168,7 +168,7 @@ listen("tauri://update-status", function (res) {
 });
 ```
 
-# Server Support
+## Server Support
 
 Your server should determine whether an update is required based on the [Update Request](#update-requests) your client issues.
 
@@ -176,7 +176,7 @@ If an update is required your server should respond with a status code of [200 O
 
 If no update is required your server must respond with a status code of [204 No Content](http://tools.ietf.org/html/rfc2616#section-10.2.5).
 
-## Update Server JSON Format
+### Update Server JSON Format
 
 When an update is available, Tauri expects the following schema in response to the update request provided:
 
@@ -196,7 +196,7 @@ The only required keys are "url" and "version", the others are optional.
 
 "signature" if present must be a valid signature generated with Tauri cli. See [Signing updates](#signing-updates).
 
-## Update File JSON Format
+### Update File JSON Format
 
 The alternate update technique uses a plain JSON file meaning you can store your update metadata on S3, gist, or another static file store. Tauri will check against the name/version field and if the version is smaller than the current one and the platform is available, the update will be triggered. The format of this file is detailed below:
 
@@ -222,7 +222,7 @@ The alternate update technique uses a plain JSON file meaning you can store your
 }
 ```
 
-# Bundler (Artifacts)
+## Bundler (Artifacts)
 
 The Tauri bundler will automatically generate update artifacts if the updater is enabled in `tauri.conf.json`
 
@@ -232,7 +232,7 @@ The signature can be found in the `sig` file. The signature can be uploaded to G
 
 You can see how it's [bundled with the CI](https://github.com/tauri-apps/tauri/blob/5b6c7bb6ee3661f5a42917ce04a89d94f905c949/.github/workflows/artifacts-updater.yml#L44) and a [sample tauri.conf.json](https://github.com/tauri-apps/tauri/blob/5b6c7bb6ee3661f5a42917ce04a89d94f905c949/examples/updater/src-tauri/tauri.conf.json#L52)
 
-## macOS
+### macOS
 
 On MACOS we create a .tar.gz from the whole application. (.app)
 
@@ -244,7 +244,7 @@ target/release/bundle
     └── app.app.tar.gz.sig (if signature enabled)
 ```
 
-## Windows
+### Windows
 
 On Windows we create a .zip from the MSI, when downloaded and validated, we run the MSI install.
 
@@ -255,7 +255,7 @@ target/release
 └── app.x64.msi.zip.sig (if signature enabled)
 ```
 
-## Linux
+### Linux
 
 On Linux, we create a .tar.gz from the AppImage.
 
@@ -267,7 +267,7 @@ target/release/bundle
     └── app.AppImage.tar.gz.sig (if signature enabled)
 ```
 
-# Signing updates
+## Signing updates
 
 We offer a built-in signature to ensure your update is safe to be installed.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 title: Frequently Asked Questions
 ---
 
-# error: could not find native static libraryWebView2LoaderStatic, perhaps an -L flag is missing?
+## error: could not find native static libraryWebView2LoaderStatic, perhaps an -L flag is missing?
 
 The WebView2 crate build pipeline requires `NuGet` to have a `PackageSource` to install the `Microsoft.Web.WebView2` package. If you never used `NuGet` before, you might need to create a file named `NuGet.Config` on `%APPDATA%/NuGet` folder, with the following contents:
 


### PR DESCRIPTION
docusaurus doesn't create anchors for h1 tags and rightfully so as there should only be one (at the top) per page anyway.