### PR TITLE
Fix incorrect heading level under logDir

### DIFF
--- a/docs/api/js/modules/path.md
+++ b/docs/api/js/modules/path.md
@@ -489,7 +489,7 @@ ___
 
 Returns the path to the suggested log directory.
 
-### Platform-specific
+#### Platform-specific
 
 - **Linux:** Resolves to `${configDir}/${bundleIdentifier}`.
 - **macOS:** Resolves to `${homeDir}//Library/Logs/{bundleIdentifier}`


### PR DESCRIPTION
What it says on the tin. `Platform-Specific` subheadings should be level-4 headings.