### PR TITLE
Fixed spelling error

### DIFF
--- a/docs/api/js/modules/path.md
+++ b/docs/api/js/modules/path.md
@@ -458,7 +458,7 @@ Returns whether the path is absolute or not.
 **`example`**
 ```typescript
 import { isAbsolute } from '@tauri-apps/api/path';
-assert(await ibsolute('/home/tauri'));
+assert(await isAbsolute('/home/tauri'));
 ```
 
 #### Parameters


### PR DESCRIPTION
Fixes a spelling error in the code example for the isAbsolute function.