### PR TITLE
chore(blog): simplify `cargo binstall` usage

### DIFF
--- a/blog/2022-09-15-tauri-1-1.mdx
+++ b/blog/2022-09-15-tauri-1-1.mdx
@@ -63,8 +63,7 @@ The Tauri CLI can now be installed using [cargo-binstall](https://github.com/car
 
 ```
 $ cargo install cargo-binstall
-# in the next release, `$ cargo binstall tauri-cli` will be enough
-$ cargo binstall tauri-cli --pkg-url "{ repo }/releases/download/cli.rs-v{ version }/cargo-tauri-{ target }.{ archive-format }"
+$ cargo binstall tauri-cli
 $ cargo tauri dev # run any Tauri command!
 ```
 


### PR DESCRIPTION
cli.rs v1.1.1 is out with the binstall metadata fix