### PR TITLE
Point RC badge to roadmap component

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -505,7 +505,7 @@ export default function App() {
 
             <div className={styles.spacer} />
 
-            <h1 className={styles.h1} id="roadmap">
+            <h1 className={styles.h1, "anchor-with-padding"} id="roadmap">
               Roadmap
             </h1>
             <div className={styles.row}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -504,7 +504,10 @@ export default function App() {
             </div>
 
             <div className={styles.spacer} />
-            <h1 className={styles.h1}>Roadmap</h1>
+
+            <h1 className={styles.h1} id="roadmap">
+              Roadmap
+            </h1>
             <div className={styles.row}>
               <Roadmap />
             </div>


### PR DESCRIPTION
# Problem
After updating the newly made roadmap component, the id has been removed and the RC badge of NavBar does not point to the correct component.

# Fix
By adding `id="roadmap"`, clicking the badge will show the users the roadmap.