### PR TITLE
really? :)

### DIFF
--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -58,13 +58,13 @@ pnpm create vite
   </TabItem>
 </Tabs>
 
-1. **Project name:**  
+1. **Project name:**
    This will be the name of your JavaScript project. Corresponds to the name of the folder this utility will create but has otherwise no effect on your app. You can use any name you want here.
 
-2. **Select a framework:**  
+2. **Select a framework:**
    If you plan on using a frontend framework later, this is where you can select it. For this guide, we assume you choose `vanilla`.
 
-3. **Select a variant:**  
+3. **Select a variant:**
    Vite offers [TypeScript] and vanilla JavaScript variants for all templates, and you can select the variant here. We **strongly** recommend TypeScript as it helps you write more secure, maintainable code faster and more efficiently. For this guide, we assume you choose `vanilla-ts`.
 
 Before we move on, let's quickly customize our `vite.config.ts` file, so you get the best compatibility with Tauri!
@@ -183,5 +183,5 @@ If you want to know more about the communication between Rust and JavaScript, pl
 [prerequisites]: ../prerequisites.md
 [tauri-cli]: ../tauri-cli.md
 [awesome-vite]: https://github.com/vitejs/awesome-vite#plugins
-[`@tauri-apps/api`]: ../../../api/js/
-[inter-process-communication]: ../../architecture/inter-process-communication
+[`@tauri-apps/api`]: ../../../api/js/README.md
+[inter-process-communication]: ../../architecture/inter-process-communication/README.md


### PR DESCRIPTION
for https://tauri.app/v1/guides/getting-started/setup/vite/ you are using relative paths which are correct when referring to a specific folder in a file path. However, when parsed to a URL this means that you need to go up an additional folder in order for the generated URL to be correct. However(again), if you do this then you will break docs links like this when people are browsing via github. The current best solution for you... just fully spell out the file path. 

I checked a few other files.. and didn't see the same mistake, but it's probably present elsewhere. 

https://docusaurus.io/docs/markdown-features/links !!!!