### PR TITLE
Remove .md extention from links

### DIFF
--- a/docs/guides/architecture/inter-process-communication/isolation.md
+++ b/docs/guides/architecture/inter-process-communication/isolation.md
@@ -9,7 +9,7 @@ Isolation application.
 The Isolation pattern's purpose is to provide a mechanism for developers to help protect their application from unwanted
 or malicious frontend calls to Tauri Core. The need for the Isolation pattern rose out of threats coming from
 untrusted content running on the frontend, a common case for applications with many dependencies. See
-[Security: Threat Models](../../development/security.md#threat-models) for a list of many sources of threats that an
+[Security: Threat Models](../../development/security#threat-models) for a list of many sources of threats that an
 application may see.
 
 The largest threat model described above that the Isolation pattern was designed in mind with was Development Threats.
@@ -29,7 +29,7 @@ to access a path outside your application's expected locations. Another example 
 fetch call is only setting the Origin header to what your application expects it to be.
 
 That said, it intercepts _**all**_ messages from the frontend, so it will even work with always-on APIs such as
-[Events](../../features/events.md). Since some events may cause your own rust code to perform actions, the same sort of
+[Events](../../features/events). Since some events may cause your own rust code to perform actions, the same sort of
 validation techniques can be used with them.
 
 ## How
@@ -62,7 +62,7 @@ _Note: Arrows (->) indicate message passing._
 ### Performance Implications
 
 Because encryption of the message does occur, there are additional overhead costs compared to the
-[Brownfield pattern](./brownfield.md), even if the secure Isolation application doesn't do anything. Aside from
+[Brownfield pattern](./brownfield), even if the secure Isolation application doesn't do anything. Aside from
 performance-sensitive applications (who likely have a carefully-maintained and small set of dependencies, to keep the performance
 adequate), most applications should not notice the runtime costs of encrypting/decrypting the IPC messages, as they are
 relatively small and AES-GCM is relatively fast. If you are unfamiliar with AES-GCM, all that is relevant in this
@@ -73,7 +73,7 @@ and that you probably already use it every day under the hood with TLS.
 There is also a cryptographically secure key generated once each time the Tauri application is started. It is not
 generally noticeable if the system already has enough entropy to immediately return enough random numbers, which is
 extremely common for desktop environments. If running in a headless environment to perform
-some [integration testing with WebDriver](../../testing/webdriver/introduction.md)
+some [integration testing with WebDriver](../../testing/webdriver/introduction)
 then you may want to install some sort of entropy generating service such as `haveged` if your operating system does not
 have one included. <sup>Linux 5.6 (March 2020) now includes entropy generation using speculative execution.</sup>
 
@@ -127,7 +127,7 @@ window.__TAURI_ISOLATION_HOOK__ = (payload) => {
 ```
 
 Now, all we need to do is set up our `tauri.conf.json` [configuration](#configuration) to use the Isolation pattern, and
-have just bootstrapped to the Isolation pattern from the [Brownfield pattern](./brownfield.md).
+have just bootstrapped to the Isolation pattern from the [Brownfield pattern](./brownfield).
 
 ## Configuration
 

--- a/docs/guides/architecture/recipes/lockdown.md
+++ b/docs/guides/architecture/recipes/lockdown.md
@@ -46,7 +46,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 ## Description
 
-The Lockdown recipe is a minimal usage of the [Bridge pattern](./bridge.md), which only allows interaction between Rust and the Window via expiring JS Promise Closures that are injected into the Window by Rust and nulled as part of the callback.
+The Lockdown recipe is a minimal usage of the [Bridge pattern](./bridge), which only allows interaction between Rust and the Window via expiring JS Promise Closures that are injected into the Window by Rust and nulled as part of the callback.
 
 ## Diagram
 

--- a/docs/guides/building/README.md
+++ b/docs/guides/building/README.md
@@ -8,6 +8,6 @@ The Tauri Bundler is a Rust harness to compile your binary, package assets, and 
 
 It will detect your operating system and build a bundle accordingly. It currently supports:
 
-- [Windows](./windows.md): .msi
-- [macOS](./macos.md): .app, .dmg
-- [Linux](./debian.md): .deb, .appimage
+- [Windows](./windows): .msi
+- [macOS](./macos): .app, .dmg
+- [Linux](./debian): .deb, .appimage

--- a/docs/guides/distribution/macos.md
+++ b/docs/guides/distribution/macos.md
@@ -73,4 +73,4 @@ See the [Code signing guide].
 [`tauri.bundle.macos.exceptiondomain`]: ../../api/config/#tauri.bundle.macOS.exceptionDomain
 [`tauri.bundle.macos.usebootstrapper`]: ../../api/config#tauri.bundle.deb.useBootstrapper
 [info.plist file]: https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html
-[code signing guide]: ./sign-macos.md
+[code signing guide]: ./sign-macos

--- a/docs/guides/distribution/windows.md
+++ b/docs/guides/distribution/windows.md
@@ -192,4 +192,4 @@ See the [Code signing guide].
 [tauri.bundle.windows.wix.language]: ../../api/config/#tauri.bundle.windows.wix.language
 [1]: https://docs.microsoft.com/en-us/windows/win32/msi/localizing-the-error-and-actiontext-tables
 [wix localization documentation]: https://wixtoolset.org/documentation/manual/v3/howtos/ui_and_localization/make_installer_localizable.html
-[code signing guide]: ./sign-windows.md
+[code signing guide]: ./sign-windows

--- a/docs/guides/features/splashscreen.md
+++ b/docs/guides/features/splashscreen.md
@@ -31,7 +31,7 @@ Now, your main window will be hidden and the splashscreen window will show when 
 
 ### Waiting for Webpage
 
-If you are waiting for your web code, you'll want to create a `close_splashscreen` [command](command.md).
+If you are waiting for your web code, you'll want to create a `close_splashscreen` [command](command).
 
 ```rust title=src-tauri/main.rs
 use tauri::Manager;

--- a/docs/guides/getting-started/setup/README.mdx
+++ b/docs/guides/getting-started/setup/README.mdx
@@ -21,5 +21,5 @@ If you miss your favorite frontend framework or build tool, we're always looking
 
 If you're unfamiliar with web development or have no favorite frontend stack you might find the [HTML/CSS/JS] guide the most helpful. It guides you through getting started with the most minimal frontend setup possible: A single HTML file.
 
-[html/css/js]: ./html-css-js.mdx
-[contributing]: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md
+[html/css/js]: ./html-css-js
+[contributing]: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING

--- a/docs/guides/getting-started/setup/_commands.mdx
+++ b/docs/guides/getting-started/setup/_commands.mdx
@@ -25,4 +25,4 @@ fn main() {
 
 Now we're ready to call your Command from the JavaScript frontend!
 
-[command]: ../../features/command.md
+[command]: ../../features/command

--- a/docs/guides/getting-started/setup/_intro.mdx
+++ b/docs/guides/getting-started/setup/_intro.mdx
@@ -38,5 +38,5 @@ pnpm create tauri-app
 :::
 
 [cargo]: https://doc.rust-lang.org/cargo/
-[prerequisites]: ../prerequisites.md
-[tauri-cli]: ../tauri-cli.md
+[prerequisites]: ../prerequisites
+[tauri-cli]: ../tauri-cli

--- a/docs/guides/getting-started/setup/_tauri-init.mdx
+++ b/docs/guides/getting-started/setup/_tauri-init.mdx
@@ -70,7 +70,7 @@ The `tauri init` command generates a folder called `src-tauri`. It's a conventio
 [cfg macro]: https://doc.rust-lang.org/rust-by-example/attribute/cfg.html
 [api config]: ../../../api/config
 [icons]: ../../features/icons
-[prerequisites]: ../prerequisites.md
-[tauri-cli]: ../tauri-cli.md
+[prerequisites]: ../prerequisites
+[tauri-cli]: ../tauri-cli
 [cargo]: https://doc.rust-lang.org/cargo/
 [cargo commands]: https://doc.rust-lang.org/cargo/commands/index.html

--- a/docs/guides/getting-started/setup/html-css-js.mdx
+++ b/docs/guides/getting-started/setup/html-css-js.mdx
@@ -124,7 +124,7 @@ If you want to know more about the communication between Rust and JavaScript, pl
 
 [inter-process-communication]: ../../architecture/inter-process-communication
 [cargo]: https://doc.rust-lang.org/cargo/
-[prerequisites]: ../prerequisites.md
-[tauri-cli]: ../tauri-cli.md
+[prerequisites]: ../prerequisites
+[tauri-cli]: ../tauri-cli
 [`withglobaltauri`]: ../../../api/config#buildconfig.withglobaltauri
 [`@tauri-apps/api`]: ../../../api/js/

--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -179,8 +179,8 @@ If you want to know more about the communication between Rust and JavaScript, pl
 [vite]: https://vitejs.dev
 [cargo]: https://doc.rust-lang.org/cargo/
 [typescript]: https://www.typescriptlang.org
-[prerequisites]: ../prerequisites.md
-[tauri-cli]: ../tauri-cli.md
+[prerequisites]: ../prerequisites
+[tauri-cli]: ../tauri-cli
 [awesome-vite]: https://github.com/vitejs/awesome-vite#plugins
 [`@tauri-apps/api`]: ../../../api/js/
 [inter-process-communication]: ../../architecture/inter-process-communication

--- a/docs/guides/testing/mocking.md
+++ b/docs/guides/testing/mocking.md
@@ -122,8 +122,8 @@ test('invoke', async () => {
 })
 ```
 
-[`@tauri-apps/api/mocks`]: /docs/api/js/modules/mocks.md
-[`mockipc()`]: /docs/api/js/modules/mocks.md#mockipc
-[`mockwindows()`]: /docs/api/js/modules/mocks.md#mockwindows
-[`clearmocks()`]: /docs/api/js/modules/mocks.md#clearmocks
+[`@tauri-apps/api/mocks`]: ../../api/js/modules/mocks
+[`mockipc()`]: ../../api/js/modules/mocks#mockipc
+[`mockwindows()`]: ../../api/js/modules/mocks#mockwindows
+[`clearmocks()`]: ../../api/js/modules/mocks#clearmocks
 [vitest]: https://vitest.dev


### PR DESCRIPTION
Helps with https://github.com/tauri-apps/tauri-docs/issues/673

Apparently putting `.md` when referencing links breaks something with i18n