### PR TITLE
swap unaffliated youtube video with quick overview

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,12 +4,4 @@ sidebar_position: 1
 
 # Introduction
 
-## Quick Overview
-
-Check out [Tauri in 100 Seconds](https://www.youtube.com/watch?v=-X8evddpu7M) by [Fireship](https://www.youtube.com/channel/UCsBjURrPoezykLs9EqgamOA) on YouTube for a quick introduction to Tauri
-
-<div className="videowrapper">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-X8evddpu7M" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
-<br />
+Tauri is a security-first and performance conscience framework for building apps. [Rust](https://www.rust-lang.org/) is at the heart of the framework and handles the backend. The system-based browser drives the frontend enabling OS-level browser patching. This browser, known as the webview, handles the HTML/CSS/JS or other compatible web content. Use the web ecosystem tools to create the web content, and Tauri will bundle it up into a tiny app.


### PR DESCRIPTION
## Motivation

I swapped a quick overview of Tauri instead of the YouTube video link. The video contained outdated and misleading content. We have previously discussed that we should not be enabling poor benchmarks, and linking this video directly enables that.

Also if we want a video, we should create this under our namespace rather than affiliating ourselves with someone outside of the Tauri team.
