### PR TITLE
fix: cert signing steps

### DIFF
--- a/docs/distribution/sign-windows.md
+++ b/docs/distribution/sign-windows.md
@@ -166,10 +166,10 @@ jobs:
         WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
       run: |
         New-Item -ItemType directory -Path certificate
-        Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_PFX
+        Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_CERTIFICATE
         certutil -decode certificate/tempCert.txt certificate/certificate.pfx
         Remove-Item -path certificate -include tempCert.txt
-        Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+        Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
 ```
 
 4. Save and push to your repo.


### PR DESCRIPTION
Hi all, 

I think in Tauri's documentation on signing, it is referring to Environment variables that do not match the name of the environment variables that are created by the process.

The scripts reference  `WINDOWS_PFX` and `WINDOWS_PFX_PASSWORD` when the environment variables set above in the action are `WINDOWS_CERTIFICATE` and `WINDOWS_CERTIFICATE_PASSWORD`. 

Here, I am assuming the environment variable names are the ones you want to go with, and am correcting the variable usage for consistency.