### PR TITLE
Fix announcement bar width, format html

### DIFF
--- a/docs/guides/testing/webdriver/example/setup.md
+++ b/docs/guides/testing/webdriver/example/setup.md
@@ -31,30 +31,30 @@ First, let's create our Tauri `distDir` that we know we will need once building 
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Hello Tauri!</title>
     <style>
-        body {
-            /* Add a nice colorscheme */
-            background-color: #222831;
-            color: #ececec;
+      body {
+        /* Add a nice colorscheme */
+        background-color: #222831;
+        color: #ececec;
 
-            /* Make the body the exact size of the window */
-            margin: 0;
-            height: 100vh;
-            width: 100vw;
+        /* Make the body the exact size of the window */
+        margin: 0;
+        height: 100vh;
+        width: 100vw;
 
-            /* Vertically and horizontally center children of the body tag */
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
+        /* Vertically and horizontally center children of the body tag */
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
     </style>
-</head>
-<body>
-<h1>Hello, Tauri!</h1>
-</body>
+  </head>
+  <body>
+    <h1>Hello, Tauri!</h1>
+  </body>
 </html>
 ```
 
@@ -146,9 +146,7 @@ here.
   "tauri": {
     "bundle": {
       "identifier": "studio.tauri.hello_tauri_webdriver",
-      "icon": [
-        "icon.png"
-      ]
+      "icon": ["icon.png"]
     },
     "allowlist": {
       "all": false
@@ -179,7 +177,7 @@ will also run our WebDriver tests with a release profile. Run `cargo run --relea
 see the following application pop up.
 
 <div style={{textAlign: 'center'}}>
-    <img src={HelloTauriWebdriver}/>
+  <img src={HelloTauriWebdriver}/>
 </div>
 
 _Note: If you are modifying the application and want to use the Devtools, then run it without `--release` and "Inspect

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -64,7 +64,7 @@
   min-height: 3rem;
 }
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 350px) {
   #announcement-link {
     display: block;
   }


### PR DESCRIPTION
# Before (Width: 500px)
![500](https://user-images.githubusercontent.com/78584173/197644098-facdc0cc-0804-48e8-8957-067d052c9969.png)

This is probably what the website looks like on 100% of all the phones out their.
Does not seem like there is any need for breaking in screen width 500px.

# After (Width is now set to 350px)
![350](https://user-images.githubusercontent.com/78584173/197644469-e1b173cd-f1d7-4aa9-934f-6adee8683f50.png)

# HTML is not properly formatted
![before](https://user-images.githubusercontent.com/78584173/197644764-26a3c0cb-1576-486e-8822-eb34e51e165c.png)

# After
![after](https://user-images.githubusercontent.com/78584173/197644777-49fc2164-72c5-4703-809a-8eb76d77b492.png)

