### PR TITLE
Revert "doc: update install command to use secure curl, with fish-compatible pipe (#1153)"

### DIFF
--- a/blog/2023-03-01-create-tauri-app-version-3-released.mdx
+++ b/blog/2023-03-01-create-tauri-app-version-3-released.mdx
@@ -35,7 +35,7 @@ cargo install create-tauri-app
 cargo create-tauri-app --alpha
 
 # Bash
-curl https://create.tauri.app/sh | sh -s -- --alpha
+sh <(curl https://create.tauri.app/sh) --alpha
 
 # Powershell
 $env:CTA_ARGS="--alpha";iwr -useb https://create.tauri.app/ps | iex
@@ -147,7 +147,7 @@ cargo install create-tauri-app --version 2.8.0
 cargo create-tauri-app
 
 # Bash
-curl https://create.tauri.app/v/2.8.0/sh | sh
+sh <(curl https://create.tauri.app/v/2.8.0/sh)
 
 # Powershell
 iwr -useb https://create.tauri.app/v/2.8.0/ps | iex

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -24,7 +24,7 @@ export const CreateTauriApp = () => {
     <Tabs groupId="package-manager">
       <TabItem value="Bash">
         <CodeBlock className="language-shell" language="shell">
-          {`curl --proto '=https' --tlsv1.2 -sSf https://create.tauri.app/sh | sh`}
+          {`sh <(curl https://create.tauri.app/sh)`}
         </CodeBlock>
       </TabItem>
       <TabItem value="PowerShell">


### PR DESCRIPTION
This reverts commit 6e1deeeae9e6847ca97356f1e8f107d79ec0f284 because the new instructions don't work on macOS, we should look for a new instruction layout in the new docs to reintroduce this change for Linux users if possible.