### PR TITLE
crucial fix on console you must input always cargo

### DIFF
--- a/docs/guides/distribution/updater.md
+++ b/docs/guides/distribution/updater.md
@@ -303,7 +303,7 @@ The _Private key_ (privkey) is used to sign your update and should NEVER be shar
 To generate your keys, you need to use the Tauri CLI:
 
 ```shell
-tauri signer generate -w ~/.tauri/myapp.key
+cargo tauri signer generate -w ~/.tauri/myapp.key
 ```
 
 You have multiple options available


### PR DESCRIPTION
crucial fix on console you must input always cargo as well as we know is a common thing to add, but for newcomers, this is a must or console will return the error