### PR TITLE
fix(sidebar): use descriptive label instead of Tauri name

### DIFF
--- a/docs/building/sidecar.md
+++ b/docs/building/sidecar.md
@@ -1,10 +1,7 @@
----
-sidebar_label: Sidecar
----
-
-# Sidecar (Embedding External Binaries)
+# Embedding External Binaries
 
 You may need to embed depending binaries to make your application work or prevent users from installing additional dependencies (e.g., Node.js or Python).
+We call this binary a `sidecar`.
 
 To bundle the binaries of your choice, you can add the `externalBin` property to the `tauri > bundle` object in your `tauri.conf.json`.
 

--- a/docs/guides/command.md
+++ b/docs/guides/command.md
@@ -1,6 +1,7 @@
-# Creating Rust Commands
+# Calling Rust from the frontend
 
-Tauri provides a simple yet powerful "command" system for calling Rust functions from your web app. Commands can accept arguments and return values. They can also return errors and be `async`.
+Tauri provides a simple yet powerful `command` system for calling Rust functions from your web app.
+Commands can accept arguments and return values. They can also return errors and be `async`.
 
 ## Basic Example
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,7 +52,6 @@ const docs = [
       },
     ],
     Guides: [
-      'guides/cli',
       'guides/command',
       'guides/events',
       'guides/plugin',
@@ -61,6 +60,7 @@ const docs = [
       'guides/window-customization',
       'guides/menu',
       'guides/system-tray',
+      'guides/cli',
     ],
     Debugging: ['debugging/debugging'],
     Testing: [


### PR DESCRIPTION
When the reader sees `Command` or `Sidecar`, it is not clear what that guide is about. This PR changes the titles so it's clear what the developer will learn in that doc page.