### PR TITLE
Update sveltekit output directory

### DIFF
--- a/docs/guides/getting-started/setup/sveltekit.mdx
+++ b/docs/guides/getting-started/setup/sveltekit.mdx
@@ -138,7 +138,7 @@ Furthermore, if you prefer a Single-Page Application (SPA) mode over SSG, you ca
 
 <TauriInit
   destDirExplination={{
-    __html: 'Use <code>../build</code> for this value.',
+    __html: 'Use <code>../.svelte-kit</code> for this value.',
   }}
   devPathExplination={{
     __html: 'Use <code>http://localhost:5173</code> for this value.',
@@ -163,7 +163,7 @@ Now that we have scaffolded our frontend and initialized the Rust project the cr
     // This command will execute when you run `tauri dev`
     "beforeDevCommand": "npm run dev",
     "devPath": "http://localhost:5173",
-    "distDir": "../build"
+    "distDir": "../.svelte-kit"
   },
 ```
 


### PR DESCRIPTION
The sveltekit output directory that needs to be configured when using `pnpm tauri init` is not `../build`. It is instead `../svelte-kit`. You can also check it here in the sveltekit [documentation](https://kit.svelte.dev/docs/project-structure#other-files).

Thank you guys for the awasome work with tauri !