### PR TITLE
Fix: Update Server JSON missing required key

### DIFF
--- a/docs/guides/distribution/updater.md
+++ b/docs/guides/distribution/updater.md
@@ -207,7 +207,7 @@ When an update is available, Tauri expects the following schema in response to t
 }
 ```
 
-The only required keys are "url" and "version"; the others are optional.
+The required keys are "url", "version" and "signature"; the others are optional.
 
 "pub_date" if present must be formatted according to [RFC 3339][date and time on the internet: timestamps].
 


### PR DESCRIPTION
If the "signature" key is missing, the Updater will not work.