### PR TITLE
Updated Crowdin config to include more Guides pages

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -13,12 +13,5 @@ files:
       [
         /docs/.templates,
         /docs/api,
-        /docs/guides/architecture/recipes,
-        /docs/guides/development,
-        /docs/guides/debugging,
-        /docs/guides/testing,
-        /docs/guides/building,
-        /docs/guides/distribution,
-        /docs/guides/features,
-        /docs/guides/faq.md,
+        /docs/guides/distribution/updater,
       ]

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -13,5 +13,5 @@ files:
       [
         /docs/.templates,
         /docs/api,
-        /docs/guides/distribution/updater,
+        /docs/guides/distribution/updater.md,
       ]


### PR DESCRIPTION
Removed ignore configuration for re-written guide pages that are ready to be translated.