### PR TITLE
plugin to rewrite markdown links

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,6 +5,7 @@ import sitemap from '@astrojs/sitemap'
 import i18n from 'astro-i18n'
 import Icons from 'unplugin-icons/vite'
 import { extractImageClass } from './src/plugins/remark-extract-image-class'
+import { rewriteMarkdownLinks } from './src/plugins/remark-rewrite-markdown-links'
 import { nonDefaultLocales } from './astro.i18n.config'
 import solidJs from '@astrojs/solid-js'
 import mdx from '@astrojs/mdx'
@@ -42,6 +43,6 @@ export default defineConfig({
     ],
   },
   markdown: {
-    remarkPlugins: [extractImageClass],
+    remarkPlugins: [extractImageClass, rewriteMarkdownLinks],
   },
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "i18n:sync": "astro-i18n sync",
     "i18n:extract:keys": "astro-i18n extract:keys",
     "generate:cli": "node .scripts/generate-cli-doc.cjs",
-    "generate:config": "node .scripts/generate-config-doc.cjs"
+    "generate:config": "node .scripts/generate-config-doc.cjs",
+    "test": "ts-node --esm src/plugins/remark-rewrite-markdown-links/test.ts"
   },
   "dependencies": {
     "@astrojs/mdx": "^0.18.0",
@@ -31,6 +32,7 @@
     "meilisearch-docsearch": "0.4.5",
     "solid-js": "^1.6.12",
     "tailwindcss": "^3.2.7",
+    "ts-node": "^10.9.1",
     "unplugin-icons": "^0.15.3"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@fontsource/ibm-plex-mono": "^4.5.13",
     "@fontsource/rubik": "^4.5.14",
     "@iconify/json": "^2.2.31",
-    "@types/node": "18.15.0",
     "astro": "^2.1.0",
     "astro-i18n": "^1.6.6",
     "docs-searchbar.js": "^2.4.1",
@@ -49,6 +48,7 @@
   "devDependencies": {
     "@types/json-schema": "^7.0.11",
     "@types/marked": "^4.0.8",
+    "@types/node": "18.15.0",
     "shiki": "^0.14.1",
     "unist": "^8.0.11",
     "unist-util-visit": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fontsource/ibm-plex-mono": "^4.5.13",
     "@fontsource/rubik": "^4.5.14",
     "@iconify/json": "^2.2.31",
+    "@types/node": "18.15.0",
     "astro": "^2.1.0",
     "astro-i18n": "^1.6.6",
     "docs-searchbar.js": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ specifiers:
   shiki: ^0.14.1
   solid-js: ^1.6.12
   tailwindcss: ^3.2.7
+  ts-node: ^10.9.1
   unist: ^8.0.11
   unist-util-visit: ^4.1.2
   unplugin-icons: ^0.15.3
@@ -29,7 +30,7 @@ dependencies:
   '@astrojs/prefetch': 0.1.2
   '@astrojs/sitemap': 1.2.0
   '@astrojs/solid-js': 2.1.0_solid-js@1.6.12
-  '@astrojs/tailwind': 3.1.0_o5pmjyiyxefuvlue2yryq6hdmq
+  '@astrojs/tailwind': 3.1.0_h6o2enrwrybidubiz7bof7tlyu
   '@fontsource/ibm-plex-mono': 4.5.13
   '@fontsource/rubik': 4.5.14
   '@iconify/json': 2.2.31
@@ -39,7 +40,8 @@ dependencies:
   marked: 4.2.12
   meilisearch-docsearch: 0.4.5
   solid-js: 1.6.12
-  tailwindcss: 3.2.7
+  tailwindcss: 3.2.7_ts-node@10.9.1
+  ts-node: 10.9.1_@types+node@18.15.0
   unplugin-icons: 0.15.3
 
 devDependencies:
@@ -182,7 +184,7 @@ packages:
       - vite
     dev: false
 
-  /@astrojs/tailwind/3.1.0_o5pmjyiyxefuvlue2yryq6hdmq:
+  /@astrojs/tailwind/3.1.0_h6o2enrwrybidubiz7bof7tlyu:
     resolution: {integrity: sha512-eNflzlCdCtLZjc8pK0xQb/hXYnN/mVGVJFRAMWStrFwg8Tsvj6WVCPyRy77D5NL2tQ1piS2wiouOzAgiy1Dsiw==}
     peerDependencies:
       astro: ^2.1.0
@@ -192,8 +194,8 @@ packages:
       astro: 2.1.0_@types+node@18.15.0
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
-      postcss-load-config: 4.0.1_postcss@8.4.21
-      tailwindcss: 3.2.7
+      postcss-load-config: 4.0.1_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -458,6 +460,13 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: false
+
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
     dev: false
 
   /@emmetio/abbreviation/2.2.3:
@@ -762,6 +771,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
+
   /@ljharb/has-package-exports-patterns/0.0.2:
     resolution: {integrity: sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==}
     dev: false
@@ -855,6 +871,22 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: false
+
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: false
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: false
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: false
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: false
 
   /@types/acorn/4.0.6:
@@ -1009,6 +1041,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /acorn/7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -1066,6 +1103,10 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: false
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: false
 
   /arg/5.0.2:
@@ -1413,6 +1454,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
@@ -1504,6 +1549,11 @@ packages:
 
   /didyoumean/1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: false
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: false
 
   /diff/5.1.0:
@@ -2452,6 +2502,10 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: false
+
   /markdown-extensions/1.1.1:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
     engines: {node: '>=0.10.0'}
@@ -3321,7 +3375,7 @@ packages:
       postcss: 8.4.21
     dev: false
 
-  /postcss-load-config/3.1.4_postcss@8.4.21:
+  /postcss-load-config/3.1.4_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -3335,10 +3389,11 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
+      ts-node: 10.9.1_@types+node@18.15.0
       yaml: 1.10.2
     dev: false
 
-  /postcss-load-config/4.0.1_postcss@8.4.21:
+  /postcss-load-config/4.0.1_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -3352,6 +3407,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
+      ts-node: 10.9.1_@types+node@18.15.0
       yaml: 2.2.1
     dev: false
 
@@ -3875,7 +3931,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /tailwindcss/3.2.7:
+  /tailwindcss/3.2.7_ts-node@10.9.1:
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -3897,7 +3953,7 @@ packages:
       postcss: 8.4.21
       postcss-import: 14.1.0_postcss@8.4.21
       postcss-js: 4.0.1_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-load-config: 3.1.4_aesdjsunmf4wiehhujt67my7tu
       postcss-nested: 6.0.0_postcss@8.4.21
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
@@ -3945,6 +4001,36 @@ packages:
 
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+    dev: false
+
+  /ts-node/10.9.1_@types+node@18.15.0:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.15.0
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: false
 
   /tsconfig-resolver/3.0.1:
@@ -4126,6 +4212,10 @@ packages:
       diff: 5.1.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: false
 
   /validate-html-nesting/1.2.1:
@@ -4366,6 +4456,11 @@ packages:
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: false
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: false
 
   /yocto-queue/0.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@iconify/json': ^2.2.31
   '@types/json-schema': ^7.0.11
   '@types/marked': ^4.0.8
+  '@types/node': 18.15.0
   astro: ^2.1.0
   astro-i18n: ^1.6.6
   docs-searchbar.js: ^2.4.1
@@ -32,7 +33,8 @@ dependencies:
   '@fontsource/ibm-plex-mono': 4.5.13
   '@fontsource/rubik': 4.5.14
   '@iconify/json': 2.2.31
-  astro: 2.1.0
+  '@types/node': 18.15.0
+  astro: 2.1.0_@types+node@18.15.0
   astro-i18n: 1.6.6
   docs-searchbar.js: 2.4.1
   marked: 4.2.12
@@ -101,7 +103,7 @@ packages:
       astro: ^2.1.0
     dependencies:
       '@astrojs/prism': 2.1.0
-      astro: 2.1.0
+      astro: 2.1.0_@types+node@18.15.0
       github-slugger: 1.5.0
       image-size: 1.0.2
       import-meta-resolve: 2.2.1
@@ -187,7 +189,7 @@ packages:
       tailwindcss: ^3.0.24
     dependencies:
       '@proload/core': 0.3.3
-      astro: 2.1.0
+      astro: 2.1.0_@types+node@18.15.0
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       postcss-load-config: 4.0.1_postcss@8.4.21
@@ -948,6 +950,10 @@ packages:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: false
 
+  /@types/node/18.15.0:
+    resolution: {integrity: sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==}
+    dev: false
+
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
     dev: false
@@ -959,7 +965,7 @@ packages:
   /@types/sax/1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.15.0
     dev: false
 
   /@types/unist/2.0.6:
@@ -1089,7 +1095,7 @@ packages:
       get-file-exports: 1.2.1
     dev: false
 
-  /astro/2.1.0:
+  /astro/2.1.0_@types+node@18.15.0:
     resolution: {integrity: sha512-5MkwcRSAfdtz+9KjFHWe2aLhnDGhTTrgCMryMWdcENos9mcrLZmjpXEI7A75PTq0hHixT8n9K/4URAoPQO8AHA==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
@@ -1149,7 +1155,7 @@ packages:
       typescript: 4.9.5
       unist-util-visit: 4.1.2
       vfile: 5.3.7
-      vite: 4.1.4
+      vite: 4.1.4_@types+node@18.15.0
       vitefu: 0.2.4_vite@4.1.4
       yargs-parser: 21.1.1
       zod: 3.21.4
@@ -4150,7 +4156,7 @@ packages:
       vfile-message: 3.1.4
     dev: false
 
-  /vite/4.1.4:
+  /vite/4.1.4_@types+node@18.15.0:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -4175,6 +4181,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 18.15.0
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
@@ -4200,7 +4207,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.4
+      vite: 4.1.4_@types+node@18.15.0
     dev: false
 
   /vscode-css-languageservice/6.2.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,6 @@ dependencies:
   '@fontsource/ibm-plex-mono': 4.5.13
   '@fontsource/rubik': 4.5.14
   '@iconify/json': 2.2.31
-  '@types/node': 18.15.0
   astro: 2.1.0_@types+node@18.15.0
   astro-i18n: 1.6.6
   docs-searchbar.js: 2.4.1
@@ -46,6 +45,7 @@ dependencies:
 devDependencies:
   '@types/json-schema': 7.0.11
   '@types/marked': 4.0.8
+  '@types/node': 18.15.0
   shiki: 0.14.1
   unist: 8.0.11
   unist-util-visit: 4.1.2
@@ -952,7 +952,6 @@ packages:
 
   /@types/node/18.15.0:
     resolution: {integrity: sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==}
-    dev: false
 
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}

--- a/src/plugins/remark-rewrite-markdown-links.ts
+++ b/src/plugins/remark-rewrite-markdown-links.ts
@@ -1,0 +1,49 @@
+import { visit } from 'unist-util-visit'
+import type { RemarkPlugin } from '@astrojs/markdown-remark'
+
+function removeIndexFromEnd(link: string) {
+  return link.replace(/(\/|^)index$/, '')
+}
+
+function removeExplicitCurrentDir(link: string) {
+  return link.replace(/^.\//, '')
+}
+
+// Content collection slug manipulation could affect this
+function transformLink(link: string, currentFileIsIndex: boolean) {
+  link = link.trim()
+  if (
+    /^\/\//.test(link) ||
+    /^http(s)?:\/\//.test(link) ||
+    !/\.md(#[^/]+)?$/.test(link)
+  ) {
+    return link
+  }
+
+  let [pathToMdFile, afterPoundSign] = link.split(/(?<=\.md)#/)
+  let fragment = afterPoundSign ? `#${afterPoundSign}` : ''
+  let pathToPage = pathToMdFile.replace(/\.md$/, '')
+
+  let urlPath = removeIndexFromEnd(removeExplicitCurrentDir(pathToPage))
+  if (!currentFileIsIndex) {
+    // Because of the trailing slashes in urls, we always want to move one level up if we aren't on an index page
+    urlPath = '..' + (urlPath ? `/${urlPath}` : '')
+  }
+
+  if (urlPath === '') {
+    return fragment || '#'
+  } else {
+    // Add the trailing slash at the end, then the fragment if necessary
+    return urlPath + '/' + fragment
+  }
+}
+
+let rewriteMarkdownLinks: RemarkPlugin = function rewriteMarkdownLinks() {
+  return (tree, file) => {
+    visit(tree, 'link', (node, _index, _parent) => {
+      node.url = transformLink(node.url, file.basename === 'index.md')
+    })
+  }
+}
+
+export { rewriteMarkdownLinks }

--- a/src/plugins/remark-rewrite-markdown-links.ts
+++ b/src/plugins/remark-rewrite-markdown-links.ts
@@ -15,14 +15,14 @@ function transformLink(link: string, currentFileIsIndex: boolean) {
   if (
     /^\/\//.test(link) ||
     /^http(s)?:\/\//.test(link) ||
-    !/\.md(#[^/]+)?$/.test(link)
+    !/\.mdx?(#[^/]+)?$/.test(link)
   ) {
     return link
   }
 
-  let [pathToMdFile, afterPoundSign] = link.split(/(?<=\.md)#/)
+  let [pathToMdFile, afterPoundSign] = link.split(/(?<=\.mdx?)#/)
   let fragment = afterPoundSign ? `#${afterPoundSign}` : ''
-  let pathToPage = pathToMdFile.replace(/\.md$/, '')
+  let pathToPage = pathToMdFile.replace(/\.mdx?$/, '')
 
   let urlPath = removeIndexFromEnd(removeExplicitCurrentDir(pathToPage))
   if (!currentFileIsIndex) {

--- a/src/plugins/remark-rewrite-markdown-links.ts
+++ b/src/plugins/remark-rewrite-markdown-links.ts
@@ -40,8 +40,9 @@ function transformLink(link: string, currentFileIsIndex: boolean) {
 
 let rewriteMarkdownLinks: RemarkPlugin = function rewriteMarkdownLinks() {
   return (tree, file) => {
-    visit(tree, 'link', (node, _index, _parent) => {
-      node.url = transformLink(node.url, file.basename === 'index.md')
+    visit(tree, ['link', 'definition'], (node, _index, _parent) => {
+      // node is actually a link or a definition given the filter above, but there doesn't appear to be sufficient type narrowing
+      (node as any).url = transformLink((node as any).url, file.basename === 'index.md' || file.basename === 'index.mdx')
     })
   }
 }

--- a/src/plugins/remark-rewrite-markdown-links/index.ts
+++ b/src/plugins/remark-rewrite-markdown-links/index.ts
@@ -10,7 +10,7 @@ function removeExplicitCurrentDir(link: string) {
 }
 
 // Content collection slug manipulation could affect this
-function transformLink(link: string, currentFileIsIndex: boolean) {
+export function transformLink(link: string, currentFileIsIndex: boolean) {
   link = link.trim()
   if (
     /^\/\//.test(link) ||

--- a/src/plugins/remark-rewrite-markdown-links/test.ts
+++ b/src/plugins/remark-rewrite-markdown-links/test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test'
+import { strict as assert } from 'node:assert'
+import { transformLink } from './index.js'
+
+// Assume trailing slash in all urls
+test('nonindex to nonindex, same directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_1/nonindex_2.md
+  // url: base/dir_1/nonindex/ -> base/dir_1/nonindex_2/
+  assert.equal(transformLink('./nonindex_2.md', false), '../nonindex_2/')
+  assert.equal(transformLink('nonindex_2.md', false), '../nonindex_2/')
+  assert.equal(transformLink('./nonindex_2.md#id', false), '../nonindex_2/#id')
+  assert.equal(transformLink('nonindex_2.md#id', false), '../nonindex_2/#id')
+})
+test('nonindex to nonindex in sibling directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_2/nonindex.md
+  // url: base/dir_1/nonindex/ -> base/dir_2/nonindex/
+  assert.equal(
+    transformLink('../dir_2/nonindex.md', false),
+    '../../dir_2/nonindex/'
+  )
+  assert.equal(
+    transformLink('../dir_2/nonindex.md#id', false),
+    '../../dir_2/nonindex/#id'
+  )
+})
+test('nonindex to index in same directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_1/index.md
+  // url: base/dir_1/nonindex/ -> base/dir_1/
+  assert.equal(transformLink('./index.md', false), '../')
+  assert.equal(transformLink('index.md', false), '../')
+  assert.equal(transformLink('./index.md#id', false), '../#id')
+  assert.equal(transformLink('index.md#id', false), '../#id')
+})
+test('nonindex to index in different directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_2/index.md
+  // url: base/dir_1/nonindex/ -> base/dir_2/
+  assert.equal(transformLink('../dir_2/index.md', false), '../../dir_2/')
+  assert.equal(transformLink('../dir_2/index.md#id', false), '../../dir_2/#id')
+})
+test('index to nonindex in same directory', () => {
+  // fs: base/dir_1/index.md -> base/dir_1/nonindex.md
+  // url: base/dir_1/ -> base/dir_1/nonindex/
+  assert.equal(transformLink('./nonindex.md', true), 'nonindex/')
+  assert.equal(transformLink('nonindex.md', true), 'nonindex/')
+  assert.equal(transformLink('./nonindex.md#id', true), 'nonindex/#id')
+  assert.equal(transformLink('nonindex.md#id', true), 'nonindex/#id')
+})
+test('index to nonindex in nested directory', () => {
+  // fs: base/dir_1/index.md -> base/dir_1/nested/nonindex.md
+  // url: base/dir_1/ -> base/dir_1/nested/nonindex/
+  assert.equal(transformLink('./nested/nonindex.md', true), 'nested/nonindex/')
+  assert.equal(transformLink('nested/nonindex.md', true), 'nested/nonindex/')
+  assert.equal(
+    transformLink('./nested/nonindex.md#id', true),
+    'nested/nonindex/#id'
+  )
+  assert.equal(
+    transformLink('nested/nonindex.md#id', true),
+    'nested/nonindex/#id'
+  )
+})
+test('nonindex to nonindex in nested directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_1/nested/nonindex.md
+  // url: base/dir_1/nonindex/ -> base/dir_1/nested/nonindex/
+  assert.equal(
+    transformLink('./nested/nonindex.md', false),
+    '../nested/nonindex/'
+  )
+  assert.equal(
+    transformLink('nested/nonindex.md', false),
+    '../nested/nonindex/'
+  )
+  assert.equal(
+    transformLink('./nested/nonindex.md#id', false),
+    '../nested/nonindex/#id'
+  )
+  assert.equal(
+    transformLink('nested/nonindex.md#id', false),
+    '../nested/nonindex/#id'
+  )
+})
+test('nonindex to index in nested directory', () => {
+  // fs: base/dir_1/nonindex.md -> base/dir_1/nested/index.md
+  // url: base/dir_1/nonindex/ -> base/dir_1/nested/
+  assert.equal(transformLink('./nested/index.md', false), '../nested/')
+  assert.equal(transformLink('nested/index.md', false), '../nested/')
+  assert.equal(transformLink('./nested/index.md#id', false), '../nested/#id')
+  assert.equal(transformLink('nested/index.md#id', false), '../nested/#id')
+})
+test('index to index in nested directory', () => {
+  // fs: base/dir_1/index.md -> base/dir_1/nested/index.md
+  // url: base/dir_1/ -> base/dir_1/nested/
+  assert.equal(transformLink('./nested/index.md', true), 'nested/')
+  assert.equal(transformLink('nested/index.md', true), 'nested/')
+  assert.equal(transformLink('./nested/index.md#id', true), 'nested/#id')
+  assert.equal(transformLink('nested/index.md#id', true), 'nested/#id')
+})
+test('index to index in sibling dir', () => {
+  // fs: base/dir_1/index.md -> base/dir_2/index.md
+  // url: base/dir_1/ -> base/dir_2/
+  assert.equal(transformLink('../dir_2/index.md', true), '../dir_2/')
+  assert.equal(transformLink('../dir_2/index.md#id', true), '../dir_2/#id')
+})
+test('index to index in parent dir', () => {
+  // fs: base/dir_1/index.md -> base/index.md
+  // url: base/dir_1/ -> base/
+  assert.equal(transformLink('../../index.md', true), '../../')
+  assert.equal(transformLink('../../index.md#id', true), '../../#id')
+})
+test('index to nonindex in sibling dir', () => {
+  // base/dir_1/index.md -> base/dir_2/nonindex.md
+  // url: base/dir_1/ -> base/dir_2/nonindex/
+  assert.equal(
+    transformLink('../dir_2/nonindex.md', true),
+    '../dir_2/nonindex/'
+  )
+  assert.equal(
+    transformLink('../dir_2/nonindex.md#id', true),
+    '../dir_2/nonindex/#id'
+  )
+})
+test('non-md remains untouched', () => {
+  assert.equal(transformLink('./image.jpg', false), './image.jpg')
+  assert.equal(transformLink('image.jpg', false), 'image.jpg')
+  assert.equal(
+    transformLink('./image.jpg#github-light-mode', false),
+    './image.jpg#github-light-mode'
+  )
+  assert.equal(
+    transformLink('image.jpg#github-light-mode', false),
+    'image.jpg#github-light-mode'
+  )
+})
+test('full link remains untouched', () => {
+  assert.equal(
+    transformLink('https://somewhere.com/notes.md', false),
+    'https://somewhere.com/notes.md'
+  )
+  assert.equal(
+    transformLink('http://somewhere.com/notes.md', false),
+    'http://somewhere.com/notes.md'
+  )
+})
+
+// not testing index back to self (./index.md in index.md)

--- a/src/plugins/remark-rewrite-markdown-links/test.ts
+++ b/src/plugins/remark-rewrite-markdown-links/test.ts
@@ -2,144 +2,170 @@ import test from 'node:test'
 import { strict as assert } from 'node:assert'
 import { transformLink } from './index.js'
 
-// Assume trailing slash in all urls
-test('nonindex to nonindex, same directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_1/nonindex_2.md
-  // url: base/dir_1/nonindex/ -> base/dir_1/nonindex_2/
-  assert.equal(transformLink('./nonindex_2.md', false), '../nonindex_2/')
-  assert.equal(transformLink('nonindex_2.md', false), '../nonindex_2/')
-  assert.equal(transformLink('./nonindex_2.md#id', false), '../nonindex_2/#id')
-  assert.equal(transformLink('nonindex_2.md#id', false), '../nonindex_2/#id')
-})
-test('nonindex to nonindex in sibling directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_2/nonindex.md
-  // url: base/dir_1/nonindex/ -> base/dir_2/nonindex/
-  assert.equal(
-    transformLink('../dir_2/nonindex.md', false),
-    '../../dir_2/nonindex/'
-  )
-  assert.equal(
-    transformLink('../dir_2/nonindex.md#id', false),
-    '../../dir_2/nonindex/#id'
-  )
-})
-test('nonindex to index in same directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_1/index.md
-  // url: base/dir_1/nonindex/ -> base/dir_1/
-  assert.equal(transformLink('./index.md', false), '../')
-  assert.equal(transformLink('index.md', false), '../')
-  assert.equal(transformLink('./index.md#id', false), '../#id')
-  assert.equal(transformLink('index.md#id', false), '../#id')
-})
-test('nonindex to index in different directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_2/index.md
-  // url: base/dir_1/nonindex/ -> base/dir_2/
-  assert.equal(transformLink('../dir_2/index.md', false), '../../dir_2/')
-  assert.equal(transformLink('../dir_2/index.md#id', false), '../../dir_2/#id')
-})
-test('index to nonindex in same directory', () => {
-  // fs: base/dir_1/index.md -> base/dir_1/nonindex.md
-  // url: base/dir_1/ -> base/dir_1/nonindex/
-  assert.equal(transformLink('./nonindex.md', true), 'nonindex/')
-  assert.equal(transformLink('nonindex.md', true), 'nonindex/')
-  assert.equal(transformLink('./nonindex.md#id', true), 'nonindex/#id')
-  assert.equal(transformLink('nonindex.md#id', true), 'nonindex/#id')
-})
-test('index to nonindex in nested directory', () => {
-  // fs: base/dir_1/index.md -> base/dir_1/nested/nonindex.md
-  // url: base/dir_1/ -> base/dir_1/nested/nonindex/
-  assert.equal(transformLink('./nested/nonindex.md', true), 'nested/nonindex/')
-  assert.equal(transformLink('nested/nonindex.md', true), 'nested/nonindex/')
-  assert.equal(
-    transformLink('./nested/nonindex.md#id', true),
-    'nested/nonindex/#id'
-  )
-  assert.equal(
-    transformLink('nested/nonindex.md#id', true),
-    'nested/nonindex/#id'
-  )
-})
-test('nonindex to nonindex in nested directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_1/nested/nonindex.md
-  // url: base/dir_1/nonindex/ -> base/dir_1/nested/nonindex/
-  assert.equal(
-    transformLink('./nested/nonindex.md', false),
-    '../nested/nonindex/'
-  )
-  assert.equal(
-    transformLink('nested/nonindex.md', false),
-    '../nested/nonindex/'
-  )
-  assert.equal(
-    transformLink('./nested/nonindex.md#id', false),
-    '../nested/nonindex/#id'
-  )
-  assert.equal(
-    transformLink('nested/nonindex.md#id', false),
-    '../nested/nonindex/#id'
-  )
-})
-test('nonindex to index in nested directory', () => {
-  // fs: base/dir_1/nonindex.md -> base/dir_1/nested/index.md
-  // url: base/dir_1/nonindex/ -> base/dir_1/nested/
-  assert.equal(transformLink('./nested/index.md', false), '../nested/')
-  assert.equal(transformLink('nested/index.md', false), '../nested/')
-  assert.equal(transformLink('./nested/index.md#id', false), '../nested/#id')
-  assert.equal(transformLink('nested/index.md#id', false), '../nested/#id')
-})
-test('index to index in nested directory', () => {
-  // fs: base/dir_1/index.md -> base/dir_1/nested/index.md
-  // url: base/dir_1/ -> base/dir_1/nested/
-  assert.equal(transformLink('./nested/index.md', true), 'nested/')
-  assert.equal(transformLink('nested/index.md', true), 'nested/')
-  assert.equal(transformLink('./nested/index.md#id', true), 'nested/#id')
-  assert.equal(transformLink('nested/index.md#id', true), 'nested/#id')
-})
-test('index to index in sibling dir', () => {
-  // fs: base/dir_1/index.md -> base/dir_2/index.md
-  // url: base/dir_1/ -> base/dir_2/
-  assert.equal(transformLink('../dir_2/index.md', true), '../dir_2/')
-  assert.equal(transformLink('../dir_2/index.md#id', true), '../dir_2/#id')
-})
-test('index to index in parent dir', () => {
-  // fs: base/dir_1/index.md -> base/index.md
-  // url: base/dir_1/ -> base/
-  assert.equal(transformLink('../../index.md', true), '../../')
-  assert.equal(transformLink('../../index.md#id', true), '../../#id')
-})
-test('index to nonindex in sibling dir', () => {
-  // base/dir_1/index.md -> base/dir_2/nonindex.md
-  // url: base/dir_1/ -> base/dir_2/nonindex/
-  assert.equal(
-    transformLink('../dir_2/nonindex.md', true),
-    '../dir_2/nonindex/'
-  )
-  assert.equal(
-    transformLink('../dir_2/nonindex.md#id', true),
-    '../dir_2/nonindex/#id'
-  )
-})
-test('non-md remains untouched', () => {
-  assert.equal(transformLink('./image.jpg', false), './image.jpg')
-  assert.equal(transformLink('image.jpg', false), 'image.jpg')
-  assert.equal(
-    transformLink('./image.jpg#github-light-mode', false),
-    './image.jpg#github-light-mode'
-  )
-  assert.equal(
-    transformLink('image.jpg#github-light-mode', false),
-    'image.jpg#github-light-mode'
-  )
-})
-test('full link remains untouched', () => {
-  assert.equal(
-    transformLink('https://somewhere.com/notes.md', false),
-    'https://somewhere.com/notes.md'
-  )
-  assert.equal(
-    transformLink('http://somewhere.com/notes.md', false),
-    'http://somewhere.com/notes.md'
-  )
-})
+for (let ext of [`md`, `mdx`]) {
+  // Assume trailing slash in all urls
+  test(`nonindex to nonindex, same directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_1/nonindex_2.md
+    // url: base/dir_1/nonindex/ -> base/dir_1/nonindex_2/
+    assert.equal(transformLink(`./nonindex_2.${ext}`, false), `../nonindex_2/`)
+    assert.equal(transformLink(`nonindex_2.${ext}`, false), `../nonindex_2/`)
+    assert.equal(
+      transformLink(`./nonindex_2.${ext}#id`, false),
+      `../nonindex_2/#id`
+    )
+    assert.equal(
+      transformLink(`nonindex_2.${ext}#id`, false),
+      `../nonindex_2/#id`
+    )
+  })
+  test(`nonindex to nonindex in sibling directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_2/nonindex.md
+    // url: base/dir_1/nonindex/ -> base/dir_2/nonindex/
+    assert.equal(
+      transformLink(`../dir_2/nonindex.${ext}`, false),
+      `../../dir_2/nonindex/`
+    )
+    assert.equal(
+      transformLink(`../dir_2/nonindex.${ext}#id`, false),
+      `../../dir_2/nonindex/#id`
+    )
+  })
+  test(`nonindex to index in same directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_1/index.md
+    // url: base/dir_1/nonindex/ -> base/dir_1/
+    assert.equal(transformLink(`./index.${ext}`, false), `../`)
+    assert.equal(transformLink(`index.${ext}`, false), `../`)
+    assert.equal(transformLink(`./index.${ext}#id`, false), `../#id`)
+    assert.equal(transformLink(`index.${ext}#id`, false), `../#id`)
+  })
+  test(`nonindex to index in different directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_2/index.md
+    // url: base/dir_1/nonindex/ -> base/dir_2/
+    assert.equal(transformLink(`../dir_2/index.${ext}`, false), `../../dir_2/`)
+    assert.equal(
+      transformLink(`../dir_2/index.${ext}#id`, false),
+      `../../dir_2/#id`
+    )
+  })
+  test(`index to nonindex in same directory`, () => {
+    // fs: base/dir_1/index.md -> base/dir_1/nonindex.md
+    // url: base/dir_1/ -> base/dir_1/nonindex/
+    assert.equal(transformLink(`./nonindex.${ext}`, true), `nonindex/`)
+    assert.equal(transformLink(`nonindex.${ext}`, true), `nonindex/`)
+    assert.equal(transformLink(`./nonindex.${ext}#id`, true), `nonindex/#id`)
+    assert.equal(transformLink(`nonindex.${ext}#id`, true), `nonindex/#id`)
+  })
+  test(`index to nonindex in nested directory`, () => {
+    // fs: base/dir_1/index.md -> base/dir_1/nested/nonindex.md
+    // url: base/dir_1/ -> base/dir_1/nested/nonindex/
+    assert.equal(
+      transformLink(`./nested/nonindex.${ext}`, true),
+      `nested/nonindex/`
+    )
+    assert.equal(
+      transformLink(`nested/nonindex.${ext}`, true),
+      `nested/nonindex/`
+    )
+    assert.equal(
+      transformLink(`./nested/nonindex.${ext}#id`, true),
+      `nested/nonindex/#id`
+    )
+    assert.equal(
+      transformLink(`nested/nonindex.${ext}#id`, true),
+      `nested/nonindex/#id`
+    )
+  })
+  test(`nonindex to nonindex in nested directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_1/nested/nonindex.md
+    // url: base/dir_1/nonindex/ -> base/dir_1/nested/nonindex/
+    assert.equal(
+      transformLink(`./nested/nonindex.${ext}`, false),
+      `../nested/nonindex/`
+    )
+    assert.equal(
+      transformLink(`nested/nonindex.${ext}`, false),
+      `../nested/nonindex/`
+    )
+    assert.equal(
+      transformLink(`./nested/nonindex.${ext}#id`, false),
+      `../nested/nonindex/#id`
+    )
+    assert.equal(
+      transformLink(`nested/nonindex.${ext}#id`, false),
+      `../nested/nonindex/#id`
+    )
+  })
+  test(`nonindex to index in nested directory`, () => {
+    // fs: base/dir_1/nonindex.md -> base/dir_1/nested/index.md
+    // url: base/dir_1/nonindex/ -> base/dir_1/nested/
+    assert.equal(transformLink(`./nested/index.${ext}`, false), `../nested/`)
+    assert.equal(transformLink(`nested/index.${ext}`, false), `../nested/`)
+    assert.equal(
+      transformLink(`./nested/index.${ext}#id`, false),
+      `../nested/#id`
+    )
+    assert.equal(
+      transformLink(`nested/index.${ext}#id`, false),
+      `../nested/#id`
+    )
+  })
+  test(`index to index in nested directory`, () => {
+    // fs: base/dir_1/index.md -> base/dir_1/nested/index.md
+    // url: base/dir_1/ -> base/dir_1/nested/
+    assert.equal(transformLink(`./nested/index.${ext}`, true), `nested/`)
+    assert.equal(transformLink(`nested/index.${ext}`, true), `nested/`)
+    assert.equal(transformLink(`./nested/index.${ext}#id`, true), `nested/#id`)
+    assert.equal(transformLink(`nested/index.${ext}#id`, true), `nested/#id`)
+  })
+  test(`index to index in sibling dir`, () => {
+    // fs: base/dir_1/index.md -> base/dir_2/index.md
+    // url: base/dir_1/ -> base/dir_2/
+    assert.equal(transformLink(`../dir_2/index.${ext}`, true), `../dir_2/`)
+    assert.equal(
+      transformLink(`../dir_2/index.${ext}#id`, true),
+      `../dir_2/#id`
+    )
+  })
+  test(`index to index in parent dir`, () => {
+    // fs: base/dir_1/index.md -> base/index.md
+    // url: base/dir_1/ -> base/
+    assert.equal(transformLink(`../../index.${ext}`, true), `../../`)
+    assert.equal(transformLink(`../../index.${ext}#id`, true), `../../#id`)
+  })
+  test(`index to nonindex in sibling dir`, () => {
+    // base/dir_1/index.md -> base/dir_2/nonindex.md
+    // url: base/dir_1/ -> base/dir_2/nonindex/
+    assert.equal(
+      transformLink(`../dir_2/nonindex.${ext}`, true),
+      `../dir_2/nonindex/`
+    )
+    assert.equal(
+      transformLink(`../dir_2/nonindex.${ext}#id`, true),
+      `../dir_2/nonindex/#id`
+    )
+  })
+  test(`non-md remains untouched`, () => {
+    assert.equal(transformLink(`./image.jpg`, false), `./image.jpg`)
+    assert.equal(transformLink(`image.jpg`, false), `image.jpg`)
+    assert.equal(
+      transformLink(`./image.jpg#github-light-mode`, false),
+      `./image.jpg#github-light-mode`
+    )
+    assert.equal(
+      transformLink(`image.jpg#github-light-mode`, false),
+      `image.jpg#github-light-mode`
+    )
+  })
+  test(`full link remains untouched`, () => {
+    assert.equal(
+      transformLink(`https://somewhere.com/notes.${ext}`, false),
+      `https://somewhere.com/notes.${ext}`
+    )
+    assert.equal(
+      transformLink(`http://somewhere.com/notes.${ext}`, false),
+      `http://somewhere.com/notes.${ext}`
+    )
+  })
+}
 
 // not testing index back to self (./index.md in index.md)


### PR DESCRIPTION
https://github.com/orgs/tauri-apps/projects/18/views/1?pane=issue&itemId=19155863

This plugin modifies relative links to other markdown files by: 

- removing `.md` file extensions
- resolving inconsistencies between relative linking in filesystems vs in urls

It assumes that we're using [Netlify pretty url configuration that applies trailing slashes](https://docs.netlify.com/routing/redirects/redirect-options/#trailing-slash).