### PR TITLE
Revise `create-tauri-app` usage

### DIFF
--- a/docs/guides/getting-started/setup/_intro.mdx
+++ b/docs/guides/getting-started/setup/_intro.mdx
@@ -13,10 +13,10 @@ In the following, we will first scaffold the Frontend, then set up the Rust proj
 The easiest way to scaffold a new project is the [`create-tauri-app`](https://github.com/tauri-apps/create-tauri-app) utility. It will ask you a series of questions and quickly bootstrap a Tauri project for you to begin developing with. It has support for vanilla HTML/CSS/JavaScript but also many frontend frameworks like React, Vue, or Svelte.
 
 <Tabs groupId="package-manager">
-<TabItem value="npx" label="npx" default>
+<TabItem value="npm" label="npm" default>
 
 ```shell
-npx create-tauri-app
+npm create tauri-app
 ```
 
 </TabItem>

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -24,16 +24,13 @@ export const CreateTauriApp = () => {
     <Tabs>
       <TabItem value="npm">
         <CodeBlock className={`language-shell`}>
-          npm x create-tauri-app
+          npm create tauri-app
         </CodeBlock>
       </TabItem>
       <TabItem value="yarn">
         <CodeBlock className={`language-shell`}>
           yarn create tauri-app
         </CodeBlock>
-      </TabItem>
-      <TabItem value="npx">
-        <CodeBlock className={`language-shell`}>npx create-tauri-app</CodeBlock>
       </TabItem>
       <TabItem value="pnpm">
         <CodeBlock className={`language-shell`}>


### PR DESCRIPTION
- `npx` and `npm x` are the same, so they shouldn't have different tabs.
- I switched all npm usages to `npm create tauri-app` because it is similar to other package managers and `npm` had the `create` command for so long now.