### PR TITLE
fix: rename `__TAURI__._invoke` to `__TAURI_INVOKE__`.

### DIFF
--- a/docs/guides/command.md
+++ b/docs/guides/command.md
@@ -32,7 +32,7 @@ Now, you can invoke the command from your JS code:
 // With the Tauri API npm package:
 import { invoke } from '@tauri-apps/api/tauri'
 // With the Tauri global script, enabled when `tauri.conf.json > build > withGlobalTauri` is set to true:
-const invoke = window.__TAURI__.invoke
+const invoke = window.__TAURI_INVOKE__
 
 // Invoke the command
 invoke('my_custom_command')

--- a/docs/guides/splashscreen.md
+++ b/docs/guides/splashscreen.md
@@ -64,7 +64,7 @@ Then, you can call it from your JS:
 // With the Tauri API npm package:
 import { invoke } from '@tauri-apps/api/tauri'
 // With the Tauri global script:
-const invoke = window.__TAURI__.invoke
+const invoke = window.__TAURI_INVOKE__
 
 document.addEventListener('DOMContentLoaded', () => {
   // This will wait for the window to load, but you could


### PR DESCRIPTION
Renamed `__TAURI__._invoke` to `__TAURI_INVOKE__` in [tauri-app/tauri #2417](https://github.com/tauri-apps/tauri/pull/2417), but not reflected in the document.