### PR TITLE
Remove note recommendation to target macOS 10.15

### DIFF
--- a/docs/guides/building/macos.md
+++ b/docs/guides/building/macos.md
@@ -19,10 +19,6 @@ GUI apps on macOS and Linux do not inherit the `$PATH` from your shell dotfiles 
 The minimum version of the operating system required for a Tauri app to run in macOS is `10.13`. If you need support for newer macOS APIs like `window.print` that is only supported from macOS version `11.0`
 onwards, you can change the [`tauri.bundle.macOS.minimumSystemVersion`]. This will in turn set the `Info.plist` [LSMinimumSystemVersion] property and the `MACOSX_DEPLOYMENT_TARGET` environment variable.
 
-:::caution
-macOS High Sierra (10.13) no longer receives security updates from Apple. You should target macOS Catalina (10.15) if possible.
-:::
-
 ## Binary Targets
 
 macOS applications can target Apple Silicon, Intel-based Mac computers, or Universal macOS binaries that work on both architectures. By default, the Tauri CLI uses your machine's architecture, but you can configure a different target using the `--target` flag:

--- a/docs/guides/distribution/macos.md
+++ b/docs/guides/distribution/macos.md
@@ -11,10 +11,6 @@ Tauri applications for macOS are distributed either with an [Application Bundle]
 
 The minimum version of the operating system required for a Tauri app to run in macOS is `10.13`. You can change that value on the [`tauri.bundle.macOS.minimumSystemVersion`] property. The value is set to the Info.plist key [LSMinimumSystemVersion] and the MACOSX_DEPLOYMENT_TARGET environment variable.
 
-:::note
-macOS High Sierra (10.13) no longer receives security updates from Apple. You should target macOS Catalina (10.15) if possible.
-:::
-
 :::caution
 Using the `window.print` API requires macOS version `11.0+`.
 :::


### PR DESCRIPTION
I don't see a good reason to recommend building apps that are unsupported/blocked from running on older OS-es. We don't seem to recommend against supporting/running on Windows 7, which has gone even longer without security support.

Newer macOS versions drop support for older hardware, which means that supporting older OS-es can also potentially help reduce e-waste.