### PR TITLE
Add extra prerequisite in order to develop under windows

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -58,6 +58,7 @@ rustup default stable-msvc
 ```
 
 :::
+
 ### Setting Up macOS
 
 #### 1. CLang and macOS Development Dependencies
@@ -314,7 +315,8 @@ If you don't see this information, your Rust installation might be broken. Pleas
 [github discussions]: https://github.com/tauri-apps/tauri/discussions
 [download webview2]: https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section
 [rustup.sh]: https://sh.rustup.rs
-[Nix Flakes]: https://nixos.wiki/wiki/Flakes
-[direnv's Flakes integration]: https://nixos.wiki/wiki/Flakes#Direnv_integration
-[Nix Shell]: https://nixos.wiki/wiki/Development_environment_with_nix-shell
-[direnv's Shell integration]: https://nixos.wiki/wiki/Development_environment_with_nix-shell#direnv
+[nix flakes]: https://nixos.wiki/wiki/Flakes
+[direnv's flakes integration]: https://nixos.wiki/wiki/Flakes#Direnv_integration
+[nix shell]: https://nixos.wiki/wiki/Development_environment_with_nix-shell
+[direnv's shell integration]: https://nixos.wiki/wiki/Development_environment_with_nix-shell#direnv
+[`trunk`]: https://trunkrs.dev

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -49,7 +49,17 @@ winget install --id Rustlang.Rustup
 
 #### 3. MSVC toolchain as default
 
-In order to be able to install tools like `tauri-cli` and `trunk` you need to make sure that the proper toolchain is set as default:
+In order to be able to install tools like `tauri-cli` and `trunk` you need to make sure that the proper toolchain is set as default.
+
+To display the current configured default toolchain please run the following command:
+
+```powershell
+rustup default
+```
+
+The command should return either `i686-pc-windows-msvc`, `x86_64-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
+
+If the command returns a different toolchain, please configure the default toolchain in the following way: 
 
 ```powershell
 rustup default stable-msvc

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -49,7 +49,7 @@ winget install --id Rustlang.Rustup
 
 :::caution MSVC toolchain as default
 
-For full support for Tauri and tools like [`trunk`] make sure the MSVC Rust toolchain is the selected `default host triple` in the installer dialog.<br/>Depending on your system it should be either `x86_64-pc-windows-msvc`, `i686-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
+For full support for Tauri and tools like [`trunk`] make sure the MSVC Rust toolchain is the selected `default host triple` in the installer dialog. Depending on your system it should be either `x86_64-pc-windows-msvc`, `i686-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
 
 If you already had Rust installed, you can make sure the correct toolchain is installed by running this command:
 

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -51,7 +51,7 @@ winget install --id Rustlang.Rustup
 
 For full support for Tauri and tools like [`trunk`] make sure the MSVC Rust toolchain is the selected `default host triple` in the installer dialog. Depending on your system it should be either `x86_64-pc-windows-msvc`, `i686-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
 
-If you already had Rust installed, you can make sure the correct toolchain is installed by running this command:
+If you already have Rust installed, you can make sure the correct toolchain is installed by running this command:
 
 ```powershell
 rustup default stable-msvc

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -47,24 +47,17 @@ Alternatively, you could use `winget` to install rustup using the following comm
 winget install --id Rustlang.Rustup
 ```
 
-#### 3. MSVC toolchain as default
+:::caution MSVC toolchain as default
 
-In order to be able to install tools like `tauri-cli` and `trunk` you need to make sure that the proper toolchain is set as default.
+For full support for Tauri and tools like [`trunk`] make sure the MSVC Rust toolchain is the selected `default host triple` in the installer dialog.<br/>Depending on your system it should be either `x86_64-pc-windows-msvc`, `i686-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
 
-To display the current configured default toolchain please run the following command:
-
-```powershell
-rustup default
-```
-
-The command should return either `i686-pc-windows-msvc`, `x86_64-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
-
-If the command returns a different toolchain, please configure the default toolchain in the following way: 
+If you already had Rust installed, you can make sure the correct toolchain is installed by running this command:
 
 ```powershell
 rustup default stable-msvc
 ```
 
+:::
 ### Setting Up macOS
 
 #### 1. CLang and macOS Development Dependencies

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -47,6 +47,14 @@ Alternatively, you could use `winget` to install rustup using the following comm
 winget install --id Rustlang.Rustup
 ```
 
+#### 3. MSVC toolchain as default
+
+In order to be able to install tools like `tauri-cli` and `trunk` you need to make sure that the proper toolchain is set as default:
+
+```powershell
+rustup default stable-msvc
+```
+
 ### Setting Up macOS
 
 #### 1. CLang and macOS Development Dependencies


### PR DESCRIPTION
I'm a newbie on Tauri development. And I was trying to get started, but got stuck. I used the powershell method. 

The default toolchain I had configured (gnu) is not compatible with the getting started guide. However it is [assumed that the msvc toolchain is set as default](https://github.com/tauri-apps/tauri/issues/3953#issuecomment-1107807436). When I did configure the msvc toolchain, the problems were resolved. 

Maybe it also needs to be added in the powershell script. Where it is mentioned that it is important to install `tauri-cli` and `trunk`.