### PR TITLE
Removing Node.js as a Tauri requirement

### DIFF
--- a/docs/getting-started/beginning-tutorial.md
+++ b/docs/getting-started/beginning-tutorial.md
@@ -1,10 +1,14 @@
 import Command from '@theme/Command'
 import Link from '@docusaurus/Link'
 
-# Your First Tauri App
+# Your First Node.js-based Tauri App
 
 :::caution
 You must have completed all the steps required for setting up the development environment on your machine. Please see the [setup page for your operating system][Prerequisites] if you haven't done this yet.
+:::
+
+:::info
+In this guide, we are assuming you already have installed [Node.js](https://nodejs.org/) and a package manager of your choice.
 :::
 
 There are two ways to integrate with Tauri depending on your needs:

--- a/docs/getting-started/setting-up-linux.md
+++ b/docs/getting-started/setting-up-linux.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 <Intro />
 
-## 1. System Dependencies&nbsp;<Icon title="alert" color="danger"/>
+## 1. System Dependencies 🧰
 
 <Tabs
 defaultValue="debian"
@@ -74,37 +74,7 @@ $ sudo dnf check-update && sudo dnf install webkit2gtk3-devel.x86_64 \
 - `libappindicator`: needed to use the system tray feature.
 - `patchelf` and `librsvg`: needed to bundle `AppImage`.
 
-## 2. Node.js Runtime and Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
-
-### Node.js (npm included)
-
-We recommend using nvm to manage your Node.js runtime. It allows you to switch versions and update Node.js easily.
-
-```sh
-$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-```
-
-:::note
-We have audited this bash script, and it does what it says it is supposed to do. Nevertheless, before blindly curl-bashing a script, it is always wise to look at it first. Here is the file as a mere [download link][[nvm install.sh]].
-:::
-
-Once nvm is installed, close and reopen your terminal, then install the latest version of Node.js and npm:
-
-```sh
-$ nvm install node --latest-npm
-$ nvm use node
-```
-
-If you have any problems with nvm, please consult their [project readme][nvm].
-
-### Optional Node.js Package Manager
-
-You may want to use an alternative to npm:
-
-- [Yarn@v1] - Used by the Tauri team for v1
-- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
-
-## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
+## 2. Rustc and Cargo Package Manager 📦
 
 The following command installs [rustup], the official installer for [Rust].
 
@@ -120,12 +90,12 @@ To make sure that Rust has been installed successfully, run the following comman
 
 ```sh
 $ rustc --version
-latest update on 2019-12-19, rust version 1.40.0
+rustc 1.58.1 (db9d1b20b 2022-01-20)
 ```
 
 You may need to restart your terminal if the command does not work.
 
-## 4. For Windows Subsystem for Linux (WSL) Users&nbsp;<Icon title="info-alt" color="info"/>
+## 3. For Windows Subsystem for Linux (WSL) Users&nbsp;<Icon title="info-alt" color="info"/>
 
 To run a graphical application with WSL, you need to download **one** of these X servers: Xming, Cygwin X, and vcXsrv.
 Since vcXsrv has been used internally, it's the one we recommend installing.

--- a/docs/getting-started/setting-up-macos.md
+++ b/docs/getting-started/setting-up-macos.md
@@ -9,7 +9,7 @@ import Icon from '@theme/Icon'
 
 <Intro />
 
-## 1. System Dependencies&nbsp;<Icon title="alert" color="danger"/>
+## 1. System Dependencies 🧰
 
 Make sure you have `xcode` installed.
 
@@ -17,37 +17,7 @@ Make sure you have `xcode` installed.
 $ xcode-select --install
 ```
 
-## 2. Node.js Runtime and Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
-
-### Node.js (npm included)
-
-We recommend using nvm to manage your Node.js runtime. It allows you to switch versions and update Node.js easily.
-
-```sh
-$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-```
-
-:::note
-We have audited this bash script, and it does what it says it is supposed to do. Nevertheless, before blindly curl-bashing a script, it is always wise to look at it first. Here is the file as a mere [download link][nvm install.sh].
-:::
-
-Once nvm is installed, close and reopen your terminal, then install the latest version of Node.js and npm:
-
-```sh
-$ nvm install node --latest-npm
-$ nvm use node
-```
-
-If you have any problems with nvm, please consult their [project readme][nvm].
-
-### Optional Node.js Package Manager
-
-You may want to use an alternative to npm:
-
-- [Yarn@v1] - Used by the Tauri team for v1
-- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
-
-## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
+## 2. Rustc and Cargo Package Manager 📦
 
 The following command will install [rustup], the official installer for [Rust].
 
@@ -63,7 +33,7 @@ To make sure that Rust has been installed successfully, run the following comman
 
 ```sh
 $ rustc --version
-latest update on 2019-12-19, rust version 1.40.0
+rustc 1.58.1 (db9d1b20b 2022-01-20)
 ```
 
 You may need to restart your terminal if the command does not work.

--- a/docs/getting-started/setting-up-windows.md
+++ b/docs/getting-started/setting-up-windows.md
@@ -13,7 +13,7 @@ For those using the Windows Subsystem for Linux (WSL), please refer to our [Linu
 
 <Intro />
 
-## 1. System Dependencies&nbsp;<Icon title="alert" color="danger"/>
+## 1. System Dependencies 🧰
 
 You'll need to install Microsoft Visual Studio C++ build tools. [Download the installer here][Microsoft Visual Studio C++ build tools], and then run it. When it asks you what packages you would like to install, select C++ Build Tools and make sure the Windows SDK is selected.
 
@@ -25,30 +25,7 @@ This is a big download (over 1GB) and takes the most time, so grab a snack or co
 You may need to uninstall the 2017 version of the build tools if you have them. There are reports of Tauri not working with both the 2017 and 2019 versions installed.
 :::
 
-## 2. Node.js Runtime and Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
-
-### Node.js (npm included)
-
-We recommend using [nvm-windows] to manage your Node.js runtime. It allows you to switch versions and update Node.js easily.
-
-Then run the following from an Administrative PowerShell and press Y when prompted:
-
-```powershell
-# BE SURE YOU ARE IN AN ADMINISTRATIVE PowerShell!
-nvm install latest
-nvm use {{latest}} # Replace with your latest downloaded version
-```
-
-This installs the most recent version of Node.js with npm.
-
-### Optional Node.js Package Manager
-
-You may want to use an alternative to npm:
-
-- [Yarn@v1] - Used by the Tauri team for v1
-- [pnpm] - Alternative package manager focusing on decreasing disk space and installation time
-
-## 3. Rustc and Cargo Package Manager&nbsp;<Icon title="control-skip-forward" color="warning"/>
+## 2. Rustc and Cargo Package Manager 📦
 
 Now you need to install [Rust]. The easiest way to do this is to use [rustup], the official installer.
 
@@ -58,7 +35,7 @@ Now you need to install [Rust]. The easiest way to do this is to use [rustup], t
 Download and install the proper variant for your computer's architecture.
 
 
-## 4. Install WebView2
+## 3. Install WebView2&nbsp;<Icon title="control-skip-forward" color="warning"/>
 
 :::tip
 WebView2 is pre-installed in Windows 11.

--- a/src/theme/SetupDocs.js
+++ b/src/theme/SetupDocs.js
@@ -1,22 +1,9 @@
 import React from 'react'
 
-import Icon from '@theme/Icon'
-
 export const Intro = () => (
   <>
-    <p>This setup is only needed for development. Consumers of Tauri apps will not have to do any of this.</p>
+    <p>This setup is only needed for <strong>development stage</strong>. Tauri apps end-users will not have to undergo the following steps.</p>
 
-    <p>This page provides a <strong>complete guide</strong> to install Tauri along with its dependencies. Because Tauri is a polyglot toolchain and involves complex installation instructions, we want to make sure <i>anybody</i> will manage to set it up by reading this guide without having to open another documentation.</p>
-
-    <p>Additionally, it contains nice tips and tools that will help you if you're beginning with Node.js or Rust and security.</p>
-
-    <Icon title="alert" color="danger"/>: This step is required
-    <br/>
-
-    <Icon title="control-skip-forward" color="warning"/>: This step is skippable if already satisfied (e.g. you already have Node.js/Rust installed)
-    <br/>
-
-    <Icon title="info-alt" color="info"/>: This step is purely informational
-    <br/>
+    <p>This page provides a <strong>complete guide</strong> to install Tauri along with its dependencies. </p>
   </>
 )


### PR DESCRIPTION
Since Node.js is not a Tauri dependency anymore; removing it from the setup guides makes them lighter.