### PR TITLE
Added missing step to custom titlebar example

### DIFF
--- a/docs/guides/features/window-customization.md
+++ b/docs/guides/features/window-customization.md
@@ -84,3 +84,26 @@ document
   .getElementById('titlebar-close')
   .addEventListener('click', () => appWindow.close())
 ```
+
+### tauri.conf.json
+
+To make calls to `appWindow` work don't forget to add [window](../../api/js/window.md) permissions in `tauri.conf.json` file:
+```json
+"tauri": {
+  "allowList": {
+    ...
+    "window": {
+        "all": false,
+        "close": true,
+        "hide": true,
+        "show": true,
+        "maximize": true,
+        "minimize": true,
+        "unmaximize": true,
+        "unminimize": true,
+        "startDragging": true
+      }
+  }
+  ...
+}
+```


### PR DESCRIPTION
Custom titlebar example didn't mention that you need to add window permissions in `tauri.conf.json` to make it work