### PR TITLE
Recommend CodeLLDB VSCode extension instead

### DIFF
--- a/docs/guides/debugging/vs-code.md
+++ b/docs/guides/debugging/vs-code.md
@@ -4,9 +4,9 @@ This guide describes how to setup debugging in VS Code for the [Core Process in 
 
 ## Setup
 
-Install the [`lldb-vscode`] extension.
+Install the [`vscode-lldb`] extension.
 
-[`lldb-vscode`]: https://marketplace.visualstudio.com/items?itemName=lanza.lldb-vscode
+[`vscode-lldb`]: https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb
 
 ## Configure launch.json
 


### PR DESCRIPTION
Recommend the more up-to-date and cross-platform LLDB extension 'CodeLLDB' (vadimcn.vscode-lldb). Instead of the abandoned and Darwin only 'LLDB VSCode' (lanza.lldb-vscode).