### PR TITLE
Remove swcMinify default config

### DIFF
--- a/docs/mobile/development/configuration.mdx
+++ b/docs/mobile/development/configuration.mdx
@@ -86,7 +86,6 @@ module.exports = async (phase, { defaultConfig }) => {
    */
   const nextConfig = {
     reactStrictMode: true,
-    swcMinify: true,
     // Note: This experimental feature is required to use NextJS Image in SSG mode.
     // See https://nextjs.org/docs/messages/export-image-api for different workarounds.
     images: {


### PR DESCRIPTION
Hi there, thanks for Tauri, looking really cool! 🙌

A quick PR to remove the `swcMinify: true` config, since this is now default - Next.js 13 enabled `swcMinify` by default:

- https://nextjs.org/docs/advanced-features/compiler#:~:text=v13.0.0,enabled%20by%20default.
- https://nextjs.org/blog/next-13#:~:text=The%20swcMinify%20configuration%20property%20was%20changed%20from%20false%20to%20true.