### PR TITLE
docs: fixed arguments

### DIFF
--- a/docs/api/js/modules/fs.md
+++ b/docs/api/js/modules/fs.md
@@ -206,7 +206,7 @@ List directory files.
 **`example`** Reads the `$APPDIR/users` directory recursively
 ```typescript
 import { readDir, BaseDirectory } from '@tauri-apps/api/fs';
-const entries = await readDir('users', new Uint8Array([]), { dir: BaseDirectory.App, recursive: true });
+const entries = await readDir('users', { dir: BaseDirectory.App, recursive: true });
 
 function processEntries(entries) {
   for (const entry of entries) {


### PR DESCRIPTION
readDir doesn't take a datatype