### PR TITLE
 Add Guix setup instructions for next branch

### DIFF
--- a/docs/guides/getting-started/prerequisites/linux.md
+++ b/docs/guides/getting-started/prerequisites/linux.md
@@ -173,6 +173,28 @@ pkgs.mkShell {
 ```
 
   </TabItem>
+  <TabItem value="gnu_guix" label="GNU Guix">
+
+To create Tauri development environments using [Guix shell], copy the following code into `manifest.scm` on your repository, then run `guix shell` to activate. You can also use [direnv's Guix shell support] to automatically start the Guix shell when entering the project folder.
+
+```scheme
+(specifications->manifest
+ (list "gtk+@3"
+       "webkitgtk"
+       "libsoup"
+       "cairo"
+       "gdk-pixbuf"
+       "glib"
+       "dbus"
+       "openssl@3"
+       "gcc:lib"
+
+       "curl"
+       "wget"
+       "pkg-config"
+       "gsettings-desktop-schemas"))
+```
+  </TabItem>
 </Tabs>
 
 ### 2. Rust


### PR DESCRIPTION
There is #1106 which is using webkit2gtk-4.0.

I saw #1097 mentioned webkit2gtk-4.1.
Instead of waiting for #1106 get merged and ported back to next branch and the send a PR to reflect webkit2gtk-4.1.
I decided to send this separated PR for next branch.