### PR TITLE
Update blog, include election results

### DIFF
--- a/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
+++ b/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
@@ -30,7 +30,7 @@ We'll be back soon with an update.
 
 The results are in, so here is the reveal!
 
-The existing Directors applied for another term and there were no additional applicants. Meaning no vote was necessary to select between candidates. For the Chair position Daniel ran as only candidate.
+The existing Directors applied for another term and there were no additional applicants. Meaning no vote was necessary to select between candidates. For the Chair position Daniel ran as the only candidate.
 
 The Tauri Board then voted unanimously in favor of the following:
 

--- a/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
+++ b/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
@@ -5,7 +5,7 @@ description: The one year anniversary for Tauri becoming a programme within The 
 
 # Tauri Programme Turns 1 and Board Elections
 
-The one year anniversary for Tauri becoming a programme within [The Commons Conservancy][tcc-home] is upcoming on the 16th of July! On that anniversary, two of our Directors on the Tauri Board will be at the end of their first half-term. The Board will hold an election on the 15th of July to decide the Directors for the next two year term.
+The one year anniversary for Tauri becoming a programme within [The Commons Conservancy](https://commonsconservancy.org/) is upcoming on the 16th of July! On that anniversary, two of our Directors on the Tauri Board will be at the end of their first half-term. The Board will hold an election on the 15th of July to decide the Directors for the next two year term.
 
 <!--truncate-->
 
@@ -22,9 +22,6 @@ If you're still with me, then here are some additional details:
 - The Directors running for office again will have _**half a vote**_ deducted from votes in their favor (one for each consecutive term served).
 - _**After voting on July 15th**_ we'll share the results.
 
-All this is governed by our [statutes and core regulations][statutes-dracc] if you're interested in seeing the fine print.
+All this is governed by our [statutes and core regulations](https://dracc.commonsconservancy.org/0035/) if you're interested in seeing the fine print.
 
 We'll be back soon with an update.
-
-[tcc-home]: https://commonsconservancy.org/ 'The Commons Conservancy'
-[statutes-dracc]: https://dracc.commonsconservancy.org/0035/ 'Statutes of Tauri'

--- a/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
+++ b/blog/2022-07-12-tauri-programme-turns-1-and-board-elections.mdx
@@ -25,3 +25,16 @@ If you're still with me, then here are some additional details:
 All this is governed by our [statutes and core regulations](https://dracc.commonsconservancy.org/0035/) if you're interested in seeing the fine print.
 
 We'll be back soon with an update.
+
+### Update: Election results
+
+The results are in, so here is the reveal!
+
+The existing Directors applied for another term and there were no additional applicants. Meaning no vote was necessary to select between candidates. For the Chair position Daniel ran as only candidate.
+
+The Tauri Board then voted unanimously in favor of the following:
+
+1. The Board appoints Daniel and Lucas for an additional full term (2 years) as Board Directors, starting the 16th of July.
+2. The Board appoints Daniel as Chairperson for the next term (1 year), starting the 16th of July.
+
+Another election will be held around the same time July next year, now with extra time to apply and for the Board to vote. We'll announce the specifics in due time.


### PR DESCRIPTION
- fix: Inline blogpost links
This solves an issue where the truncate feature would break links.
- Update blog, include election results