### PR TITLE
(fix) Safari favicon Fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -291,12 +291,6 @@ const siteConfig = {
             content: '#0F0F0F',
           },
           {
-            tagName: 'link',
-            rel: 'mask-icon',
-            href: '/img/tauri.svg',
-            color: '#0F0F0F',
-          },
-          {
             tagName: 'meta',
             name: 'msapplication-TileColor',
             content: '#0F0F0F',


### PR DESCRIPTION
Logo was cut off like this before:
<img width="160" alt="Screenshot 2022-05-23 at 22 17 49" src="https://user-images.githubusercontent.com/15347255/169907738-b3b2195a-28b0-4451-b82f-47dfd96b6075.png">

Now looks like this with the fix:
<img width="163" alt="Screenshot 2022-05-23 at 22 23 59" src="https://user-images.githubusercontent.com/15347255/169908241-0e23b0ff-1757-4cb5-bae3-9b856af89653.png">

