### PR TITLE
fix(copyright): proper org name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Tauri
+Copyright (c) 2020-2022 Tauri Programme within the Commons Conservancy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The **API docs** are generated from our [Rust] and [TypeScript] source code.
 
 See [Contributing Guide].
 
+## Trademark Usage
+If you are interested in using the Tauri trademarks, please read this page: https://tauri.app/about/trademark
+
 ## License
 
 MIT License


### PR DESCRIPTION
This commit does not modify the license,
it only assigns the proper name of the
copyright holder:

"Tauri Programme within the Commons Conservancy" 

It also mentions a way to discover more about the trademark usage.