### PR TITLE
fix: add temporary redirect from docs/guides/ to guides/examples/

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,10 @@ from = "/partners"
 to = "/#sponsors"
 
 [[redirects]]
+from = "/docs/guides/*"
+to = "/v1/guides/examples/:splat"
+
+[[redirects]]
 from = "/docs/*"
 to = "/v1/:splat"
 


### PR DESCRIPTION
just to tell google and co to update the linkx