### PR TITLE
Match APPLE_SIGNING_IDENTITY secret name to env variable name

### DIFF
--- a/docs/distribution/sign-macos.md
+++ b/docs/distribution/sign-macos.md
@@ -125,7 +125,7 @@ jobs:
           ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_IDENTITY_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:


### PR DESCRIPTION
Noticed this while reading the docs and using the example. This is once instance where the env variable name doesn't seem to match the secret name. It was unintuitive to me so submitting this PR to hopefully save others some time.