### PR TITLE
Mention prevent close API in docs

### DIFF
--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -201,8 +201,8 @@ If your app should run in the backgorund, you can call `api.prevent_close()` lik
 ```rust
 tauri::Builder::default()
     .on_window_event(|event| if let tauri::RunEvent::ExitRequested { api, .. } => {
-    api.prevent_exit();
-  })
+      api.prevent_exit();
+    })
 ```
 
 [template image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc

--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -193,5 +193,18 @@ Note that you need to add `icon-ico` or `icon-png` feature flag to the tauri dep
 app.tray_handle().set_icon(tauri::Icon::Raw(include_bytes!("../path/to/myicon.ico").to_vec())).unwrap();
 ```
 
+### Keep app running in the background after closing all windows
+
+By default, tauri closes the application when the last window is closed.
+If your app should run in the backgorund, you can call `api.prevent_close()` like so:
+
+```rust
+tauri::Builder::default()
+    .on_window_event(|event| if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
+        event.window().hide().unwrap();
+        api.prevent_close();
+    })
+```
+
 [template image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc
 [libayatana-appindicator]: https://github.com/AyatanaIndicators/libayatana-appindicator

--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -200,9 +200,14 @@ If your app should run in the backgorund, you can call `api.prevent_close()` lik
 
 ```rust
 tauri::Builder::default()
-    .on_window_event(|event| if let tauri::RunEvent::ExitRequested { api, .. } => {
+  .build(tauri::generate_context!())
+  .expect("error while building tauri application")
+  .run(|_app_handle, event| match event {
+    tauri::RunEvent::ExitRequested { api, .. } => {
       api.prevent_exit();
-    })
+    }
+    _ => {}
+  });
 ```
 
 [template image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc

--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -200,9 +200,9 @@ If your app should run in the backgorund, you can call `api.prevent_close()` lik
 
 ```rust
 tauri::Builder::default()
-    .on_window_event(|event| if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
-        api.prevent_close();
-    })
+    .on_window_event(|event| if let tauri::RunEvent::ExitRequested { api, .. } => {
+    api.prevent_exit();
+  })
 ```
 
 [template image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc

--- a/docs/guides/features/system-tray.md
+++ b/docs/guides/features/system-tray.md
@@ -201,7 +201,6 @@ If your app should run in the backgorund, you can call `api.prevent_close()` lik
 ```rust
 tauri::Builder::default()
     .on_window_event(|event| if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
-        event.window().hide().unwrap();
         api.prevent_close();
     })
 ```


### PR DESCRIPTION
Adds a section to the `system-tray` feature page to describe how you can have an app that keeps running in the background.