### PR TITLE
fixes #819 wrong command in docs for cargo update

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -164,10 +164,10 @@ Rust is installed now. Great!
 
 ## Updating and Uninstalling
 
-Tauri and its components can be manually updated by editing the `Cargo.toml` file or running the `cargo upgrade` command that is part of the [`cargo-edit`] tool. Open a terminal and enter the following command:
+Tauri and its components can be manually updated by editing the `Cargo.toml` file or running the `cargo update` command that is part of the [`cargo-edit`] tool. Open a terminal and enter the following command:
 
 ```shell
-cargo upgrade
+cargo update
 ```
 
 Updating Rust itself is easy via `rustup`. Open a terminal and run the following command:


### PR DESCRIPTION
fixes #819 

Example:
```
E:\GitHub Repos\openrefine-tauri\src-tauri>cargo upgrade
error: no such subcommand: `upgrade`

        Did you mean `update`?

E:\GitHub Repos\openrefine-tauri\src-tauri>cargo update
    Updating crates.io index
    Updating anyhow v1.0.56 -> v1.0.61
    Removing async-broadcast v0.3.4
    Removing async-channel v1.6.1
<snip>
```