### PR TITLE
Fix link to contributing file in tauri-app

### DIFF
--- a/docs/guides/getting-started/setup/README.mdx
+++ b/docs/guides/getting-started/setup/README.mdx
@@ -22,4 +22,4 @@ If you miss your favorite frontend framework or build tool, we're always looking
 If you're unfamiliar with web development or have no favorite frontend stack you might find the [HTML/CSS/JS] guide the most helpful. It guides you through getting started with the most minimal frontend setup possible: A single HTML file.
 
 [html/css/js]: ./html-css-js
-[contributing]: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING
+[contributing]: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md


### PR DESCRIPTION
Corrected the link in the docs to redirect to the correct file contributing file 