### PR TITLE
docs(guide): fix typo in installMode values

### DIFF
--- a/docs/guides/distribution/updater.md
+++ b/docs/guides/distribution/updater.md
@@ -81,7 +81,7 @@ On Windows there is an additional optional config [`"installMode"`](../../api/co
 ```
 
 - `"passive"`: There will be a small window with a progress bar. The update will be installed without requiring any user interaction. Generally recommended and the default mode.
-- `"basicUI"`: There will be a basic user interface shown which requires user interaction to finish the installation.
+- `"basicUi"`: There will be a basic user interface shown which requires user interaction to finish the installation.
 - `"quiet"`: There will be no progress feedback to the user. With this mode the installer cannot request admin privileges by itself so it only works in user-wide installations or when your app itself already runs with admin privileges. Generally not recommended.
 
 ## Update Artifacts


### PR DESCRIPTION
Just changed basicUi to match this:
https://github.com/tauri-apps/tauri/blob/b257bebf9e478d616690ba1c357dc7f071ea7b31/core/tauri-config-schema/schema.json#L2790

the api config is already correct.
https://tauri.app/v1/api/config/#windowsupdateinstallmode