### PR TITLE
Fix typo in _tauri-init.mdx

### DIFF
--- a/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
+++ b/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
@@ -24,7 +24,7 @@ yarn add -D @tauri-apps/cli
 ```
 
 </TabItem>
-<TabItem value="pnpm" label="npm">
+<TabItem value="pnpm" label="pnpm">
 
 ```shell
 pnpm add -D @tauri-apps/cli
@@ -59,7 +59,7 @@ yarn tauri init
 ```
 
 </TabItem>
-<TabItem value="pnpm" label="npm">
+<TabItem value="pnpm" label="pnpm">
 
 ```shell
 pnpm tauri init


### PR DESCRIPTION
This commit addresses a typo where a `pnpm` example is incorrectly labelled as `npm`, resulting in what looks like two examples using `npm`.