### PR TITLE
Update Release Candidate Announcement Banner Style

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,6 +177,7 @@ const siteConfig = {
       content:
         "<div id='announcement-rc'>🚀 Tauri Release Candidate has landed! <a id='announcement-link' target='_blank' rel='noopener noreferrer' href='https://dev.to/tauri/tauri-10-release-candidate-53jk'>Click here for more details.</a></div>",
       backgroundColor: 'var(--ifm-color-primary)',
+      textColor: 'var(--ifm-button-color)',
     },
     navbar: {
       hideOnScroll: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -175,7 +175,7 @@ const siteConfig = {
     announcementBar: {
       id: 'rc',
       content:
-        "<div id='announcement-rc'>🚀 Tauri Release Candidate has landed! <a target='_blank' rel='noopener noreferrer' href='https://dev.to/tauri/tauri-10-release-candidate-53jk'>Click here for more details.</a></div>",
+        "<div id='announcement-rc'>🚀 Tauri Release Candidate has landed! <a id='announcement-link' target='_blank' rel='noopener noreferrer' href='https://dev.to/tauri/tauri-10-release-candidate-53jk'>Click here for more details.</a></div>",
       backgroundColor: 'var(--ifm-color-primary)',
     },
     navbar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -234,7 +234,12 @@ html[data-theme='light'] .header-github-link::before {
 
 #announcement-rc {
   font-weight: bold;
-  margin-top: 10px;
+}
+
+@media only screen and (max-width: 500px) {
+  #announcement-link {
+    display: block;
+  }
 }
 
 .badge--warning,


### PR DESCRIPTION
# Problem - 1
![desktop-margin](https://user-images.githubusercontent.com/78584173/167238302-022809ca-0c35-4767-b485-b1eea897d08c.png)

In Desktop and Mobile, the banner has margin of 10px on the top which makes the banner look squashed.

# Problem - 2

![mobile-link](https://user-images.githubusercontent.com/78584173/167238303-5d28b3f0-a90c-439b-a831-1063020e17b8.png)

In Mobile, the links goes to a new line and it is hard to understand at first sight.

# Solution
For problem 1, remove `margin: 10px`.
For problem 2, add id to the link and use `display: block` when screen width is less than 500px.

# Fixed
![desktop-margin-fixed](https://user-images.githubusercontent.com/78584173/167238445-4d6b2628-91a3-41f2-b7de-3d9196614b20.png)
![mobile-link-fixed](https://user-images.githubusercontent.com/78584173/167238447-97e566ce-a848-4360-9d16-a54c64c27662.png)
