### PR TITLE
fix scope example

### DIFF
--- a/docs/api/js/shell.md
+++ b/docs/api/js/shell.md
@@ -54,11 +54,13 @@ CLI: `git commit -m "the commit message"`
 Configuration:
 ```json
 {
-  "scope": {
-    "name": "run-git-commit",
-    "cmd": "git",
-    "args": ["commit", "-m", { "validator": "\\S+" }]
-  }
+  "scope": [
+    {
+      "name": "run-git-commit",
+      "cmd": "git",
+      "args": ["commit", "-m", { "validator": "\\S+" }]
+    }
+  ]
 }
 ```
 Usage:


### PR DESCRIPTION
Changed `scope` example to provide an array, as described in the docs and how it works.