### PR TITLE
fix(updater): typo in update file format

### DIFF
--- a/docs/guides/distribution/updater.md
+++ b/docs/guides/distribution/updater.md
@@ -233,7 +233,7 @@ The alternate update technique uses a plain JSON file, storing your update metad
       "signature": "",
       "url": "https://github.com/lemarier/tauri-test/releases/download/v1.0.0/app.AppImage.tar.gz"
     },
-    "win64": {
+    "windows-x86_64": {
       "signature": "",
       "url": "https://github.com/lemarier/tauri-test/releases/download/v1.0.0/app.x64.msi.zip"
     }


### PR DESCRIPTION
Changed `win64` to `windows-x86_64`.