### PR TITLE
Use rubik instead of tauri font

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@docusaurus/core": "2.0.0-beta.20",
     "@docusaurus/preset-classic": "2.0.0-beta.20",
     "@docusaurus/theme-common": "2.0.0-beta.20",
-    "@fontsource/tauri": "4.5.9",
+    "@fontsource/rubik": "4.5.9",
     "@lottiefiles/lottie-player": "1.5.7",
     "@mdx-js/react": "1.6.22",
     "apexcharts": "3.35.2",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,11 +7,11 @@
 
 @import 'themify-icons.css';
 @import 'tabs.css';
-@import '~@fontsource/tauri';
+@import '~@fontsource/rubik';
 
 /* You can override the default Infima variables here. */
 :root {
-  font-family: 'Tauri';
+  font-family: 'Rubik', sans-serif;
 
   --ifm-code-font-size: 95%;
   --ifm-heading-line-height: 1.4;
@@ -47,10 +47,6 @@
 .features h3 {
   text-align: center;
   font-size: 1.6em;
-}
-
-body {
-  font-family: 'Tauri';
 }
 
 ul.roadmap-legend {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     url-loader "^4.1.1"
     webpack "^5.72.0"
 
-"@fontsource/tauri@4.5.9":
+"@fontsource/rubik@4.5.9":
   version "4.5.9"
-  resolved "https://registry.yarnpkg.com/@fontsource/tauri/-/tauri-4.5.9.tgz#877c21eeed4ff29451d43dcba5ac7e239a3267ab"
-  integrity sha512-t2rmUNnML354akzKnrFFyIX4Rx7aCpMAPVrXyNdCRbOkpNcJIjjRtyDelSofmgqLP+HViDS0rZOkvhqVgoWN0g==
+  resolved "https://registry.yarnpkg.com/@fontsource/rubik/-/rubik-4.5.9.tgz#46e81911b601183699a117edfdd32c05cad1fd49"
+  integrity sha512-atF0Mvh6woVFPX2p2MdVO0JIqw6DSjrb82EQJ9UaHnJeJ79SfaTUFxRoQMF3yF6ehaY5el3SgynSX5w02O3lqQ==
 
 "@hapi/hoek@^9.0.0":
   version "9.2.1"


### PR DESCRIPTION
Honestly, my biggest motivation for this is a double forward slash. This brings the website inline with the brand guidelines. 

Before:
<img width="773" alt="Screenshot 2022-05-20 at 09 56 39" src="https://user-images.githubusercontent.com/15347255/169493073-839a25a9-a5b2-43ee-96b9-25f98cb2d68b.png">
After:
<img width="781" alt="Screenshot 2022-05-20 at 09 56 44" src="https://user-images.githubusercontent.com/15347255/169493083-ccc6bd7a-cedf-4a1a-b618-668581c0f385.png">

