### PR TITLE
list yarn first and specify it is our own package manager for v1

### DIFF
--- a/docs/getting-started/setting-up-linux.md
+++ b/docs/getting-started/setting-up-linux.md
@@ -101,7 +101,7 @@ If you have any problems with nvm, please consult their [project readme][nvm].
 
 You may want to use an alternative to npm:
 
-- [Yarn] - Used by the Tauri team for v1
+- [Yarn@v1] - Used by the Tauri team for v1
 - [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
@@ -151,7 +151,7 @@ Now that you have set up the Linux-specific dependencies for Tauri, learn how to
 [nvm]: https://github.com/nvm-sh/nvm
 [nvm install.sh]: https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh
 [Beginning Tutorial]: ./beginning-tutorial.md
-[Yarn]: https://yarnpkg.com/getting-started"
+[Yarn@v1]: https://classic.yarnpkg.com/en/docs/getting-started
 [pnpm]: https://pnpm.js.org/en/installation
 [rustup]: https://rustup.rs/
 [Rust]: https://www.rust-lang.org/

--- a/docs/getting-started/setting-up-linux.md
+++ b/docs/getting-started/setting-up-linux.md
@@ -101,8 +101,8 @@ If you have any problems with nvm, please consult their [project readme][nvm].
 
 You may want to use an alternative to npm:
 
-- [pnpm]
-- [Yarn]
+- [Yarn] - Used by the Tauri team for v1
+- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
 

--- a/docs/getting-started/setting-up-macos.md
+++ b/docs/getting-started/setting-up-macos.md
@@ -44,7 +44,7 @@ If you have any problems with nvm, please consult their [project readme][nvm].
 
 You may want to use an alternative to npm:
 
-- [Yarn] - Used by the Tauri team for v1
+- [Yarn@v1] - Used by the Tauri team for v1
 - [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
@@ -75,7 +75,7 @@ Now that you have set up the macOS-specific dependencies for Tauri, learn how to
 [nvm]: https://github.com/nvm-sh/nvm
 [nvm install.sh]: https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh
 [Beginning Tutorial]: ./beginning-tutorial.md
-[Yarn]: https://yarnpkg.com/getting-started"
+[Yarn@v1]: https://classic.yarnpkg.com/en/docs/getting-started
 [pnpm]: https://pnpm.js.org/en/installation
 [rustup]: https://rustup.rs/
 [Rust]: https://www.rust-lang.org/

--- a/docs/getting-started/setting-up-macos.md
+++ b/docs/getting-started/setting-up-macos.md
@@ -44,8 +44,8 @@ If you have any problems with nvm, please consult their [project readme][nvm].
 
 You may want to use an alternative to npm:
 
-- [pnpm]
-- [Yarn]
+- [Yarn] - Used by the Tauri team for v1
+- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
 

--- a/docs/getting-started/setting-up-windows.md
+++ b/docs/getting-started/setting-up-windows.md
@@ -45,7 +45,7 @@ This installs the most recent version of Node.js with npm.
 
 You may want to use an alternative to npm:
 
-- [Yarn] - Used by the Tauri team for v1
+- [Yarn@v1] - Used by the Tauri team for v1
 - [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
@@ -76,7 +76,7 @@ Now that you have set up the Windows-specific dependencies for Tauri learn how t
 
 [nvm-windows]: https://github.com/coreybutler/nvm-windows#installation--upgrades
 [Beginning Tutorial]: ./beginning-tutorial.md
-[Yarn]: https://yarnpkg.com/getting-started"
+[Yarn@v1]: https://classic.yarnpkg.com/en/docs/getting-started
 [pnpm]: https://pnpm.js.org/en/installation
 [rustup x86_64]: https://win.rustup.rs/x86_64
 [rustup i686]: https://win.rustup.rs/i686

--- a/docs/getting-started/setting-up-windows.md
+++ b/docs/getting-started/setting-up-windows.md
@@ -45,8 +45,8 @@ This installs the most recent version of Node.js with npm.
 
 You may want to use an alternative to npm:
 
-- [pnpm]
-- [Yarn]
+- [Yarn] - Used by the Tauri team for v1
+- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
 
 ## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
 


### PR DESCRIPTION
it's a bit disingenuous to list pnpm first and remove the yarn recommendation descriptions, especially since we use yarn for v1