### PR TITLE
Added information about the use of Cargo.toml if the version field

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -70,7 +70,7 @@ Type: `object`
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | <div className="anchor-with-padding" id="packageconfig.productname">`productName`<a class="hash-link" href="#packageconfig.productname"></a></div> | `string`? | _null_ | App name. |
-| <div className="anchor-with-padding" id="packageconfig.version">`version`<a class="hash-link" href="#packageconfig.version"></a></div> | `string`? | _null_ | App version. It is a semver version number or a path to a `package.json` file containing the `version` field. |
+| <div className="anchor-with-padding" id="packageconfig.version">`version`<a class="hash-link" href="#packageconfig.version"></a></div> | `string`? | _null_ | App version. It is a semver version number or a path to a `package.json` file containing the `version` field. If removed the version number from `Cargo.toml` is used. |
 
 
 ### TauriConfig


### PR DESCRIPTION
Saw this functionality mentioned in [#4643](https://github.com/tauri-apps/tauri/issues/4643) and figured I'd amend it.