### PR TITLE
Include information about borrowed values in command.md

### DIFF
--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -190,7 +190,7 @@ When working with borrowed types, you have to make additional changes. These are
 *Example:*
 
 ```rust
-// Declare the constructor using String instead of &str, as &str is borrowed and thus unsupported
+// Declare the async function using String instead of &str, as &str is borrowed and thus unsupported
 #[tauri::command]
 async fn my_custom_command(value: String) {
   // Call another async function and wait for it to finish

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -164,6 +164,8 @@ It also gives you full control over the way your error type gets serialized. In 
 
 ## Async Commands
 
+Asynchornous functions are benefical in Tauri to perform heavy work in a manner that doesn't result in UI freezes or slowdowns.
+
 :::note
 
 Async commands are executed on a separate thread using [`async_runtime::spawn`].
@@ -171,13 +173,23 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 
 :::
 
+
+
+:::note
+
+You need to be careful when creating asynchornous functions using Tauri. Currently, you cannot include types that contain the & symbol (indicating they are borrowed) in the constructor of an asynchornous function. A common example of a type like this is _&str_.
+
+:::
+
+
 If your command needs to run asynchronously, simply declare it as `async`:
 
 ```rust
+// declare the constructor using String instead of &str, as &str is unsupported
 #[tauri::command]
-async fn my_custom_command() {
+async fn my_custom_command(value: String) {
   // Call another async function and wait for it to finish
-  let result = some_async_function().await;
+  let result = some_async_function(value).await;
   println!("Result: {}", result);
 }
 ```
@@ -185,7 +197,7 @@ async fn my_custom_command() {
 Since invoking the command from JS already returns a promise, it works just like any other command:
 
 ```js
-invoke('my_custom_command').then(() => console.log('Completed!'))
+invoke('my_custom_command', {value: "Hello, Async!"}).then(() => console.log('Completed!'))
 ```
 
 ## Accessing the Window in Commands

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -215,7 +215,9 @@ async fn my_custom_command(value: &str) -> Result<(), ()> {
 }
 ```
 
-**Invoking from JS:** Since invoking the command from JS already returns a promise, it works just like any other command:
+#### Invoking from JS
+
+Since invoking the command from JS already returns a promise, it works just like any other command:
 
 ```js
 invoke('my_custom_command', {value: "Hello, Async!"}).then(() => console.log('Completed!'))

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -176,7 +176,7 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 
 :::note
 
-You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot include types that are borrowed, such as those with the & symbol, in the constructor of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`.
+You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot include borrowed arguments in the signature of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`.
 
 :::
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -181,7 +181,7 @@ You need to be careful when creating asynchronous functions using Tauri. Current
 :::
 
 
-If your command needs to run asynchronously, simply declare it as `async`, and convert all borrowed types their non-borrowed counterparts:
+If your command needs to run asynchronously, simply declare it as `async`, and convert all borrowed types to their non-borrowed counterparts:
 
 ```rust
 // declare the constructor using String instead of &str, as &str is borrowed and thus unsupported

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -199,7 +199,7 @@ async fn my_custom_command(value: String) {
 }
 ```
 
-**Option 2**: Wrap the return type in a Result. This one is a bit harder to implement, but works for all types.
+**Option 2**: Wrap the return type in a Result. This one is a bit harder to implement, but should work for all types.
 
 If you have no return type, like in our function, use the return type `Result<(), ()>`. Otherwise, use the return type `Result<bool, ()>`, replacing `bool` with whatever type you wish to return.
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -220,7 +220,7 @@ async fn my_custom_command(value: &str) -> Result<(), ()> {
 Since invoking the command from JS already returns a promise, it works just like any other command:
 
 ```js
-invoke('my_custom_command', {value: "Hello, Async!"}).then(() => console.log('Completed!'))
+invoke('my_custom_command', { value: "Hello, Async!" }).then(() => console.log('Completed!'))
 ```
 
 ## Accessing the Window in Commands

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -185,7 +185,7 @@ If your command needs to run asynchronously, simply declare it as `async`.
 
 When working with borrowed types, you have to make additional changes. These are your two main options:
 
-**Option 1**: Convert the type, such as `&str` to a similar type that is not borrowed, such as `String`. This won't work for all types.
+**Option 1**: Convert the type, such as `&str` to a similar type that is not borrowed, such as `String`. This may not work for all types.
 
 *Example:*
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -174,7 +174,7 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 :::
 
 
-:::note
+:::warning
 
 You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot include borrowed arguments in the signature of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`.
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -192,26 +192,30 @@ When working with borrowed types, you have to make additional changes. These are
 ```rust
 // Declare the async function using String instead of &str, as &str is borrowed and thus unsupported
 #[tauri::command]
-async fn my_custom_command(value: String) {
+async fn my_custom_command(value: String) -> String {
   // Call another async function and wait for it to finish
-  let result = some_async_function(value).await;
-  println!("Result: {}", result);
+  some_async_function().await;
+  format!(value)
 }
 ```
 
 **Option 2**: Wrap the return type in a Result. This one is a bit harder to implement, but should work for all types.
 
-If you have no return type, like in our function, use the return type `Result<(), ()>`. Otherwise, use the return type `Result<bool, ()>`, replacing `bool` with whatever type you wish to return.
+Use the return type `Result<a, b>`, replacing `a` with whatever type you wish to return, or `()` if you wish to return no type, and replacing `b` with an error type to return if something goes wrong, or `()` if you wish to have no optional error returned. For example:
+
+- Result<String, ()> returns a String, and no error.
+- Result<(), ()> returns nothing.
+- Result<bool, Error> returing a boolean or a generic error if something goes wrong.
 
 *Example:*
 
 ```rust
-// Return a Result<(), ()> to bypass the borrowing issue
+// Return a Result<String, ()> to bypass the borrowing issue
 #[tauri::command]
-async fn my_custom_command(value: &str) -> Result<(), ()> {
+async fn my_custom_command(value: &str) -> Result<String, ()> {
   // Call another async function and wait for it to finish
-  let result = some_async_function(value).await;
-  println!("Result: {}", result);
+  some_async_function().await;
+  format!(value)
 }
 ```
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -173,21 +173,19 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 
 :::
 
+:::caution
 
-:::warning
-
-You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot include borrowed arguments in the signature of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`.
+You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot simply include borrowed arguments in the signature of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`. This limitation is tracked here: https://github.com/tauri-apps/tauri/issues/2533 and workarounds are shown below.
 
 :::
-
 
 If your command needs to run asynchronously, simply declare it as `async`.
 
 When working with borrowed types, you have to make additional changes. These are your two main options:
 
-**Option 1**: Convert the type, such as `&str` to a similar type that is not borrowed, such as `String`. This may not work for all types.
+**Option 1**: Convert the type, such as `&str` to a similar type that is not borrowed, such as `String`. This may not work for all types, for example `State<'_, Data>`.
 
-*Example:*
+_Example:_
 
 ```rust
 // Declare the async function using String instead of &str, as &str is borrowed and thus unsupported
@@ -199,15 +197,15 @@ async fn my_custom_command(value: String) -> String {
 }
 ```
 
-**Option 2**: Wrap the return type in a Result. This one is a bit harder to implement, but should work for all types.
+**Option 2**: Wrap the return type in a [`Result`]. This one is a bit harder to implement, but should work for all types.
 
-Use the return type `Result<a, b>`, replacing `a` with whatever type you wish to return, or `()` if you wish to return no type, and replacing `b` with an error type to return if something goes wrong, or `()` if you wish to have no optional error returned. For example:
+Use the return type `Result<a, b>`, replacing `a` with the type you wish to return, or `()` if you wish to return nothing, and replacing `b` with an error type to return if something goes wrong, or `()` if you wish to have no optional error returned. For example:
 
-- Result<String, ()> returns a String, and no error.
-- Result<(), ()> returns nothing.
-- Result<bool, Error> returing a boolean or a generic error if something goes wrong.
+- `Result<String, ()>` to return a String, and no error.
+- `Result<(), ()>` to return nothing.
+- `Result<bool, Error>` to return a boolean or an error as shown in the [Error Handling](#error-handling) section above.
 
-*Example:*
+_Example:_
 
 ```rust
 // Return a Result<String, ()> to bypass the borrowing issue
@@ -215,16 +213,19 @@ Use the return type `Result<a, b>`, replacing `a` with whatever type you wish to
 async fn my_custom_command(value: &str) -> Result<String, ()> {
   // Call another async function and wait for it to finish
   some_async_function().await;
-  format!(value)
+  // Note that the return value must be wrapped in `Ok()` now.
+  Ok(format!(value))
 }
 ```
 
 #### Invoking from JS
 
-Since invoking the command from JS already returns a promise, it works just like any other command:
+Since invoking the command from JavaScript already returns a promise, it works just like any other command:
 
 ```js
-invoke('my_custom_command', { value: "Hello, Async!" }).then(() => console.log('Completed!'))
+invoke('my_custom_command', { value: 'Hello, Async!' }).then(() =>
+  console.log('Completed!')
+)
 ```
 
 ## Accessing the Window in Commands
@@ -359,3 +360,4 @@ invoke('my_custom_command', {
 [`serde::serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 [`serde::deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
 [`thiserror`]: https://github.com/dtolnay/thiserror
+[`result`]: https://doc.rust-lang.org/std/result/index.html

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -1,4 +1,4 @@
-# Communication between Rust and the Frontend
+# Calling Rust from the frontend
 
 Tauri provides a simple yet powerful `command` system for calling Rust functions from your web app.
 Commands can accept arguments and return values. They can also return errors and be `async`.

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -181,9 +181,9 @@ You need to be careful when creating asynchronous functions using Tauri. Current
 :::
 
 
-If your command needs to run asynchronously, simply declare it as `async`, and resolve any issues with borrowed types.
+If your command needs to run asynchronously, simply declare it as `async`.
 
-When working with borrowed types, there are two main options.
+When working with borrowed types, you have to make additional changes. These are your two main options:
 
 **Option 1**: Convert the type, such as `&str` to a similar type that is not borrowed, such as `String`. This won't work for all types.
 

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -1,4 +1,4 @@
-# Calling Rust from the frontend
+# Communication between Rust and the Frontend
 
 Tauri provides a simple yet powerful `command` system for calling Rust functions from your web app.
 Commands can accept arguments and return values. They can also return errors and be `async`.
@@ -164,7 +164,7 @@ It also gives you full control over the way your error type gets serialized. In 
 
 ## Async Commands
 
-Asynchornous functions are benefical in Tauri to perform heavy work in a manner that doesn't result in UI freezes or slowdowns.
+Asynchronous functions are benefical in Tauri to perform heavy work in a manner that doesn't result in UI freezes or slowdowns.
 
 :::note
 
@@ -174,18 +174,17 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 :::
 
 
-
 :::note
 
-You need to be careful when creating asynchornous functions using Tauri. Currently, you cannot include types that contain the & symbol (indicating they are borrowed) in the constructor of an asynchornous function. A common example of a type like this is _&str_.
+You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot include types that contain the & symbol (indicating they are borrowed) in the constructor of an asynchronous function. A common example of a type like this is _&str_.
 
 :::
 
 
-If your command needs to run asynchronously, simply declare it as `async`:
+If your command needs to run asynchronously, simply declare it as `async`, and convert all borrowed types their non-borrowed counterparts:
 
 ```rust
-// declare the constructor using String instead of &str, as &str is unsupported
+// declare the constructor using String instead of &str, as &str is borrowed and thus unsupported
 #[tauri::command]
 async fn my_custom_command(value: String) {
   // Call another async function and wait for it to finish

--- a/docs/guides/features/command.md
+++ b/docs/guides/features/command.md
@@ -173,13 +173,13 @@ Commands without the _async_ keyword are executed on the main thread unless defi
 
 :::
 
+**If your command needs to run asynchronously, simply declare it as `async`.**
+
 :::caution
 
 You need to be careful when creating asynchronous functions using Tauri. Currently, you cannot simply include borrowed arguments in the signature of an asynchronous function. Some common examples of types like this are `&str` and `State<'_, Data>`. This limitation is tracked here: https://github.com/tauri-apps/tauri/issues/2533 and workarounds are shown below.
 
 :::
-
-If your command needs to run asynchronously, simply declare it as `async`.
 
 When working with borrowed types, you have to make additional changes. These are your two main options:
 


### PR DESCRIPTION
This pull request updates the part of command.md about asynchronous functions to include an important note about how borrowed values like &str are not allowed at present, and updates the code sample to include an example of using a String instead as a workaround.

Helps resolve `https://github.com/tauri-apps/tauri/issues/6733`.