### PR TITLE
Fix broken link on Linux Bundle page

### DIFF
--- a/docs/guides/building/linux.md
+++ b/docs/guides/building/linux.md
@@ -70,3 +70,4 @@ If your app plays audio/video you need to enable `tauri.conf.json > tauri > bund
 [tauri-apps/tauri#1355]: https://github.com/tauri-apps/tauri/issues/1355
 [rust-lang/rust#57497]: https://github.com/rust-lang/rust/issues/57497
 [appimage guide]: https://docs.appimage.org/reference/best-practices.html#binaries-compiled-on-old-enough-base-system
+[fix-path-env-rs]: https://github.com/tauri-apps/fix-path-env-rs


### PR DESCRIPTION
It looks like the link was only partially copied over from the Mac Bundle page. This adds the missing link.

Linux:
![image](https://user-images.githubusercontent.com/113929/223224192-6cad627a-ef89-42f9-87c0-c95c22a6c650.png)

Mac:
![image](https://user-images.githubusercontent.com/113929/223224272-ff2938c1-8c09-40c7-997e-f4dbeb616d1e.png)
