### PR TITLE
Update link, break in mobile

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,7 +204,7 @@ const siteConfig = {
     },
     announcementBar: {
       content:
-        "<b>🚀 Tauri 1.0 has landed! <a href='https://tauri.app'>Click here for more details</a></b>",
+        "<b>🚀 Tauri 1.0 has landed! <a class='link-announcementBar' target='_blank' href='https://github.com/tauri-apps/tauri/releases'>Click here for more details</a></b>",
       backgroundColor: 'var(--ifm-color-primary)',
       textColor: 'var(--ifm-button-color)',
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,7 +204,7 @@ const siteConfig = {
     },
     announcementBar: {
       content:
-        "<b>🚀 Tauri 1.0 has landed! <a class='link-announcementBar' target='_blank' href='https://github.com/tauri-apps/tauri/releases'>Click here for more details</a></b>",
+        "<b>🚀 Tauri 1.0 has landed! <a class='link-announcementBar' href='https://tauri.app'>Click here for more details</a></b>",
       backgroundColor: 'var(--ifm-color-primary)',
       textColor: 'var(--ifm-button-color)',
     },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -110,6 +110,12 @@ h2 > [class^='ti-'] {
   min-height: 52px;
 }
 
+@media (max-width: 341px) {
+  .link-announcementBar {
+    display: block;
+  }
+}
+
 [class*='property_'] .hash-link {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
# New line in mobile
Link should move into new line for easier reading and clicking.

(before)
![before](https://user-images.githubusercontent.com/78584173/174421375-a57e1834-a906-46a8-9ac4-22403692442b.png)

(after)
![afer](https://user-images.githubusercontent.com/78584173/174421383-0c875af4-5879-4655-b691-189bedb1c0c2.png)
