### PR TITLE
Fix an error on the mobile version of next-js.mdx

### DIFF
--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -195,7 +195,7 @@ You can use `getStaticProps` to generate HTML/JavaScript pages at build time. Si
   }}
   beforeDevCommandExplination={{
     __html:
-      'Use <code>npm run dev</code> for this value. For mobile support use <code>npm run dev -- -h $HOST</code>.',
+      'Use <code>npm run dev</code> for this value. For mobile support use <code>npm run dev -- -H $HOST</code>.',
   }}
 />
 


### PR DESCRIPTION
Hi everyone,

On mobile with Next.JS, the command to use is not `npm run dev -- -h $HOST` but `npm run dev -- -H $HOST`