### PR TITLE
Fix i18n deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tauri Docs
 
 [![Crowdin](https://badges.crowdin.net/e/5a26ffca6fd8022c03485376ac5a082d/localized.svg)](https://tauri.crowdin.com/documentation)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/0bc4e65a-3a3a-4074-9401-1f094ecd0508/deploy-status)](https://app.netlify.com/sites/tauri/deploys)
 
 This website is built using [Docusaurus 2] with [MeiliSearch] for the docs indexation and is deployed by Netlify.
 

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -9,7 +9,17 @@ files:
   # Docs Markdown files
   - source: /docs/**/*
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
-    ignore: [/docs/.templates, /docs/api, /docs/guides]
-  # Blog Markdown files
-  - source: /blog/**/*
-    translation: /i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%
+    ignore:
+      [
+        /docs/.templates,
+        /docs/api,
+        /docs/guides/faq.md,
+        /docs/guides/architecture,
+        /docs/guides/building,
+        /docs/guides/debugging,
+        /docs/guides/development,
+        /docs/guides/distribution,
+        /docs/guides/features,
+        /docs/guides/getting-started,
+        /docs/guides/testing,
+      ]


### PR DESCRIPTION
Previously the deploys for i18n failed due to no files in the `guides` folder being matched (see deploy logs here: https://app.netlify.com/sites/tauri/deploys/629ca56aafe88300084e309f)

Now explicitly ignoring subfolders under `guides` and only going to translate the `README.md` file (landing page) for guides. Additional files/folders will be enabled as those guides are updated. 