### PR TITLE
More idiomatic NixOS setup

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -172,9 +172,9 @@ When using [Nix Flakes], copy the following code into `flake.nix` on your reposi
           gtk3
           cairo
           gdk-pixbuf
-          glib.out
-          dbus.lib
-          openssl_3.out
+          glib
+          dbus
+          openssl_3
         ];
 
         packages = with pkgs; [
@@ -194,12 +194,8 @@ When using [Nix Flakes], copy the following code into `flake.nix` on your reposi
           buildInputs = packages;
 
           shellHook =
-            let
-              joinLibs = libs: builtins.concatStringsSep ":" (builtins.map (x: "${x}/lib") libs);
-              libs = joinLibs libraries;
-            in
             ''
-              export LD_LIBRARY_PATH=${libs}:$LD_LIBRARY_PATH
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
             '';
         };
       });
@@ -217,9 +213,9 @@ let
     gtk3
     cairo
     gdk-pixbuf
-    glib.out
-    dbus.lib
-    openssl_3.out
+    glib
+    dbus
+    openssl_3
   ];
 
   packages = with pkgs; [
@@ -237,12 +233,8 @@ pkgs.mkShell {
   buildInputs = packages;
 
   shellHook =
-    let
-      joinLibs = libs: builtins.concatStringsSep ":" (builtins.map (x: "${x}/lib") libs);
-      libs = joinLibs libraries;
-    in
     ''
-      export LD_LIBRARY_PATH=${libs}:$LD_LIBRARY_PATH
+      export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
     '';
 }
 ```


### PR DESCRIPTION
This is a simple change that removes the hand-rolled function in favor of just using [lib.makeLibraryPath](https://github.com/NixOS/nixpkgs/blob/6949cecbd6b3b9e78ae91b8b97dc001075378abc/lib/strings.nix#L177), which accomplishes the same thing.