### PR TITLE
Replace deprecated libappindicator3-dev in Debian setup

### DIFF
--- a/docs/guides/01-getting-started/prerequisites.md
+++ b/docs/guides/01-getting-started/prerequisites.md
@@ -94,7 +94,7 @@ sudo apt install libwebkit2gtk-4.0-dev \
     wget \
     libssl-dev \
     libgtk-3-dev \
-    libappindicator3-dev \
+    libayatana-appindicator3-dev \
     librsvg2-dev
 ```
 


### PR DESCRIPTION
`libappindicator3` is deprecated and throws a conflict error:

```sh
$ sudo apt-get install libappindicator3-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libayatana-appindicator3-1 : Conflicts: libappindicator3-1
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```