### PR TITLE
Update next.js gettting-started since Next.js 13.3.0 now supports static export

### DIFF
--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -61,7 +61,7 @@ pnpm create next-app --use-pnpm --typescript
 
 2. _Experimental `app/` directory_  
    Next.js will ask you if you want to try the new and experimental `app/` directory.
-   > Next.js 23.3.0 now supports static exports with `next export`.
+   > Next.js 13.3.0 now supports static exports with `next export`.
 
 When starting or building the frontend, Next.js will look for a config file named `next.config.js` inside the project root.
 We want to customize this file to get the best compatibility with Tauri.

--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -60,7 +60,8 @@ pnpm create next-app --use-pnpm --typescript
    This will be the name of your project. It corresponds to the name of the folder this utility will create but has otherwise no effect on your app. You can use any name you want here.
 
 2. _Experimental `app/` directory_  
-   Next.js will ask you if you want to try the new and experimental `app/` directory. You must select `No` because it does not yet support the `next export` command.
+   Next.js will ask you if you want to try the new and experimental `app/` directory.
+   > Next.js 23.3.0 now supports static exports with `next export`.
 
 When starting or building the frontend, Next.js will look for a config file named `next.config.js` inside the project root.
 We want to customize this file to get the best compatibility with Tauri.


### PR DESCRIPTION
Since ~~23.0.0~~ 13.3.0, Next.js now supports static exports with `next export`.

Source: https://beta.nextjs.org/docs/app-directory-roadmap#configuration
Details: https://beta.nextjs.org/docs/configuring/static-export

We can now update the docs to reflect this change and let the user now that appDir is not a viable option