### PR TITLE
Remove unused code in search bar

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,15 +1,11 @@
 import React, { useEffect } from 'react'
 import classNames from 'classnames'
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
 import styles from './searchbar.module.css'
 import Icon from '@theme/Icon'
 import './searchbar.module.css'
 
 const SearchBar = ({ className }) => {
-  const context = useDocusaurusContext()
-  const { siteConfig = {} } = context
-
   useEffect(() => {
     const docsSearchBar = require('docs-searchbar.js').default
     docsSearchBar({
@@ -24,6 +20,7 @@ const SearchBar = ({ className }) => {
       }, */
     })
   }, [])
+
   return (
     <div
       className={classNames(


### PR DESCRIPTION
useDocusaurusContext is not used in search bar component.
Removing it does not effect the search bar.