### PR TITLE
Update search bar logic and style

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -3,8 +3,9 @@ import { useColorMode } from '@docusaurus/theme-common'
 import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
 import './searchbar.css'
 
-export default function Component() {
-  const { isDarkTheme } = useColorMode()
+export default function Component () {
+  const isDarkTheme = useColorMode().colorMode === 'dark'
+
   useEffect(() => {
     const DocsSearchBar = require('docs-searchbar.js').default
 

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useColorMode } from '@docusaurus/theme-common'
 import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
+import './searchbar.css'
 
 export default function Component() {
   const { isDarkTheme } = useColorMode()

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -3,7 +3,7 @@ import { useColorMode } from '@docusaurus/theme-common'
 import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
 import './searchbar.css'
 
-export default function Component () {
+export default function Component() {
   const isDarkTheme = useColorMode().colorMode === 'dark'
 
   useEffect(() => {
@@ -20,6 +20,10 @@ export default function Component () {
       enhancedSearchInput: true,
     })
   }, [])
+
+  useEffect(() => {
+    document.querySelector('.docs-searchbar-js').setAttribute('data-ds-theme', isDarkTheme ? 'dark' : 'light')
+  }, [isDarkTheme])
 
   return (
     <div>

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useColorMode } from '@docusaurus/theme-common'
 import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
-import './searchbar.css'
+import './style.css'
 
 export default function Component() {
   const isDarkTheme = useColorMode().colorMode === 'dark'

--- a/src/theme/SearchBar/searchbar.css
+++ b/src/theme/SearchBar/searchbar.css
@@ -7,6 +7,12 @@ div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
   width: 300% !important;
 }
 
+div[data-ds-theme='dark']
+  .meilisearch-autocomplete
+  .docs-searchbar-suggestion--wrapper {
+  align-items: center !important;
+}
+
 @media only screen and (max-width: 1185px) {
   .searchbox {
     width: 200px !important;
@@ -25,15 +31,11 @@ div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
 
   .meilisearch-autocomplete .dsb-dropdown-menu,
   div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
-    width: 125% !important;
+    width: 170% !important;
   }
 }
 
-@media only screen and (max-width: 600px) {
-  .searchbox {
-    width: calc(100vw - 200px) !important;
-  }
-
+@media only screen and (max-width: 630px) {
   .docs-searchbar-suggestion--subcategory-column-text {
     font-size: 12px !important;
   }
@@ -50,7 +52,33 @@ div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
 
   .meilisearch-autocomplete .dsb-dropdown-menu,
   div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
+    width: 100% !important;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .searchbox {
+    width: calc(100vw - 200px) !important;
+  }
+
+  .meilisearch-autocomplete .dsb-dropdown-menu,
+  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
     min-width: 300px;
+  }
+
+  .docs-searchbar-suggestion--wrapper {
+    display: block !important;
+  }
+
+  div[data-ds-theme='dark']
+    .meilisearch-autocomplete
+    .docs-searchbar-suggestion
+    .docs-searchbar-suggestion--subcategory-column:after {
+    display: none !important;
+  }
+
+  .docs-searchbar-suggestion--subcategory-column-text {
+    text-decoration: underline;
   }
 }
 

--- a/src/theme/SearchBar/searchbar.css
+++ b/src/theme/SearchBar/searchbar.css
@@ -1,0 +1,37 @@
+.searchbox {
+  width: 350px;
+}
+
+@media only screen and (max-width: 1185px) {
+  .searchbox {
+    width: 200px !important;
+  }
+
+  .badge {
+    display: none !important;
+  }
+
+  .svg-icons {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 995px) {
+  .searchbox {
+    width: 400px !important;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .searchbox {
+    width: calc(100vw - 200px) !important;
+  }
+}
+
+.docs-searchbar-footer-logo {
+  height: 15px;
+}
+
+.navbar-sidebar--show .navbar-sidebar {
+  z-index: 999;
+}

--- a/src/theme/SearchBar/searchbar.css
+++ b/src/theme/SearchBar/searchbar.css
@@ -2,17 +2,19 @@
   width: 350px;
 }
 
+.meilisearch-autocomplete .dsb-dropdown-menu,
+div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
+  width: 300% !important;
+}
+
 @media only screen and (max-width: 1185px) {
   .searchbox {
     width: 200px !important;
   }
 
-  .badge {
-    display: none !important;
-  }
-
+  .badge,
   .svg-icons {
-    display: none;
+    display: none !important;
   }
 }
 
@@ -20,11 +22,35 @@
   .searchbox {
     width: 400px !important;
   }
+
+  .meilisearch-autocomplete .dsb-dropdown-menu,
+  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
+    width: 125% !important;
+  }
 }
 
 @media only screen and (max-width: 600px) {
   .searchbox {
     width: calc(100vw - 200px) !important;
+  }
+
+  .docs-searchbar-suggestion--subcategory-column-text {
+    font-size: 12px !important;
+  }
+
+  .docs-searchbar-suggestion--title {
+    font-size: 5px !important;
+    margin-bottom: 0 !important;
+    margin-top: 3px !important;
+  }
+
+  .docs-searchbar-suggestion--text {
+    display: none !important;
+  }
+
+  .meilisearch-autocomplete .dsb-dropdown-menu,
+  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
+    min-width: 300px;
   }
 }
 

--- a/src/theme/SearchBar/searchbar.css
+++ b/src/theme/SearchBar/searchbar.css
@@ -37,17 +37,13 @@ div[data-ds-theme='dark']
 
 @media only screen and (max-width: 630px) {
   .docs-searchbar-suggestion--subcategory-column-text {
-    font-size: 12px !important;
+    font-size: 18px !important;
   }
 
   .docs-searchbar-suggestion--title {
-    font-size: 5px !important;
+    font-size: 12px !important;
     margin-bottom: 0 !important;
     margin-top: 3px !important;
-  }
-
-  .docs-searchbar-suggestion--text {
-    display: none !important;
   }
 
   .meilisearch-autocomplete .dsb-dropdown-menu,

--- a/src/theme/SearchBar/searchbar.css
+++ b/src/theme/SearchBar/searchbar.css
@@ -61,3 +61,7 @@ div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
 .navbar-sidebar--show .navbar-sidebar {
   z-index: 999;
 }
+
+.navbar-sidebar__backdrop {
+  z-index: 999;
+}

--- a/src/theme/SearchBar/style.css
+++ b/src/theme/SearchBar/style.css
@@ -1,3 +1,9 @@
+/*
+  The default meilisearch search bar style is docs-searchbar.js/dist/cdn/docs-searchbar.min.css.
+  But there are few configurations needed to make the site look better.
+*/
+
+/* Default searchbox and dropdown style */
 .searchbox {
   width: 350px;
 }
@@ -7,17 +13,20 @@ div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
   width: 300% !important;
 }
 
+/* The subcategory text is centered vertically */
 div[data-ds-theme='dark']
   .meilisearch-autocomplete
   .docs-searchbar-suggestion--wrapper {
   align-items: center !important;
 }
 
+/* Media Queries for specific width screen */
 @media only screen and (max-width: 1185px) {
   .searchbox {
     width: 200px !important;
   }
 
+  /* These badges and svg-icons are not needed on smaller screens */
   .badge,
   .svg-icons {
     display: none !important;
@@ -36,6 +45,7 @@ div[data-ds-theme='dark']
 }
 
 @media only screen and (max-width: 630px) {
+  /* From smaller ipad screens, the text's font size needs to be smaller */
   .docs-searchbar-suggestion--subcategory-column-text {
     font-size: 18px !important;
   }
@@ -62,6 +72,7 @@ div[data-ds-theme='dark']
     min-width: 300px;
   }
 
+  /* The texts are now in different lines (title, subcategory, text) */
   .docs-searchbar-suggestion--wrapper {
     display: block !important;
   }
@@ -78,10 +89,12 @@ div[data-ds-theme='dark']
   }
 }
 
+/* Footer's height should be smaller to be the same as the 'powered by' text */
 .docs-searchbar-footer-logo {
   height: 15px;
 }
 
+/* navigation sidebar and backdrop's z-index should be higher than the searchbar */
 .navbar-sidebar--show .navbar-sidebar {
   z-index: 999;
 }


### PR DESCRIPTION
# What Changed
- [x] Make searchbar component and drawer go behind the drawer
- [x] Make width for light/dark the same
- [x] Add media to control the width of the input according to screen size
- [x] Align logo with the baseline of text
- [x] Add custom css for the whole searchbar style to customize it
- [x] Update deprecated code (useColorMode().isDarkTheme)
- [x] Make the dropdown appear fully in mobile (Also, hide `.docs-searchbar-suggestion--text` in order to see the texts better)
- [x] Change style of search component when theme is changed (immediately)

# Before and After Comparison

### Change style of search component when theme is changed (immediately)
This can be tested in [Latest Netlify Deployment](https://deploy-preview-600--tauri.netlify.app/).

### Make the dropdown appear fully in mobile
![before mobile](https://user-images.githubusercontent.com/78584173/168419461-664d7680-cd64-42dd-b275-5b962f0bec24.png)
![after mobile](https://user-images.githubusercontent.com/78584173/168419462-380580cc-3ff5-4ad2-b9b6-08ab449abf9c.png)

### Logo
![before logo](https://user-images.githubusercontent.com/78584173/168408294-73565a26-5874-4038-a11b-1dcf1192deaa.png)
![after logo](https://user-images.githubusercontent.com/78584173/168408295-b61195d2-eee2-48f7-a308-43c732053aa6.png)

### Mobile Drawer
![before drawer](https://user-images.githubusercontent.com/78584173/168423165-602df3f6-c270-49ab-bc94-e9af2cf9a2b0.png)
![after drawer](https://user-images.githubusercontent.com/78584173/168423167-19d19d44-3a2b-4140-845d-fd8ad349ca62.png)

### Center title so that it looks better in both mobile and computer sized screens
![before center](https://user-images.githubusercontent.com/78584173/168423199-37256e10-734b-48c6-b33b-9d07225c3a61.png)
![after center](https://user-images.githubusercontent.com/78584173/168423202-f4046bf6-5803-4533-a7d4-f00b4cdac988.png)

### @media (Other screen sizes as well, 1185, 995, 600)
![before media](https://user-images.githubusercontent.com/78584173/168408325-68cd59af-b481-42c5-b646-7dc868e8155b.png)
![after media](https://user-images.githubusercontent.com/78584173/168408326-a16e5cf2-2cc7-4860-a2e8-d9259efc364d.png)

### Sizes of width is same in both light/dark theme
![before light](https://user-images.githubusercontent.com/78584173/168408839-9b602257-9def-4ec3-a450-979cf45e4d93.png)
![after light](https://user-images.githubusercontent.com/78584173/168408840-a565ff90-1649-43b2-9927-f974e9673f3a.png)

### Deprecated code
<details>
  <summary>Log</summary>
  <p>
<pre>
colorMode.tsx?7cd1:130 `useColorMode().isDarkTheme` is deprecated. Please use `useColorMode().colorMode === "dark"` instead.
get isDarkTheme @ colorMode.tsx?7cd1:130
Component @ index.js?a860:1
renderWithHooks @ react-dom.development.js?ac89:16175
mountIndeterminateComponent @ react-dom.development.js?ac89:20913
beginWork @ react-dom.development.js?ac89:22416
beginWork$1 @ react-dom.development.js?ac89:27381
performUnitOfWork @ react-dom.development.js?ac89:26513
workLoopSync @ react-dom.development.js?ac89:26422
renderRootSync @ react-dom.development.js?ac89:26390
performSyncWorkOnRoot @ react-dom.development.js?ac89:26041
flushSyncCallbacks @ react-dom.development.js?ac89:12009
flushSync @ react-dom.development.js?ac89:26157
legacyCreateRootFromDOMContainer @ react-dom.development.js?ac89:29477
legacyRenderSubtreeIntoContainer @ react-dom.development.js?ac89:29503
render @ react-dom.development.js?ac89:29587
eval @ clientEntry.js?1755:23
Promise.then(asynchronous)
eval @ clientEntry.js?1755:23
./node_modules/@docusaurus/core/lib/client/clientEntry.js @ main.js:253
__webpack_require__ @ runtime~main.js:36
__webpack_exec__ @ main.js:2016
(Anonymous) @ main.js:2017
__webpack_require__.O @ runtime~main.js:83
(Anonymous) @ main.js:2018
webpackJsonpCallback @ runtime~main.js:1331
(Anonymous) @ main.js:9
react-dom.development.js?ac89:86 Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.

Please update the following components: RevealBase
printWarning @ react-dom.development.js?ac89:86
warn @ react-dom.development.js?ac89:49
ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings @ react-dom.development.js?ac89:12203
flushRenderPhaseStrictModeWarningsInDEV @ react-dom.development.js?ac89:27263
commitRootImpl @ react-dom.development.js?ac89:26658
commitRoot @ react-dom.development.js?ac89:26638
performSyncWorkOnRoot @ react-dom.development.js?ac89:26073
flushSyncCallbacks @ react-dom.development.js?ac89:12009
flushSync @ react-dom.development.js?ac89:26157
legacyCreateRootFromDOMContainer @ react-dom.development.js?ac89:29477
legacyRenderSubtreeIntoContainer @ react-dom.development.js?ac89:29503
render @ react-dom.development.js?ac89:29587
eval @ clientEntry.js?1755:23
Promise.then(asynchronous)
eval @ clientEntry.js?1755:23
./node_modules/@docusaurus/core/lib/client/clientEntry.js @ main.js:253
__webpack_require__ @ runtime~main.js:36
__webpack_exec__ @ main.js:2016
(anonymous) @ main.js:2017
__webpack_require__.O @ runtime~main.js:83
(anonymous) @ main.js:2018
webpackJsonpCallback @ runtime~main.js:1331
(anonymous) @ main.js:9
index.js?a860:1 null
react_devtools_backend.js:4026 `useColorMode().isDarkTheme` is deprecated. Please use `useColorMode().colorMode === "dark"` instead.
    at Component (webpack-internal:///./src/theme/SearchBar/index.js:9:111)
    at div
    at NavbarSearch (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Navbar/Search/index.js:13:36)
    at SearchNavbarItem (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/SearchNavbarItem.js:14:40)
    at NavbarItem (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/index.js:15:112)
    at NavbarItems (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Navbar/Content/index.js:24:128)
    at div
    at div
    at NavbarContentLayout (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Navbar/Content/index.js:24:625)
    at NavbarContent (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Navbar/Content/index.js:24:1129)
    at nav
    at NavbarLayout (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Navbar/Layout/index.js:19:422)
    at Navbar
    at NavbarSecondaryMenuDisplayProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/display.js:20:327)
    at NavbarMobileSidebarProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/navbarMobileSidebar.js:22:423)
    at NavbarSecondaryMenuContentProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/content.js:15:166)
    at NavbarProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/navbarUtils.js:21:38)
    at HtmlClassNameProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:28:56)
    at PluginHtmlClassNameProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:31:52)
    at DocsPreferredVersionContextProviderUnsafe (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/docsPreferredVersion.js:32:392)
    at DocsPreferredVersionContextProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/docsPreferredVersion.js:35:60)
    at ScrollControllerProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/scrollUtils.js:19:498)
    at TabGroupChoiceProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/tabGroupChoice.js:15:1390)
    at AnnouncementBarProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/announcementBar.js:24:459)
    at ColorModeProvider (webpack-internal:///./node_modules/@docusaurus/theme-common/lib/contexts/colorMode.js:26:1255)
    at LayoutProviders (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/LayoutProviders/index.js:19:39)
    at Layout (webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Layout/index.js:24:33)
    at Home (webpack-internal:///./src/pages/index.js:26:959)
    at RouteContextProvider (webpack-internal:///./node_modules/@docusaurus/core/lib/client/routeContext.js:15:70)
    at LoadableComponent (webpack-internal:///./node_modules/react-loadable/lib/index.js:138:32)
    at Route (webpack-internal:///./node_modules/react-router/esm/react-router.js:449:29)
    at Switch (webpack-internal:///./node_modules/react-router/esm/react-router.js:651:29)
    at Route (webpack-internal:///./node_modules/react-router/esm/react-router.js:449:29)
    at ClientLifecyclesDispatcher (webpack-internal:///./node_modules/@docusaurus/core/lib/client/ClientLifecyclesDispatcher.js:14:710)
    at PendingNavigation (webpack-internal:///./node_modules/@docusaurus/core/lib/client/PendingNavigation.js:16:112)
    at Root (webpack-internal:///./node_modules/@docusaurus/core/lib/client/theme-fallback/Root/index.js:19:25)
    at BrowserContextProvider (webpack-internal:///./node_modules/@docusaurus/core/lib/client/browserContext.js:20:136)
    at DocusaurusContextProvider (webpack-internal:///./node_modules/@docusaurus/core/lib/client/docusaurusContext.js:20:505)
    at ErrorBoundary (webpack-internal:///./node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:14:108)
    at App (webpack-internal:///./node_modules/@docusaurus/core/lib/client/App.js:27:241)
    at Router (webpack-internal:///./node_modules/react-router/esm/react-router.js:80:30)
    at BrowserRouter (webpack-internal:///./node_modules/react-router-dom/esm/react-router-dom.js:58:35)
    at r (webpack-internal:///./node_modules/react-helmet-async/lib/index.module.js:17:7350)
overrideMethod @ react_devtools_backend.js:4026
get isDarkTheme @ colorMode.tsx?7cd1:130
Component @ index.js?a860:1
renderWithHooks @ react-dom.development.js?ac89:16175
updateFunctionComponent @ react-dom.development.js?ac89:20387
beginWork @ react-dom.development.js?ac89:22430
beginWork$1 @ react-dom.development.js?ac89:27381
performUnitOfWork @ react-dom.development.js?ac89:26513
workLoopSync @ react-dom.development.js?ac89:26422
renderRootSync @ react-dom.development.js?ac89:26390
performSyncWorkOnRoot @ react-dom.development.js?ac89:26041
flushSyncCallbacks @ react-dom.development.js?ac89:12009
flushSyncCallbacksOnlyInLegacyMode @ react-dom.development.js?ac89:11988
scheduleUpdateOnFiber @ react-dom.development.js?ac89:25438
dispatchSetState @ react-dom.development.js?ac89:17389
updateWindowSize @ useWindowSize.ts?9fc6:46
setTimeout(asynchronous)
eval @ useWindowSize.ts?9fc6:46
commitHookEffectListMount @ react-dom.development.js?ac89:23049
commitPassiveMountOnFiber @ react-dom.development.js?ac89:24816
commitPassiveMountEffects_complete @ react-dom.development.js?ac89:24781
commitPassiveMountEffects_begin @ react-dom.development.js?ac89:24768
commitPassiveMountEffects @ react-dom.development.js?ac89:24756
flushPassiveEffectsImpl @ react-dom.development.js?ac89:26990
flushPassiveEffects @ react-dom.development.js?ac89:26935
eval @ react-dom.development.js?ac89:26725
workLoop @ scheduler.development.js?bcd2:266
flushWork @ scheduler.development.js?bcd2:239
performWorkUntilDeadline @ scheduler.development.js?bcd2:533
</pre></p>
</details>