### PR TITLE
chore(docs): remove the X-UA-Compatible meta

### DIFF
--- a/docs/guides/getting-started/setup/html-css-js.mdx
+++ b/docs/guides/getting-started/setup/html-css-js.mdx
@@ -38,7 +38,6 @@ Next, create an `index.html` file inside of that folder with the following conte
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
   </head>
@@ -103,7 +102,6 @@ You can now modify your `index.html` file to call your Command:
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
   </head>


### PR DESCRIPTION
We aren't targeting Internet Explorer, so it's safe to bury its legacy.