### PR TITLE
Update NixOS requirements to include `librsvg`

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -189,6 +189,7 @@ When using [Nix Flakes], copy the following code into `flake.nix` on your reposi
           glib
           dbus
           openssl_3
+          librsvg
         ];
 
         packages = with pkgs; [
@@ -201,6 +202,7 @@ When using [Nix Flakes], copy the following code into `flake.nix` on your reposi
           gtk3
           libsoup
           webkitgtk
+          librsvg
         ];
       in
       {


### PR DESCRIPTION
I was creating a new project and at the end, I had a warning:
```
...
Template created!

Your system is missing dependencies (or they do not exist in $PATH):
╭───────┬──────────────────────────────────────────────────────────────────────────────────╮
│ rsvg2 │ Visit https://tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux │
╰───────┴──────────────────────────────────────────────────────────────────────────────────╯

Make sure you have installed the prerequisites for your OS: https://tauri.app/v1/guides/getting-started/prerequisites, then run:
...
```

This library was included in other distros, so I added it to my `shell.nix` and I created the project again, and that message wasn't displayed.
