### PR TITLE
docs: add caching to cross-platform example workflow

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -105,6 +105,23 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+          
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+          shared-key: ${{ runner.os }}-release
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/yarn
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+          
       - name: Install app dependencies and build web
         run: yarn && yarn build
 

--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -111,15 +111,11 @@ jobs:
         with:
           workspaces: "./src-tauri -> target"
 
-      - name: Yarn cache
-        uses: actions/cache@v2
+      - name: Sync node version and setup cache
+        uses: actions/setup-node@v3
         with:
-          path: |
-            ~/.cache/yarn
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: 'lts/*'
+          cache: 'yarn' # Set this to npm, yarn or pnpm.
           
       - name: Install app dependencies and build web
         run: yarn && yarn build

--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -110,7 +110,6 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          shared-key: ${{ runner.os }}-release
 
       - name: Yarn cache
         uses: actions/cache@v2


### PR DESCRIPTION
Add caching to the default workflow.

This is a pretty standard step I'd say that many people (and machines) would benefit from.

Before:
![image](https://user-images.githubusercontent.com/20756439/198698817-acc5d890-02dd-4380-9f52-dc47d66ff2c0.png)

After (from second run after implementing it)
![image](https://user-images.githubusercontent.com/20756439/198698710-9123257d-a510-4b78-898d-04ceffd6c8ba.png)

See it in action: https://github.com/webbertakken/map-editor-2d/pull/17

Changes are reflected here: https://deploy-preview-954--tauri.netlify.app/v1/guides/building/cross-platform#example-workflow