### PR TITLE
Add optimization tip for "compression" feature

### DIFF
--- a/docs/guides/building/app-size.md
+++ b/docs/guides/building/app-size.md
@@ -177,6 +177,17 @@ We've seen smaller binary sizes from `"s"` for Tauri example applications, but r
 
 For a detailed explanation of each option and a bunch more, refer to the [Cargo books Profiles section][cargo profiles].
 
+#### Disable Tauri's Asset Compression
+
+By default, Tauri uses Brotli to compress assets in the final binary. Brotli embeds a large (~170KiB) lookup table to achieve great results, but if the resources you embed are smaller than this or compress poorly, the resulting binary may be bigger than any savings.
+
+Compression can be disabled by setting `default-features` to `false` and specifying everything except the `compression` feature:
+
+```toml
+[dependencies]
+tauri = { version = "...", features = ["objc-exception", "wry"], default-features = false }
+```
+
 #### Unstable Rust Compression Features
 
 :::caution


### PR DESCRIPTION
Until cargo allows us to selectively remove a default feature, this doc will unfortunately have to be kept up to date with whatever features get added to the `tauri` crate.

With every optimization in this document (and this new one), I got the svelte template app down to 1.3MiB. An extra ~150KiB can be saved by compiling for i686 instead of x86_64, but I don't think it's worth documenting.

Still a long way from the 600KiB on the homepage (UPX gets it to 500KiB but Windows AV raises a false positive), but acceptable for now!