### PR TITLE
added SystemTrayEvent type to system tray example

### DIFF
--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -104,7 +104,7 @@ Also, Tauri emits tray icon click events.
 Use the `on_system_tray_event` API to handle them:
 
 ```rust
-use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu};
+use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu, SystemTrayEvent};
 use tauri::Manager;
 
 fn main() {
@@ -159,7 +159,7 @@ The `AppHandle` struct has a `tray_handle` method, which returns a handle to the
 #### Updating context menu items
 
 ```rust
-use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu};
+use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu, SystemTrayEvent};
 use tauri::Manager;
 
 fn main() {


### PR DESCRIPTION
missing one of the type that was used in the example (im quite new to rust i dont know what to call these the error says its type so thats what i went with)