### PR TITLE
Update heroPackage to decrease and hide in mobile

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -72,6 +72,18 @@
   height: 30%;
 }
 
+@media (max-width: 1177px) {
+  .heroPackage {
+    height: 20%;
+  }
+}
+
+@media (max-width: 1070px) {
+  .heroPackage {
+    display: none;
+  }
+}
+
 .heroBefore .heroPackage {
   position: absolute;
   transform: rotate(15deg);


### PR DESCRIPTION
# Before 

## 1177px
![before_screen_1177](https://user-images.githubusercontent.com/78584173/174420886-843d9416-7db5-4dc9-ab98-7f9c9f77b6a0.png)

The package goes off screen in big ipads/smaller computer screens.

## 760px ~ 1177px
![getting_smaller](https://user-images.githubusercontent.com/78584173/174420979-7d9fcca5-abd4-4987-80ea-bf961244a534.png)

The packages gets smaller and disappears completely in 760px

## 760px
![mobile](https://user-images.githubusercontent.com/78584173/174421012-9c0b6ef6-cd7a-41b6-b9c4-91b35044d78f.png)

# After

## 1177px
![package_smaller_1177](https://user-images.githubusercontent.com/78584173/174421052-85e5b139-dcb8-43be-ab44-d5d2e381e598.png)

## Mobile
![disappear_mobile](https://user-images.githubusercontent.com/78584173/174421070-efe376e0-124c-43ea-a004-9df163ba146d.png)
