### PR TITLE
Feat/search and navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,10 +134,6 @@ const navbarItems = [
       },
     ],
   },
-  {
-    type: 'search',
-    position: 'right',
-  },
 ]
 
 const footerLinks = [
@@ -267,15 +263,15 @@ async function siteConfig() {
             sidebarPath: require.resolve('./sidebars.js'),
             showLastUpdateTime: true,
             editUrl: ({ docPath, versionDocsDirPath }) => {
-              if (docPath === "api/cli.md") {
-                return 'https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/src';
-              } else if (docPath === "api/config.md") {
-                return 'https://github.com/tauri-apps/tauri/edit/dev/core/tauri-utils/src/config.rs';
-              } else if (docPath.startsWith("api/js")) {
-                const mod = docPath.split('/').at(-1).split('.')[0];
-                return `https://github.com/tauri-apps/tauri/edit/dev/tooling/api/src/${mod}.ts`;
+              if (docPath === 'api/cli.md') {
+                return 'https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/src'
+              } else if (docPath === 'api/config.md') {
+                return 'https://github.com/tauri-apps/tauri/edit/dev/core/tauri-utils/src/config.rs'
+              } else if (docPath.startsWith('api/js')) {
+                const mod = docPath.split('/').at(-1).split('.')[0]
+                return `https://github.com/tauri-apps/tauri/edit/dev/tooling/api/src/${mod}.ts`
               } else {
-                return `https://github.com/tauri-apps/tauri-docs/edit/dev/${versionDocsDirPath}/${docPath}`;
+                return `https://github.com/tauri-apps/tauri-docs/edit/dev/${versionDocsDirPath}/${docPath}`
               }
             },
             sidebarCollapsible: true,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -93,7 +93,7 @@
 
 /* Required due to a lot of items in navbar */
 /* https://github.com/facebook/docusaurus/issues/7635 */
-@media only screen and (max-width: 1224px) {
+@media only screen and (max-width: 1300px) {
   .navbar__items {
     white-space: nowrap;
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -91,6 +91,22 @@
   background-color: var(--ifm-background-color);
 }
 
+/* Required due to a lot of items in navbar */
+/* https://github.com/facebook/docusaurus/issues/7635 */
+@media only screen and (max-width: 1224px) {
+  .navbar__items {
+    white-space: nowrap;
+  }
+
+  .navbar__items--right {
+    font-size: 0;
+  }
+
+  .navbar__items--right .navbar__item > svg {
+    display: none;
+  }
+}
+
 .navbarIcon::before {
   display: inline-block;
   content: '';

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,11 +1,7 @@
 import React, { useEffect } from 'react'
-import { useColorMode } from '@docusaurus/theme-common'
-import 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css'
 import './style.css'
 
 export default function Component() {
-  const isDarkTheme = useColorMode().colorMode === 'dark'
-
   useEffect(() => {
     const DocsSearchBar = require('docs-searchbar.js').default
 
@@ -14,20 +10,17 @@ export default function Component() {
       apiKey:
         'XZEH8BS90ee09c45215a8421c06857bcbde5c1a6797bdf4859a57a3ac1228a2b81df0994',
       indexUid: 'consolidated',
-      inputSelector: '.search-bar-input',
+      inputSelector: '#search-bar-input',
       debug: process.env.NODE_ENV === 'development',
-      enableDarkMode: isDarkTheme,
-      enhancedSearchInput: true,
     })
   }, [])
 
-  useEffect(() => {
-    document.querySelector('.docs-searchbar-js').setAttribute('data-ds-theme', isDarkTheme ? 'dark' : 'light')
-  }, [isDarkTheme])
-
   return (
-    <div>
-      <input className="search-bar-input" />
-    </div>
+    <input
+      type="search"
+      id="search-bar-input"
+      className="navbar__search navbar__search-input"
+      placeholder="Search"
+    />
   )
 }

--- a/src/theme/SearchBar/style.css
+++ b/src/theme/SearchBar/style.css
@@ -1,104 +1,107 @@
-/*
-  The default meilisearch search bar style is docs-searchbar.js/dist/cdn/docs-searchbar.min.css.
-  But there are few configurations needed to make the site look better.
-*/
-
-/* Default searchbox and dropdown style */
-.searchbox {
-  width: 350px;
-}
-
-.meilisearch-autocomplete .dsb-dropdown-menu,
-div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
-  width: 300% !important;
-}
-
-/* The subcategory text is centered vertically */
-div[data-ds-theme='dark']
-  .meilisearch-autocomplete
-  .docs-searchbar-suggestion--wrapper {
-  align-items: center !important;
-}
-
-/* Media Queries for specific width screen */
-@media only screen and (max-width: 1400px) {
-  .searchbox {
-    width: 200px !important;
-  }
-
-  /* These badges and svg-icons are not needed on smaller screens */
-  .badge,
-  .svg-icons {
-    display: none !important;
+/* Prevents zooming in on mobile */
+@media screen and (max-width: 996px) {
+  input#search-bar-input {
+    font-size: 16px !important;
   }
 }
 
-@media only screen and (max-width: 995px) {
-  .searchbox {
-    width: 400px !important;
-  }
-
-  .meilisearch-autocomplete .dsb-dropdown-menu,
-  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
-    width: 170% !important;
-  }
+/* Main dropdown wrapper */
+.meilisearch-autocomplete .dsb-dropdown-menu {
+  background-color: var(--ifm-card-background-color);
+  border-radius: var(--ifm-card-border-radius);
+  box-shadow: var(--ifm-global-shadow-md);
+  max-height: calc(100vh - var(--ifm-navbar-height));
+  width: min(calc(90vw - var(--ifm-navbar-padding-horizontal)), 35rem);
+  z-index: unset !important;
+  right: 0;
+  overflow-y: scroll;
 }
 
-@media only screen and (max-width: 630px) {
-  /* From smaller ipad screens, the text's font size needs to be smaller */
-  .docs-searchbar-suggestion--subcategory-column-text {
-    font-size: 18px !important;
-  }
-
-  .docs-searchbar-suggestion--title {
-    font-size: 12px !important;
-    margin-bottom: 0 !important;
-    margin-top: 3px !important;
-  }
-
-  .meilisearch-autocomplete .dsb-dropdown-menu,
-  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
-    width: 100% !important;
-  }
+/* Content */
+.meilisearch-autocomplete .dsb-suggestions,
+.docs-searchbar-suggestion--no-results {
+  padding: var(--ifm-card-vertical-spacing) var(--ifm-card-horizontal-spacing);
 }
 
-@media only screen and (max-width: 600px) {
-  .searchbox {
-    width: calc(100vw - 200px) !important;
-  }
+/* A single suggestion */
+.meilisearch-autocomplete .dsb-suggestion {
+  padding: 0.25rem 0.5rem;
+  text-decoration: none;
+  border-radius: 0.5rem;
+}
 
-  .meilisearch-autocomplete .dsb-dropdown-menu,
-  div[data-ds-theme='dark'] .meilisearch-autocomplete .dsb-dropdown-menu {
-    min-width: 300px;
-  }
+.meilisearch-autocomplete .dsb-suggestion:hover {
+  background-color: var(--ifm-dropdown-hover-background-color);
+  color: var(--ifm-dropdown-link-color);
+}
 
-  /* The texts are now in different lines (title, subcategory, text) */
-  .docs-searchbar-suggestion--wrapper {
-    display: block !important;
-  }
+/* Main category */
+.meilisearch-autocomplete .docs-searchbar-suggestion--category-header {
+  display: none;
+  font-size: var(--ifm-h2-font-size);
+  color: var(--ifm-heading-color);
+  font-family: var(--ifm-heading-font-family);
+  font-weight: var(--ifm-heading-font-weight);
+}
 
-  div[data-ds-theme='dark']
-    .meilisearch-autocomplete
-    .docs-searchbar-suggestion
-    .docs-searchbar-suggestion--subcategory-column:after {
-    display: none !important;
-  }
+/* Only show the first category */
+.meilisearch-autocomplete
+  .docs-searchbar-suggestion.docs-searchbar-suggestion__main
+  .docs-searchbar-suggestion--category-header {
+  display: block;
+}
 
-  .docs-searchbar-suggestion--subcategory-column-text {
-    text-decoration: underline;
-  }
+/* Category Column */
+.meilisearch-autocomplete .docs-searchbar-suggestion--subcategory-column {
+  display: none;
+}
+
+/* Category Inline */
+.meilisearch-autocomplete .docs-searchbar-suggestion--subcategory-inline {
+  font-size: var(--ifm-h4-font-size);
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-heading-font-family);
+  font-weight: var(--ifm-heading-font-weight);
+  margin-top: 0.5em;
+}
+
+/* Title */
+.meilisearch-autocomplete .docs-searchbar-suggestion--title {
+  /* font-weight: bold; */
+  font-size: var(--ifm-h5-font-size);
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-heading-font-family);
+  font-weight: var(--ifm-heading-font-weight);
+  margin-top: 0.5em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description */
+.meilisearch-autocomplete .docs-searchbar-suggestion--text {
+  font-style: italic;
+  color: var(--ifm-font-color-base);
+}
+
+/* Highlighted text */
+.meilisearch-autocomplete .docs-searchbar-suggestion--highlight {
+  background-color: var(--ifm-code-background);
+  border-radius: var(--ifm-code-border-radius);
+  padding: var(--ifm-code-padding-vertical) 0;
+}
+
+/* Footer */
+.meilisearch-autocomplete .docs-searchbar-footer {
+  padding: var(--ifm-card-vertical-spacing) var(--ifm-card-horizontal-spacing);
+  text-align: end;
 }
 
 /* Footer's height should be smaller to be the same as the 'powered by' text */
-.docs-searchbar-footer-logo {
+.meilisearch-autocomplete .docs-searchbar-footer-logo {
   height: 15px;
 }
 
-/* navigation sidebar and backdrop's z-index should be higher than the searchbar */
-.navbar-sidebar--show .navbar-sidebar {
-  z-index: 999;
-}
-
-.navbar-sidebar__backdrop {
-  z-index: 999;
+[data-theme='dark'] .meilisearch-autocomplete .docs-searchbar-footer-logo {
+  filter: invert();
 }


### PR DESCRIPTION
- Remove the search item from navbar (this doesn't stop it from being rendered, just moves it to the very end of the navbar)
- Switch to using built-in Docusaurus theming for the search bar input
  - This allows us to remove the `useColorMode` hook that was also causing a bit of flickering on first load or when changing colors
- Rebuild the search results CSS from the ground up
  - It should behave a lot better on mobile and at the very least we have a lot more precise control as we're no longer importing the vendor CSS from `docs-searchbar.js`
- Collapse trailing navbar text if screen size would cause wrapping

I want to tweak the CSS overtime on the search results, but I think the results we get back from the indexer need optimised first (the CSS isn't concatenating a lot of the values, they're concatenated when sent back from the indexer)

Before:
<img width="1287" alt="Screenshot 2022-09-11 at 21 45 44" src="https://user-images.githubusercontent.com/15347255/189548186-b15e98db-4f0d-490e-8588-59c16b24e358.png">

After:
<img width="1287" alt="Screenshot 2022-09-11 at 21 45 09" src="https://user-images.githubusercontent.com/15347255/189548179-e933ae54-6bb0-41ab-8521-e58fe5917fb0.png">
