### PR TITLE
Update mocking.md: fixed sample code to avoid runtime type error

### DIFF
--- a/docs/guides/testing/mocking.md
+++ b/docs/guides/testing/mocking.md
@@ -31,12 +31,14 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-  //@ts-ignore
-  window.crypto = {
-    getRandomValues: function (buffer) {
-      return randomFillSync(buffer);
-    },
-  };
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // @ts-ignore      
+        getRandomValues: (buffer) => {
+          return randomFillSync(buffer);
+        },
+      },
+    });
 });
 
 
@@ -47,8 +49,6 @@ test("invoke simple", async () => {
            return (args.a as number) + (args.b as number);
         }
     })
-
-    expect(invoke("add", { a: 12, b: 15 })).resolves.toBe(27);
 });
 ```
 
@@ -64,12 +64,14 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-  //@ts-ignore
-  window.crypto = {
-    getRandomValues: function (buffer) {
-      return randomFillSync(buffer);
-    },
-  };
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // @ts-ignore      
+        getRandomValues: (buffer) => {
+          return randomFillSync(buffer);
+        },
+      },
+    });
 });
 
 
@@ -134,12 +136,14 @@ import { mockWindows } from '@tauri-apps/api/mocks';
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-  //@ts-ignore
-  window.crypto = {
-    getRandomValues: function (buffer) {
-      return randomFillSync(buffer);
-    },
-  }
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // @ts-ignore      
+        getRandomValues: (buffer) => {
+          return randomFillSync(buffer);
+        },
+      },
+    });
 });
 
 test('invoke', async () => {

--- a/docs/guides/testing/mocking.md
+++ b/docs/guides/testing/mocking.md
@@ -31,24 +31,24 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-    Object.defineProperty(window, 'crypto', {
-      value: {
-        // @ts-ignore      
-        getRandomValues: (buffer) => {
-          return randomFillSync(buffer);
-        },
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      // @ts-ignore      
+      getRandomValues: (buffer) => {
+        return randomFillSync(buffer);
       },
-    });
+    },
+  });
 });
 
 
 test("invoke simple", async () => {
-    mockIPC((cmd, args) => {
-        // simulated rust command called "add" that just adds two numbers
-        if(cmd === "add") {
-           return (args.a as number) + (args.b as number);
-        }
-    })
+  mockIPC((cmd, args) => {
+    // simulated rust command called "add" that just adds two numbers
+    if(cmd === "add") {
+      return (args.a as number) + (args.b as number);
+    }
+  });
 });
 ```
 
@@ -64,30 +64,30 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-    Object.defineProperty(window, 'crypto', {
-      value: {
-        // @ts-ignore      
-        getRandomValues: (buffer) => {
-          return randomFillSync(buffer);
-        },
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      // @ts-ignore      
+      getRandomValues: (buffer) => {
+        return randomFillSync(buffer);
       },
-    });
+    },
+  });
 });
 
 
 test("invoke", async () => {
-    mockIPC((cmd, args) => {
-        // simulated rust command called "add" that just adds two numbers
-        if(cmd === "add") {
-           return (args.a as number) + (args.b as number);
-        }
-    });
+  mockIPC((cmd, args) => {
+    // simulated rust command called "add" that just adds two numbers
+    if(cmd === "add") {
+      return (args.a as number) + (args.b as number);
+    }
+  });
 
-    // we can use the spying tools provided by vitest to track the mocked function
-    const spy = vi.spyOn(window, "__TAURI_IPC__");
+  // we can use the spying tools provided by vitest to track the mocked function
+  const spy = vi.spyOn(window, "__TAURI_IPC__");
 
-    expect(invoke("add", { a: 12, b: 15 })).resolves.toBe(27);
-    expect(spy).toHaveBeenCalled();
+  expect(invoke("add", { a: 12, b: 15 })).resolves.toBe(27);
+  expect(spy).toHaveBeenCalled();
 });
 ```
 
@@ -136,14 +136,14 @@ import { mockWindows } from '@tauri-apps/api/mocks';
 
 // jsdom doesn't come with a WebCrypto implementation
 beforeAll(() => {
-    Object.defineProperty(window, 'crypto', {
-      value: {
-        // @ts-ignore      
-        getRandomValues: (buffer) => {
-          return randomFillSync(buffer);
-        },
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      // @ts-ignore      
+      getRandomValues: (buffer) => {
+        return randomFillSync(buffer);
       },
-    });
+    },
+  });
 });
 
 test('invoke', async () => {


### PR DESCRIPTION
Updated sample code in documentation to avoid runtime type error 'Cannot set property' due to read-only window.crypto.

`window.crypto` appears to be read-only, so running this code throws a TypeError at runtime, as shown below:

![スクリーンショット 2023-04-29 3 11 01](https://user-images.githubusercontent.com/22065594/235228690-860381f1-47f6-471f-844c-18e006f35652.png)
https://www.typescriptlang.org/play?#code/PTAEEsFsAcHsCcAuoDe8CGA7AJrSAxcAGyIGUBPTAYwF9QAzePUAcivnOkVhYCheQoAAKIAzgFpwAc0wIAprwDu4HLEUA6dp26gAvKl6hQgkROmz4Co1LmIASllyQAauiIBXOaIBcoABQAlHoAfKg0vOFAA

While I handling to this issue in my project, I found `Object.defineProperty` can prevent this runtime error. How about this fix for the sample code?

