### PR TITLE
Fix link to Debian/Linux building guide

### DIFF
--- a/docs/guides/building/README.md
+++ b/docs/guides/building/README.md
@@ -10,4 +10,4 @@ It will detect your operating system and build a bundle accordingly. It currentl
 
 - [Windows](./windows.md): .msi
 - [macOS](./macos.md): .app, .dmg
-- [Linux](./windows.md): .deb, .appimage
+- [Linux](./debian.md): .deb, .appimage


### PR DESCRIPTION
Very small fix, which had the link to Linux in the building landing page point to Windows.