### PR TITLE
Make the Rust docs point to the latest RC

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -20,7 +20,7 @@ const api = [
   {
     type: 'link',
     label: 'Rust (via Docs.rs)',
-    href: 'https://docs.rs/tauri/1.0.0-rc.0/',
+    href: 'https://docs.rs/tauri/1.0.0-rc/',
   },
   {
     type: 'category',


### PR DESCRIPTION
Make this button

![image](https://user-images.githubusercontent.com/38158676/169164251-50d5a27d-0692-44f4-bd8a-0ebc2dc5115e.png)

Point to the latest docs version by simply going to https://docs.rs/tauri/1.0.0-rc instead of a fixed version.

The current link is pointing to the first RC (https://docs.rs/tauri/1.0.0-rc.0/tauri/)
