### PR TITLE
Docs: Update incorrect package manager names in vite quickstart

### DIFF
--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -44,7 +44,7 @@ yarn create vite
 ```
 
   </TabItem>
-  <TabItem value="pnpm" label="npm">
+  <TabItem value="pnpm" label="pnpm">
 
 ```shell
 pnpm create vite
@@ -140,7 +140,7 @@ yarn add @tauri-apps/api
 ```
 
   </TabItem>
-  <TabItem value="pnpm" label="npm">
+  <TabItem value="pnpm" label="pnpm">
 
 ```shell
 pnpm add @tauri-apps/api


### PR DESCRIPTION
Changed these:
1. [Create the Frontend Section](https://tauri.app/v1/guides/getting-started/setup/vite/#create-the-frontend)
2. [Invoke Commands Section](https://tauri.app/v1/guides/getting-started/setup/vite/#invoke-commands)