### PR TITLE
Show change on page instead of console

### DIFF
--- a/docs/guides/getting-started/setup/html-css-js.mdx
+++ b/docs/guides/getting-started/setup/html-css-js.mdx
@@ -106,18 +106,20 @@ You can now modify your `index.html` file to call your Command:
     <title>Document</title>
   </head>
   <body>
-    <h1>Welcome from Tauri!</h1>
     // highlight-start
+    <h1 id="header">Welcome from Tauri!</h1>
     <script>
       // access the pre-bundled global API functions
       const { invoke } = window.__TAURI__.tauri
 
       // now we can call our Command!
-      // Right-click the application background and open the developer tools.
-      // You will see "Hello, World!" printed in the console!
+      // You will see "Welcome from Tauri" replaced
+      // by "Hello, World!"!
       invoke('greet', { name: 'World' })
         // `invoke` returns a Promise
-        .then((response) => console.log(response))
+        .then((response) => {
+          window.header.innerHTML = response
+        })
     </script>
     // highlight-end
   </body>


### PR DESCRIPTION
This change updates the vanilla Getting Started docs to show the connection between environments on the page instead of the console. 

It makes it quicker to see. I think it feels more impressive since the content itself is what gets changed instead of seeing a message in a log.