### PR TITLE
Update sidecar.md

### DIFF
--- a/docs/guides/building/sidecar.md
+++ b/docs/guides/building/sidecar.md
@@ -39,11 +39,13 @@ Here is a sample to illustrate the configuration. This is not a complete `tauri.
 }
 ```
 
-A binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the specified path. For instance, `"externalBin": ["binaries/my-sidecar"]` requires a `src-tauri/binaries/my-sidecar-x86_64-unknown-linux-gnu` executable on Linux. You can find the current platform's target triple by running the following command:
+A binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the specified path. For instance, `"externalBin": ["binaries/my-sidecar"]` requires a `src-tauri/binaries/my-sidecar-x86_64-unknown-linux-gnu` executable on Linux. With `grep` and `cut` available (i.e. on most Linux distributions), you can find the current platform's target triple by running the following command:
 
 ```shell
 rustc -Vv | grep host | cut -f2 -d' '
 ```
+
+In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`](https://docs.rs/rustc-host/latest/rustc_host/fn.from_cli.html) from [`rustc-host`](https://crates.io/crates/rustc-host) crate.
 
 Here's a Node.js script to append the target triple to a binary:
 

--- a/docs/guides/building/sidecar.md
+++ b/docs/guides/building/sidecar.md
@@ -45,7 +45,7 @@ A binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the spe
 rustc -Vv | grep host | cut -f2 -d' '
 ```
 
-In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`](https://docs.rs/rustc-host/latest/rustc_host/fn.from_cli.html) from [`rustc-host`](https://crates.io/crates/rustc-host) crate.
+In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`] from [`rustc-host`](https://crates.io/crates/rustc-host) crate.
 
 Here's a Node.js script to append the target triple to a binary:
 
@@ -181,3 +181,5 @@ It compiles the Node.js code using [pkg] and uses the scripts above to run it.
 [sidecar example]: https://github.com/tauri-apps/tauri/tree/dev/examples/sidecar
 [Restricting access to the Command APIs]: ../../api/js/shell.md#restricting-access-to-the-command-apis
 [pkg]: https://github.com/vercel/pkg
+[`rustc-host`]: https://crates.io/crates/rustc-host
+[`rustc_host::from_cli()`]: https://docs.rs/rustc-host/latest/rustc_host/fn.from_cli.html

--- a/docs/guides/building/sidecar.md
+++ b/docs/guides/building/sidecar.md
@@ -45,7 +45,7 @@ A binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the spe
 rustc -Vv | grep host | cut -f2 -d' '
 ```
 
-In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`] function or `rustc-host` CLI binary from [`rustc-host`](https://crates.io/crates/rustc-host) combined (library + binary) crate.
+You can also obtain the host triple using `rustc-host` CLI binary from [`rustc-host`](https://crates.io/crates/rustc-host) combined (library + binary) crate or [`rustc_host::from_cli()`] function from Rust code.
 
 Here's a Node.js script to append the target triple to a binary:
 

--- a/docs/guides/building/sidecar.md
+++ b/docs/guides/building/sidecar.md
@@ -45,7 +45,7 @@ A binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the spe
 rustc -Vv | grep host | cut -f2 -d' '
 ```
 
-In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`] from [`rustc-host`](https://crates.io/crates/rustc-host) crate.
+In Rust, you can also obtain the host triple using [`rustc_host::from_cli()`] function or `rustc-host` CLI binary from [`rustc-host`](https://crates.io/crates/rustc-host) combined (library + binary) crate.
 
 Here's a Node.js script to append the target triple to a binary:
 


### PR DESCRIPTION
I've added a less environment-dependent way for obtaining the host triple, which uses the simple library I've made.

In case of security concerns, I'm willing to delegate ownership over [`rustc-host`](https://crates.io/crates/rustc-host) crate and its GitHub repo.