### PR TITLE
fix/Untrusted Branch Deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@
 name: build
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - dev
   push:


### PR DESCRIPTION
This will use the GitHub workflows from the base of a PR (the `dev` branch) which should allow us to deploy for external forks.