### PR TITLE
Fix `cargo-xwin` installing command may not work for Linux

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -216,7 +216,13 @@ cargo install xwin
 Then you can use the `xwin` CLI to install the needed files to a location of your choice. Remember the location, we will need it in the next step. In this guide we will create a `.xwin` directory in the Home directory.
 
 ```sh
-xwin splat --disable-symlinks --output ~/.xwin
+xwin splat --output ~/.xwin
+```
+
+If that fails, you can try adding `--disable-symlinks` to the end.
+
+```sh
+xwin splat --output ~/.xwin --disable-symlinks
 ```
 
 Now, to make the Rust compiler use these files, you first have to create a `.cargo` directory in your project and create a `config.toml` file in it with the following content. Make sure to change the paths accordingly.

--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -219,7 +219,17 @@ Then you can use the `xwin` CLI to install the needed files to a location of you
 xwin splat --output ~/.xwin
 ```
 
-If that fails, you can try adding `--disable-symlinks` to the end.
+If that fails with an error message like this:
+
+```
+Error: failed to splat Microsoft.VC.14.29.16.10.CRT.x64.Desktop.base.vsix
+
+Caused by:
+    0: unable to symlink from .xwin/crt/lib/x86_64/LIBCMT.lib to libcmt.lib
+    1: File exists (os error 17)
+```
+
+Note that this might be a bug of `xwin` CLI. A workaround is to add `--disable-symlinks` to the command:
 
 ```sh
 xwin splat --output ~/.xwin --disable-symlinks

--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -229,7 +229,7 @@ Caused by:
     1: File exists (os error 17)
 ```
 
-Note that this might be a bug of `xwin` CLI. A workaround is to add `--disable-symlinks` to the command:
+you can try adding the `--disable-symlinks` flag to the command:
 
 ```sh
 xwin splat --output ~/.xwin --disable-symlinks


### PR DESCRIPTION
Linking issue: https://github.com/tauri-apps/tauri/issues/7004