### PR TITLE
update `cargo upgrade` command

### DIFF
--- a/docs/guides/development/updating-dependencies.md
+++ b/docs/guides/development/updating-dependencies.md
@@ -48,7 +48,7 @@ cd src-tauri
 cargo update
 ```
 
-Alternatively you can run the `cargo upgrade` command provided by [cargo-edit] which does all of this automatically.
+Alternatively you can run the `cargo update` command provided by [cargo-edit] which does all of this automatically.
 
 [`cargo outdated`]: https://github.com/kbknapp/cargo-outdated
 [tauri]: https://crates.io/crates/tauri/versions

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -164,10 +164,10 @@ Rust is installed now. Great!
 
 ## Updating and Uninstalling
 
-Tauri and its components can be manually updated by editing the `Cargo.toml` file or running the `cargo upgrade` command that is part of the [`cargo-edit`] tool. Open a terminal and enter the following command:
+Tauri and its components can be manually updated by editing the `Cargo.toml` file or running the `cargo update` command that is part of the [`cargo-edit`] tool. Open a terminal and enter the following command:
 
 ```shell
-cargo upgrade
+cargo update
 ```
 
 Updating Rust itself is easy via `rustup`. Open a terminal and run the following command:


### PR DESCRIPTION
Was trying out the docs, I think `cargo upgrade` was renamed to `cargo update`. https://doc.rust-lang.org/cargo/commands/cargo-update.html