### PR TITLE
docs(clipboard): Added allowlist section to the Clipboard module

### DIFF
--- a/docs/api/js/modules/clipboard.md
+++ b/docs/api/js/modules/clipboard.md
@@ -6,6 +6,22 @@ Read and write to the system clipboard.
 
 This package is also accessible with `window.__TAURI__.clipboard` when [`build.withGlobalTauri`](https://tauri.app/v1/api/config/#buildconfig.withglobaltauri) in `tauri.conf.json` is set to `true`.
 
+The APIs must be added to [`tauri.allowlist.clipboard`](https://tauri.app/v1/api/config/#allowlistconfig.clipboard) in `tauri.conf.json`:
+```json
+{
+  "tauri": {
+    "allowlist": {
+      "clipboard": {
+        "all": true, // enable all Clipboard APIs
+        "writeText": true,
+        "readText": true
+      }
+    }
+  }
+}
+```
+It is recommended to allowlist only the APIs you use for optimal bundle size and security.
+
 ## Functions
 
 ### readText


### PR DESCRIPTION
Added missing bit about adding the available Clipboard APIs to `tauri.conf.json`.