### PR TITLE
docs 2.0: prototype for tabs via rehpye

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,58 +2,8 @@ import { defineConfig } from 'astro/config'
 import prefetch from '@astrojs/prefetch'
 import tailwind from '@astrojs/tailwind'
 import sitemap from '@astrojs/sitemap'
-import { visit } from 'unist-util-visit'
-import { h } from 'hastscript'
-import rehypeRaw from 'rehype-raw'
+import { rehypeTabPlugins } from './src/rehype-tabs/plugins'
 
-const TAB_GROUP_BEGINNING = /^- begin-tab-group -$/
-const TAB_GROUP_ENDING = /^- end-tab-group -$/
-const TAB_REGEX = /^- tab-title=(.+?) -$/
-function isTabGroupBeginning(node) {
-  return node.type === 'comment' && TAB_GROUP_BEGINNING.test(node.value)
-}
-function isTabGroupEnding(node) {
-  return node.type === 'comment' && TAB_GROUP_ENDING.test(node.value)
-}
-function isTab(node) {
-  return node.type === 'comment' && TAB_REGEX.test(node.value)
-}
-function getTabTitle(node) {
-  return node.value.match(TAB_REGEX)?.[1]
-}
-
-function createHastTab(tabInfo, suffix) {
-  return h(
-    'button',
-    {
-      id: createTabId(tabInfo, suffix),
-      role: 'tab',
-      'aria-selected': 'false',
-      'aria-controls': createTabPanelId(tabInfo, suffix),
-      tabindex: -1,
-    },
-    [tabInfo.title]
-  )
-}
-function createHastTabPanel(tabInfo, suffix) {
-  return h(
-    'div',
-    {
-      id: tabInfo.title + '-' + 'panel' + '-' + suffix,
-      role: 'tabpanel',
-      'aria-labelledby': tabInfo.title + '-' + 'tab' + '-' + suffix,
-    },
-    tabInfo.contents
-  )
-}
-function createTabId(tabInfo, suffix) {
-  return `${tabInfo.title}-tab-${suffix}`
-}
-function createTabPanelId(tabInfo, suffix) {
-  return `${tabInfo.title}-panel-${suffix}`
-}
-
-let ctr = 0
 // https://astro.build/config
 export default defineConfig({
   site: 'https://tauri.app',
@@ -64,84 +14,7 @@ export default defineConfig({
   markdown: {
     extendDefaultPlugins: true,
     rehypePlugins: [
-      // rehype-raw parses the tree again to ensure that comments are recognized as such - otherwise they're raw nodes
-      // raw nodes may contain some text content that's not part of a comment but content that should be displayed
-      // using rehype-raw solves this partially, but a comment directly preceded with text still isn't recognized
-      // so word<!--- begin-tab-group ---> will not be recognized as a comment but instead as plain text
-      rehypeRaw,
-      function rehypeComponents() {
-        return (tree) => {
-          visit(tree, (maybeStartNode, maybeStartIndex, parent) => {
-            if (isTabGroupBeginning(maybeStartNode)) {
-              let tabs = []
-              let startIndex = maybeStartIndex
-              let endIndex = -1
-              let suffix = ctr++
-
-              let tabTitle = null
-              let contents = []
-              for (let i = startIndex + 1; i < parent.children.length; i++) {
-                let node = parent.children[i]
-                if (isTab(node)) {
-                  if (tabTitle) {
-                    tabs.push({
-                      title: tabTitle,
-                      contents,
-                    })
-                  }
-                  tabTitle = getTabTitle(node)
-                  contents = []
-                } else if (isTabGroupEnding(node)) {
-                  tabs.push({
-                    title: tabTitle,
-                    contents,
-                  })
-                  endIndex = i
-                  break
-                } else if (isTabGroupBeginning(node)) {
-                  throw new Error('Unclosed tab group detected')
-                } else {
-                  contents.push(node)
-                }
-              }
-
-              if (endIndex === -1) {
-                throw new Error('Unclosed tab group detected')
-              }
-
-              parent.children.splice(
-                startIndex,
-                endIndex - startIndex + 1,
-                h(
-                  'div',
-                  {
-                    class: 'tab-container',
-                  },
-                  [
-                    h(
-                      'div',
-                      {
-                        role: 'tablist',
-                        'data-docs-tablist': true,
-                      },
-                      tabs.map((t) => createHastTab(t, suffix))
-                    ),
-                    h(
-                      'div',
-                      {
-                        class: 'spacer',
-                      },
-                      tabs.map((t) => createHastTabPanel(t, suffix))
-                    ),
-                  ]
-                )
-              )
-            }
-          })
-
-          return undefined
-        }
-      },
+      ...rehypeTabPlugins()
     ],
   },
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,61 @@ import { defineConfig } from 'astro/config'
 import prefetch from '@astrojs/prefetch'
 import tailwind from '@astrojs/tailwind'
 import sitemap from '@astrojs/sitemap'
+import { findAfter } from 'unist-util-find-after'
+import { visit } from 'unist-util-visit'
+import findAllBetween from 'unist-util-find-all-between'
+import replaceAllBetween from 'unist-util-replace-all-between'
+import { h } from 'hastscript'
+import rehypeRaw from 'rehype-raw'
 
+const TAB_GROUP_BEGINNING = /^- begin-tab-group -$/
+const TAB_GROUP_ENDING = /^- end-tab-group -$/
+const TAB_REGEX = /^- tab-title=(.+?) -$/
+function isTabGroupBeginning(node) {
+  return node.type === "comment" && TAB_GROUP_BEGINNING.test(node.value)
+}
+function isTabGroupEnding(node) {
+  return node.type === "comment" && TAB_GROUP_ENDING.test(node.value)
+}
+function isTab(node) {
+  return node.type === "comment" && TAB_REGEX.test(node.value)
+}
+function getTabTitle(node) {
+  return node.value.match(TAB_REGEX)?.[1]
+}
+
+function createHastTab(tabInfo, suffix) {
+  return h(
+    'button',
+    {
+      id: createTabId(tabInfo, suffix),
+      role: 'tab',
+      'aria-selected': 'false',
+      'aria-controls': createTabPanelId(tabInfo, suffix),
+      tabindex: -1,
+    },
+    [tabInfo.title]
+  )
+}
+function createHastTabPanel(tabInfo, suffix) {
+  return h(
+    'div',
+    {
+      id: tabInfo.title + '-' + 'panel' + '-' + suffix,
+      role: 'tabpanel',
+      'aria-labelledby': tabInfo.title + '-' + 'tab' + '-' + suffix,
+    },
+    tabInfo.contents
+  )
+}
+function createTabId(tabInfo, suffix) {
+  return `${tabInfo.title}-tab-${suffix}`
+}
+function createTabPanelId(tabInfo, suffix) {
+  return `${tabInfo.title}-panel-${suffix}`
+}
+
+let ctr = 0
 // https://astro.build/config
 export default defineConfig({
   site: 'https://tauri.app',
@@ -10,4 +64,84 @@ export default defineConfig({
     contentCollections: true,
   },
   integrations: [prefetch(), tailwind(), sitemap()],
+  markdown: {
+    extendDefaultPlugins: true,
+    rehypePlugins: [
+      // rehype-raw parses the tree again to ensure that comments are recognized as such - otherwise they're raw nodes
+      // raw nodes may contain some text content that's not part of a comment but content that should be displayed
+      // using rehype-raw solves this partially, but a comment directly preceded with text still isn't recognized
+      // so word<!--- begin-tab-group ---> will not be recognized as a comment but instead as plain text
+      rehypeRaw,
+      function rehypeComponents() {
+        return (tree) => {
+          let tab_beginnings = []
+          visit(tree, (node, _, parent) => {
+            if (isTabGroupBeginning(node)) {
+              tab_beginnings.push({
+                node,
+                parent,
+              })
+            }
+          })
+
+          for (let { node, parent } of tab_beginnings) {
+            let tabs = []
+            let start = node
+            let end = null
+            let suffix = ctr++
+
+            let searchFrom = start
+            do {
+              let nextNode = findAfter(parent, searchFrom, (node) => {
+                return isTab(node) || isTabGroupEnding(node)
+              })
+              let tabTitle = getTabTitle(searchFrom)
+              if (tabTitle) {
+                tabs.push({
+                  title: tabTitle,
+                  contents: findAllBetween(parent, searchFrom, nextNode),
+                })
+              }
+
+              if (isTabGroupEnding(nextNode)) {
+                end = nextNode
+                break
+              } else {
+                searchFrom = nextNode
+              }
+            } while (searchFrom && searchFrom.value?.match(TAB_REGEX))
+
+            replaceAllBetween(parent, start, end, () => [
+              h(
+                'div',
+                {
+                  class: 'tab-container',
+                },
+                [
+                  h(
+                    'div',
+                    {
+                      role: 'tablist',
+                      'data-docs-tablist': true
+                    },
+                    tabs.map((t, i) => createHastTab(t, suffix))
+                  ),
+                  h(
+                    'div',
+                    {
+                      class: 'spacer',
+                    },
+                    tabs.map((t) => createHastTabPanel(t, suffix))
+                  ),
+                ]
+              ),
+            ])
+          }
+
+          return undefined
+        }
+      },
+      // rehypeStringify,
+    ],
+  },
 })

--- a/package.json
+++ b/package.json
@@ -39,5 +39,13 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "hastscript": "^7.2.0",
+    "rehype-raw": "^6.1.1",
+    "unist-util-find-after": "^4.0.0",
+    "unist-util-find-all-between": "^2.1.0",
+    "unist-util-replace-all-between": "^0.1.1",
+    "unist-util-visit": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
   "devDependencies": {
     "hastscript": "^7.2.0",
     "rehype-raw": "^6.1.1",
-    "unist-util-find-after": "^4.0.0",
-    "unist-util-find-all-between": "^2.1.0",
-    "unist-util-replace-all-between": "^0.1.1",
     "unist-util-visit": "^4.1.1"
   }
 }

--- a/src/content/api-core-js-1/fs.md
+++ b/src/content/api-core-js-1/fs.md
@@ -28,6 +28,54 @@ The APIs must be added to [`tauri.allowlist.fs`](https://tauri.app/v1/api/config
 It is recommended to allowlist only the APIs you use for optimal bundle size and security.
 
 ## Security
+<!--- begin-tab-group --->
+<!--- tab-title=npm --->
+```shell
+npm install --save-dev @tauri-apps/cli
+```
+
+<!--- tab-title=yarn --->
+```shell
+yarn add -D @tauri-apps/cli
+```
+
+<!--- tab-title=pnpm --->
+```shell
+pnpm add -D @tauri-apps/cli
+```
+
+<!--- tab-title=Cargo --->
+```shell
+cargo install tauri-cli
+```
+
+<!--- end-tab-group --->
+
+
+
+
+<!--- begin-tab-group --->
+<!--- tab-title=npm --->
+```shell
+npm install --save-dev @tauri-apps/cli
+```
+
+<!--- tab-title=yarn --->
+```shell
+yarn add -D @tauri-apps/cli
+```
+
+<!--- tab-title=pnpm --->
+```shell
+pnpm add -D @tauri-apps/cli
+```
+
+<!--- tab-title=Cargo --->
+```shell
+cargo install tauri-cli
+```
+
+<!--- end-tab-group --->
 
 This module prevents path traversal, not allowing absolute paths or parent dir components
 (i.e. "/usr/path/to/file" or "../path/to/file" paths are not allowed).

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,6 +38,103 @@ const { title } = Astro.props
     <meta name="theme-color" content="#2f2f2f" />
     <meta name="generator" content={Astro.generator} />
     <title>{`${title} | Tauri.app`}</title>
+    <script>
+      function initTabs(tabList: HTMLElement){
+        let tabs: HTMLElement[] = Array.from(tabList.querySelectorAll("[role=tab]"));
+        let selectTab = (selected: HTMLElement) => {
+          for (let tab of tabs) {
+            let panel = document.getElementById(tab.getAttribute("aria-controls")!)!;
+            if (tab === selected) {
+              tab.setAttribute('aria-selected', 'true');
+              tab.removeAttribute('tabindex');
+              panel.removeAttribute('hidden')
+            } else {
+              tab.setAttribute('aria-selected', 'false');
+              tab.tabIndex = -1;
+              panel.hidden = true;
+            }
+          }
+        };
+
+        
+        let onKeydown = (event: KeyboardEvent) => {
+          let tab = event.currentTarget as HTMLElement;
+          let index = Number(tab.dataset.index);
+          let next_index: number | undefined = undefined;
+      
+          switch (event.key) {
+            case 'ArrowLeft':
+              next_index = index - 1 < 0 ? tabs.length - 1 : index - 1;
+              break;
+            case 'ArrowRight':
+              next_index = index + 1 > tabs.length - 1 ? 0 : index + 1;
+              break;
+            case 'Home':
+              next_index = 0;
+              break;
+            case 'End':
+              next_index = tabs.length - 1;
+              break;
+            default:
+              break;
+          }
+      
+          if (next_index !== undefined) {
+            tabs[next_index].focus();
+            event.stopPropagation();
+            event.preventDefault();
+          }
+        }
+    
+
+        let firstTab: HTMLElement | undefined = undefined;
+        for (let index in tabs) {
+          let tab = tabs[index];
+          if (!firstTab) {
+            firstTab = tab;
+          }
+
+          tab.tabIndex = -1;
+          tab.setAttribute('aria-selected', 'false');
+          tab.setAttribute("data-index", index);
+
+          // TODO: implement roving tabindex that handles keyboard focus change properly
+          tab.addEventListener('keydown', onKeydown);
+          tab.addEventListener('click', (event: MouseEvent) => {
+            selectTab(event.currentTarget as HTMLElement);
+          });
+        }
+
+        selectTab(firstTab!);
+      }
+
+      for (let tabList of document.querySelectorAll('[role=tablist][data-docs-tablist]')) {
+        initTabs(tabList as HTMLElement);
+      }
+    </script>
+    <style is:global>
+      .tab-container {
+        width: max-content;
+      }
+      [role=tab] {
+        border-bottom: 3px solid transparent;
+        border-radius: 0.4rem;
+        cursor: pointer;
+        display: inline-flex;
+        padding: 1rem;
+      }
+
+      [role=tab][aria-selected=true] {
+        border-bottom-color: #67d6ed;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        color: #67d6ed;
+      }
+
+      .spacer {
+        margin-top: 1rem;
+      }
+    </style>
   </head>
   <body>
     <NavBar />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import NavBar from '../components/Layout/NavBar.astro'
 import '../styles/global.css'
+import '../styles/tabs.css'
 
 export interface Props {
   title: string
@@ -38,103 +39,7 @@ const { title } = Astro.props
     <meta name="theme-color" content="#2f2f2f" />
     <meta name="generator" content={Astro.generator} />
     <title>{`${title} | Tauri.app`}</title>
-    <script>
-      function initTabs(tabList: HTMLElement){
-        let tabs: HTMLElement[] = Array.from(tabList.querySelectorAll("[role=tab]"));
-        let selectTab = (selected: HTMLElement) => {
-          for (let tab of tabs) {
-            let panel = document.getElementById(tab.getAttribute("aria-controls")!)!;
-            if (tab === selected) {
-              tab.setAttribute('aria-selected', 'true');
-              tab.removeAttribute('tabindex');
-              panel.removeAttribute('hidden')
-            } else {
-              tab.setAttribute('aria-selected', 'false');
-              tab.tabIndex = -1;
-              panel.hidden = true;
-            }
-          }
-        };
-
-        
-        let onKeydown = (event: KeyboardEvent) => {
-          let tab = event.currentTarget as HTMLElement;
-          let index = Number(tab.dataset.index);
-          let next_index: number | undefined = undefined;
-      
-          switch (event.key) {
-            case 'ArrowLeft':
-              next_index = index - 1 < 0 ? tabs.length - 1 : index - 1;
-              break;
-            case 'ArrowRight':
-              next_index = index + 1 > tabs.length - 1 ? 0 : index + 1;
-              break;
-            case 'Home':
-              next_index = 0;
-              break;
-            case 'End':
-              next_index = tabs.length - 1;
-              break;
-            default:
-              break;
-          }
-      
-          if (next_index !== undefined) {
-            tabs[next_index].focus();
-            event.stopPropagation();
-            event.preventDefault();
-          }
-        }
-    
-
-        let firstTab: HTMLElement | undefined = undefined;
-        for (let index in tabs) {
-          let tab = tabs[index];
-          if (!firstTab) {
-            firstTab = tab;
-          }
-
-          tab.tabIndex = -1;
-          tab.setAttribute('aria-selected', 'false');
-          tab.setAttribute("data-index", index);
-
-          // TODO: implement roving tabindex that handles keyboard focus change properly
-          tab.addEventListener('keydown', onKeydown);
-          tab.addEventListener('click', (event: MouseEvent) => {
-            selectTab(event.currentTarget as HTMLElement);
-          });
-        }
-
-        selectTab(firstTab!);
-      }
-
-      for (let tabList of document.querySelectorAll('[role=tablist][data-docs-tablist]')) {
-        initTabs(tabList as HTMLElement);
-      }
-    </script>
-    <style is:global>
-      .tab-container {
-        width: max-content;
-      }
-      [role=tab] {
-        border-bottom: 3px solid transparent;
-        border-radius: 0.4rem;
-        cursor: pointer;
-        display: inline-flex;
-        padding: 1rem;
-      }
-
-      [role=tab][aria-selected=true] {
-        border-bottom-color: #67d6ed;
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        color: #67d6ed;
-      }
-
-      .spacer {
-        margin-top: 1rem;
-      }
-    </style>
+    <script src="../rehype-tabs/initializeTabs.ts"></script>
   </head>
   <body>
     <NavBar />

--- a/src/rehype-tabs/initializeTabs.ts
+++ b/src/rehype-tabs/initializeTabs.ts
@@ -1,0 +1,75 @@
+function initTabs(tabList: HTMLElement) {
+  let tabs: HTMLElement[] = Array.from(tabList.querySelectorAll('[role=tab]'))
+  let selectTab = (selected: HTMLElement) => {
+    for (let tab of tabs) {
+      let panel = document.getElementById(tab.getAttribute('aria-controls')!)!
+      if (tab === selected) {
+        tab.setAttribute('aria-selected', 'true')
+        tab.removeAttribute('tabindex')
+        panel.removeAttribute('hidden')
+      } else {
+        tab.setAttribute('aria-selected', 'false')
+        tab.tabIndex = -1
+        panel.hidden = true
+      }
+    }
+  }
+
+  let onKeydown = (event: KeyboardEvent) => {
+    let tab = event.currentTarget as HTMLElement
+    let index = Number(tab.dataset.index)
+    let next_index: number | undefined = undefined
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        next_index = index - 1 < 0 ? tabs.length - 1 : index - 1
+        break
+      case 'ArrowRight':
+        next_index = index + 1 > tabs.length - 1 ? 0 : index + 1
+        break
+      case 'Home':
+        next_index = 0
+        break
+      case 'End':
+        next_index = tabs.length - 1
+        break
+      default:
+        break
+    }
+
+    if (next_index !== undefined) {
+      tabs[next_index].focus()
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
+  let firstTab: HTMLElement | undefined = undefined
+  for (let index in tabs) {
+    let tab = tabs[index]
+    if (!firstTab) {
+      firstTab = tab
+    }
+
+    tab.tabIndex = -1
+    tab.setAttribute('aria-selected', 'false')
+    tab.setAttribute('data-index', index)
+
+    // TODO: implement roving tabindex that handles keyboard focus change properly
+    tab.addEventListener('keydown', onKeydown)
+    tab.addEventListener('click', (event: MouseEvent) => {
+      selectTab(event.currentTarget as HTMLElement)
+    })
+  }
+
+  selectTab(firstTab!)
+}
+
+for (let tabList of document.querySelectorAll(
+  '[role=tablist][data-docs-tablist]'
+)) {
+  initTabs(tabList as HTMLElement)
+}
+
+// Without this Typescript complains about not being able to compile this under --isolatedModules
+export {};

--- a/src/rehype-tabs/plugins.js
+++ b/src/rehype-tabs/plugins.js
@@ -53,6 +53,9 @@ let ctr = 0
 function rehypeTabs() {
   return (tree) => {
     visit(tree, (maybeStartNode, maybeStartIndex, parent) => {
+      if (isTabGroupEnding(maybeStartNode) || isTab(maybeStartNode)) {
+        throw new Error('Tab group missing opening')
+      }
       if (isTabGroupBeginning(maybeStartNode)) {
         let tabs = []
         let startIndex = maybeStartIndex

--- a/src/rehype-tabs/plugins.js
+++ b/src/rehype-tabs/plugins.js
@@ -1,0 +1,136 @@
+import { visit } from 'unist-util-visit'
+import { h } from 'hastscript'
+import rehypeRaw from 'rehype-raw'
+
+const TAB_GROUP_BEGINNING = /^- begin-tab-group -$/
+const TAB_GROUP_ENDING = /^- end-tab-group -$/
+const TAB_REGEX = /^- tab-title=(.+?) -$/
+function isTabGroupBeginning(node) {
+  return node.type === 'comment' && TAB_GROUP_BEGINNING.test(node.value)
+}
+function isTabGroupEnding(node) {
+  return node.type === 'comment' && TAB_GROUP_ENDING.test(node.value)
+}
+function isTab(node) {
+  return node.type === 'comment' && TAB_REGEX.test(node.value)
+}
+function getTabTitle(node) {
+  return node.value.match(TAB_REGEX)?.[1]
+}
+
+function createHastTab(tabInfo, suffix) {
+  return h(
+    'button',
+    {
+      id: createTabId(tabInfo, suffix),
+      role: 'tab',
+      'aria-selected': 'false',
+      'aria-controls': createTabPanelId(tabInfo, suffix),
+      tabindex: -1,
+    },
+    [tabInfo.title]
+  )
+}
+function createHastTabPanel(tabInfo, suffix) {
+  return h(
+    'div',
+    {
+      id: tabInfo.title + '-' + 'panel' + '-' + suffix,
+      role: 'tabpanel',
+      'aria-labelledby': tabInfo.title + '-' + 'tab' + '-' + suffix,
+    },
+    tabInfo.contents
+  )
+}
+function createTabId(tabInfo, suffix) {
+  return `${tabInfo.title}-tab-${suffix}`
+}
+function createTabPanelId(tabInfo, suffix) {
+  return `${tabInfo.title}-panel-${suffix}`
+}
+
+let ctr = 0
+function rehypeTabs() {
+  return (tree) => {
+    visit(tree, (maybeStartNode, maybeStartIndex, parent) => {
+      if (isTabGroupBeginning(maybeStartNode)) {
+        let tabs = []
+        let startIndex = maybeStartIndex
+        let endIndex = -1
+        let suffix = ctr++
+
+        let tabTitle = null
+        let contents = []
+        for (let i = startIndex + 1; i < parent.children.length; i++) {
+          let node = parent.children[i]
+          if (isTab(node)) {
+            if (tabTitle) {
+              tabs.push({
+                title: tabTitle,
+                contents,
+              })
+            }
+            tabTitle = getTabTitle(node)
+            contents = []
+          } else if (isTabGroupEnding(node)) {
+            tabs.push({
+              title: tabTitle,
+              contents,
+            })
+            endIndex = i
+            break
+          } else if (isTabGroupBeginning(node)) {
+            throw new Error('Unclosed tab group detected')
+          } else {
+            contents.push(node)
+          }
+        }
+
+        if (endIndex === -1) {
+          throw new Error('Unclosed tab group detected')
+        }
+
+        parent.children.splice(
+          startIndex,
+          endIndex - startIndex + 1,
+          h(
+            'div',
+            {
+              class: 'tab-container',
+            },
+            [
+              h(
+                'div',
+                {
+                  role: 'tablist',
+                  'data-docs-tablist': true,
+                },
+                tabs.map((t) => createHastTab(t, suffix))
+              ),
+              h(
+                'div',
+                {
+                  class: 'spacer',
+                },
+                tabs.map((t) => createHastTabPanel(t, suffix))
+              ),
+            ]
+          )
+        )
+      }
+    })
+
+    return undefined
+  }
+}
+
+export function rehypeTabPlugins(){
+    return [
+      // rehype-raw parses the tree again to ensure that comments are recognized as such - otherwise they're raw nodes
+      // raw nodes may contain some text content that's not part of a comment but content that should be displayed
+      // using rehype-raw solves this partially, but a comment directly preceded with text still isn't recognized
+      // so word<!--- begin-tab-group ---> will not be recognized as a comment but instead as plain text
+      rehypeRaw,
+      rehypeTabs
+    ]
+}

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -1,0 +1,22 @@
+.tab-container {
+  width: max-content;
+}
+
+[role='tab'] {
+  border-bottom: 3px solid transparent;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 1rem;
+}
+
+[role='tab'][aria-selected='true'] {
+  border-bottom-color: #67d6ed;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  color: #67d6ed;
+}
+
+.spacer {
+  margin-top: 1rem;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,11 +2185,6 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
-lodash.iteratee@^4.5.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz#be4177db289a8ccc3c0990f1db26b5b22fc1554c"
-  integrity sha512-yv3cSQZmfpbIKo4Yo45B1taEvxjNvcpF1CEOc0Y6dEyvhPIfEJE3twDwPgWTPQubcSgXyBwBKG6wpQvWMDOf6Q==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3703,46 +3698,12 @@ unist-builder@^3.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
 
-unist-util-find-after@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-4.0.0.tgz#1101cebf5fed88ae3c6f3fa676e86fd5772a4f32"
-  integrity sha512-gfpsxKQde7atVF30n5Gff2fQhAc4/HTOV4CvkXpTg9wRfQhZWdXitpyXHWB6YcYgnsxLx+4gGHeVjCTAAp9sjw==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^5.0.0"
-
-unist-util-find-all-between@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-find-all-between/-/unist-util-find-all-between-2.1.0.tgz#18ddb51f7abc4e22c645b4321e82ab6a6decc640"
-  integrity sha512-OCCUtDD8UHKeODw3TPXyFDxPCbpgBzbGTTaDpR68nvxkwiVcawBqMVrokfBMvUi7ij2F5q7S4s4Jq5dvkcBt+w==
-  dependencies:
-    unist-util-find "^1.0.1"
-    unist-util-is "^4.0.2"
-
-unist-util-find@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.2.tgz#4d5b01a69fca2a382ad4f55f9865e402129ecf56"
-  integrity sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==
-  dependencies:
-    lodash.iteratee "^4.5.0"
-    unist-util-visit "^1.1.0"
-
 unist-util-generated@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz"
   integrity sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==
 
-unist-util-is@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
-  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
-
-unist-util-is@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
-  integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
-
-unist-util-is@^5.0.0, unist-util-is@^5.1.1:
+unist-util-is@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
@@ -3784,13 +3745,6 @@ unist-util-remove-position@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-visit "^4.0.0"
 
-unist-util-replace-all-between@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-replace-all-between/-/unist-util-replace-all-between-0.1.1.tgz#c67bb7a3730e9a5981b1621eb79f1929c3bf395f"
-  integrity sha512-k/ROgwulcFwIYe+qNYdYZYAI1T1JO//XWQJCi8yH8wgNGM8/PnuN3A/+WjWIOZ6UeUJ6y59zxVW/mARmcxgPAg==
-  dependencies:
-    unist-util-is "^5.1.1"
-
 unist-util-stringify-position@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz"
@@ -3805,13 +3759,6 @@ unist-util-visit-children@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
 
-unist-util-visit-parents@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
-  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  dependencies:
-    unist-util-is "^3.0.0"
-
 unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz"
@@ -3819,13 +3766,6 @@ unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
-
-unist-util-visit@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
-  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
-  dependencies:
-    unist-util-visit-parents "^2.0.0"
 
 unist-util-visit@^4.0.0, unist-util-visit@^4.1.0, unist-util-visit@^4.1.1:
   version "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,17 @@ hastscript@^7.0.0:
     property-information "^6.0.0"
     space-separated-tokens "^2.0.0"
 
+hastscript@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-7.2.0.tgz#0eafb7afb153d047077fa2a833dc9b7ec604d10b"
+  integrity sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^3.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+
 html-entities@^2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz"
@@ -2173,6 +2184,11 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.iteratee@^4.5.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz#be4177db289a8ccc3c0990f1db26b5b22fc1554c"
+  integrity sha512-yv3cSQZmfpbIKo4Yo45B1taEvxjNvcpF1CEOc0Y6dEyvhPIfEJE3twDwPgWTPQubcSgXyBwBKG6wpQvWMDOf6Q==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -3135,7 +3151,7 @@ rehype-parse@^8.0.0:
 
 rehype-raw@^6.1.1:
   version "6.1.1"
-  resolved "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-6.1.1.tgz#81bbef3793bd7abacc6bf8335879d1b6c868c9d4"
   integrity sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -3687,12 +3703,46 @@ unist-builder@^3.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
 
+unist-util-find-after@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-4.0.0.tgz#1101cebf5fed88ae3c6f3fa676e86fd5772a4f32"
+  integrity sha512-gfpsxKQde7atVF30n5Gff2fQhAc4/HTOV4CvkXpTg9wRfQhZWdXitpyXHWB6YcYgnsxLx+4gGHeVjCTAAp9sjw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-find-all-between@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-between/-/unist-util-find-all-between-2.1.0.tgz#18ddb51f7abc4e22c645b4321e82ab6a6decc640"
+  integrity sha512-OCCUtDD8UHKeODw3TPXyFDxPCbpgBzbGTTaDpR68nvxkwiVcawBqMVrokfBMvUi7ij2F5q7S4s4Jq5dvkcBt+w==
+  dependencies:
+    unist-util-find "^1.0.1"
+    unist-util-is "^4.0.2"
+
+unist-util-find@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.2.tgz#4d5b01a69fca2a382ad4f55f9865e402129ecf56"
+  integrity sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==
+  dependencies:
+    lodash.iteratee "^4.5.0"
+    unist-util-visit "^1.1.0"
+
 unist-util-generated@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz"
   integrity sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==
 
-unist-util-is@^5.0.0:
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-is@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
+  integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
+
+unist-util-is@^5.0.0, unist-util-is@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
@@ -3734,6 +3784,13 @@ unist-util-remove-position@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-visit "^4.0.0"
 
+unist-util-replace-all-between@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-replace-all-between/-/unist-util-replace-all-between-0.1.1.tgz#c67bb7a3730e9a5981b1621eb79f1929c3bf395f"
+  integrity sha512-k/ROgwulcFwIYe+qNYdYZYAI1T1JO//XWQJCi8yH8wgNGM8/PnuN3A/+WjWIOZ6UeUJ6y59zxVW/mARmcxgPAg==
+  dependencies:
+    unist-util-is "^5.1.1"
+
 unist-util-stringify-position@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz"
@@ -3748,6 +3805,13 @@ unist-util-visit-children@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
 
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
 unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz"
@@ -3756,7 +3820,14 @@ unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit@^4.0.0, unist-util-visit@^4.1.0:
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
+
+unist-util-visit@^4.0.0, unist-util-visit@^4.1.0, unist-util-visit@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz"
   integrity sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==


### PR DESCRIPTION
Prototype demonstrating rehype plugin setup to allow specifying tabs in HTML comment syntax. There's some areas for improvement - a few are:

1. More robust HTML AST processing - it seems like the current plugin setup doesn't handle nodes where a string precedes a tab-comment directly (such as `something<!--- begin-tab-group --->`) 
2. Javascript needs to handle roving tabindex when focus is moved around the tab group using arrow keys
3. Doesn't handle all cases of invalid tab groups yet (such as unclosed tabs)

Opening this PR to demonstrate the high level approach - is this worth polishing up, and if so how? Are [directives](https://github.com/remarkjs/remark-directive) a good alternative to explore?