### PR TITLE
Clarified command.md Passing Arguments case conversion

### DIFF
--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -70,11 +70,11 @@ fn my_custom_command(invoke_message: String) {
 }
 ```
 
-the corresponding JavaScript:
+The corresponding JavaScript:
+
 ```js
 invoke('my_custom_command', { invoke_message: 'Hello!' })
 ```
-
 
 ## Returning Data
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -59,6 +59,23 @@ invoke('my_custom_command', { invokeMessage: 'Hello!' })
 
 Arguments can be of any type, as long as they implement [`serde::Deserialize`].
 
+Please note, when declaring arguments in Rust using snake_case, the arguments are converted to camelCase for JavaScript.  
+To use snake_case in JavaScript, you have to declare it in the `tauri::command` statement:
+
+
+```rust
+#[tauri::command(rename_all = "snake_case")]
+fn my_custom_command(invoke_message: String) {
+  println!("I was invoked from JS, with this message: {}", invoke_message);
+}
+```
+
+the corresponding JavaScript:
+```js
+invoke('my_custom_command', { invoke_message: 'Hello!' })
+```
+
+
 ## Returning Data
 
 Command handlers can return data as well:

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -62,7 +62,6 @@ Arguments can be of any type, as long as they implement [`serde::Deserialize`].
 Please note, when declaring arguments in Rust using snake_case, the arguments are converted to camelCase for JavaScript.  
 To use snake_case in JavaScript, you have to declare it in the `tauri::command` statement:
 
-
 ```rust
 #[tauri::command(rename_all = "snake_case")]
 fn my_custom_command(invoke_message: String) {


### PR DESCRIPTION
Added clarification to the case conversion from snake_case (Rust) to camelCase (JavaScript) and an example how to use snake_case in JavaScript