### PR TITLE
Change SearchBar's height and icon's margin

### DIFF
--- a/src/theme/SearchBar/searchbar.module.css
+++ b/src/theme/SearchBar/searchbar.module.css
@@ -4,7 +4,7 @@
   border: 2px solid var(--ifm-font-color-base);
   padding: 8px;
   margin: 0 8px;
-  height: 41px;
+  height: 35px;
   display: flex;
   align-content: center;
   align-items: center;
@@ -24,4 +24,5 @@
 
 .searchIcon {
   font-size: 1.2em;
+  margin-right: 3px;
 }


### PR DESCRIPTION
# Problem
![before](https://user-images.githubusercontent.com/78584173/168228511-64bbc123-9d2c-4a0b-9f2b-3b3556836f1f.png)
![before2](https://user-images.githubusercontent.com/78584173/168228779-0f4568a7-7ea4-48f1-bc93-6cfcf287ce73.png)


1. The search bar component's height is too big.
2. The icon is too close to the typing space.

# Updated
![after](https://user-images.githubusercontent.com/78584173/168228637-5ca94537-ba34-4c4d-835f-a6d484043e34.png)

# Code
Changed `height` and `margin-right`.