### PR TITLE
Fix TS error in config example

### DIFF
--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -87,7 +87,7 @@ export default defineConfig({
     // Tauri supports es2021
     target: ['es2021', 'chrome97', 'safari13'],
     // don't minify for debug builds
-    minify: !process.env.TAURI_DEBUG && 'esbuild',
+    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
     // produce sourcemaps for debug builds
     sourcemap: !!process.env.TAURI_DEBUG,
   },


### PR DESCRIPTION
Hi! Here is a little fix of vite.config.ts example.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/2021856/175318467-cdc809b0-3829-466b-aee1-2a28c7d1b14f.png">
