### PR TITLE
Hide package on small screens

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -72,6 +72,12 @@
   height: 30%;
 }
 
+@media (max-width: 1200px) {
+  .heroPackage {
+    display: none;
+  }
+}
+
 .heroBefore .heroPackage {
   position: absolute;
   transform: rotate(15deg);


### PR DESCRIPTION
Hides the packages on smaller screens where overflow was causing over scroll issues (particularly on mobile)