### PR TITLE
Feat/i18n banner

### DIFF
--- a/src/theme/Navbar/Layout/index.js
+++ b/src/theme/Navbar/Layout/index.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import Layout from '@theme-original/Navbar/Layout'
+import styles from './styles.module.css'
+import classNames from 'classnames'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import IconLanguage from '@theme/Icon/Language'
+
+export default function LayoutWrapper(props) {
+  const { siteConfig, i18n } = useDocusaurusContext()
+  return (
+    <>
+      <Layout {...props} />
+      {i18n.currentLocale != siteConfig.i18n.defaultLocale && (
+        <div
+          className={classNames('alert alert--info', styles.alert)}
+          role="alert"
+        >
+          {/* Note: This is purposefully not translated so that we can keep the official wording */}
+          <IconLanguage className={classNames(styles.iconLanguage)} />
+          You're visiting the {
+            i18n.localeConfigs[i18n.currentLocale].label
+          }{' '}
+          version of the site translated by the community. This content is not
+          reviewed and is not guaranteed to be accurate nor up-to-date.
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/theme/Navbar/Layout/styles.module.css
+++ b/src/theme/Navbar/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.alert {
+  z-index: 100;
+  text-align: center;
+  /* display: display-b; */
+}
+
+.iconLanguage {
+  vertical-align: text-bottom;
+  margin-right: 5px;
+}

--- a/src/theme/Navbar/Layout/styles.module.css
+++ b/src/theme/Navbar/Layout/styles.module.css
@@ -1,7 +1,6 @@
 .alert {
   z-index: 100;
   text-align: center;
-  /* display: display-b; */
 }
 
 .iconLanguage {


### PR DESCRIPTION
This adds a banner across the top of all non-English pages noting that translations are from the community. 

<img width="1624" alt="Screenshot 2022-12-03 at 21 38 32" src="https://user-images.githubusercontent.com/15347255/205463176-fe4ada54-18cd-4c2f-bcc4-9f9b43ab5d0c.png">
