### PR TITLE
Added link to the tauri cli for the 'Writing a Plugin' doc

### DIFF
--- a/docs/guides/features/plugin.md
+++ b/docs/guides/features/plugin.md
@@ -21,7 +21,7 @@ fn main() {
 
 Plugins are reusable extensions to the Tauri API that solve common problems. They are also a very convenient way to structure your code base!
 
-If you intend to share your plugin with others, we provide a ready-made template! With the Tauri's CLI installed just run:
+If you intend to share your plugin with others, we provide a ready-made template! With the Tauri's [CLI](https://tauri.app/v1/api/cli/) installed just run:
 
 <Command name="plugin init --name awesome" />
 

--- a/docs/guides/features/plugin.md
+++ b/docs/guides/features/plugin.md
@@ -21,7 +21,7 @@ fn main() {
 
 Plugins are reusable extensions to the Tauri API that solve common problems. They are also a very convenient way to structure your code base!
 
-If you intend to share your plugin with others, we provide a ready-made template! With the Tauri's [CLI](https://tauri.app/v1/api/cli/) installed just run:
+If you intend to share your plugin with others, we provide a ready-made template! With Tauri's [CLI](../../api/cli.md)installed just run:
 
 <Command name="plugin init --name awesome" />
 


### PR DESCRIPTION
I added a link to the CLI as a note for a very small DX improvement:
I was just using `cargo create-tauri-app` followed by `npm tauri ...` for the cli commands, to build my Tauri apps, so the command to create a plugin (via `cargo tauri`) in the docs failed. It took me a minute to realize that I didn't have `cargo tauri` installed.