### PR TITLE
Update math calc on eco impact table

### DIFF
--- a/blog/2022-06-19-tauri-1-0.mdx
+++ b/blog/2022-06-19-tauri-1-0.mdx
@@ -73,7 +73,7 @@ To illustrate this, we compiled some numbers on the ecological impact of your ap
 | 200 MB   | 16 seconds          | 10,000,000 | 2 PB    | 5 years              | 200,000               | 120,000            | 720,000         |
 | 600 MB   | 48 seconds          | 1,000      | 0.6 TB  | 13 hours             | 60                    | 36                 | 216             |
 | 600 MB   | 48 seconds          | 100,000    | 60 TB   | 54.2 days            | 6,000                 | 3,600              | 21,600          |
-| 600 MB   | 48 seconds          | 10,000,000 | 5.6 PB  | 14.8 years           | 600,000               | 360,000            | 2,160,000       |
+| 600 MB   | 48 seconds          | 10,000,000 | 6 PB    | 14.8 years           | 600,000               | 360,000            | 2,160,000       |
 
 <figcaption>
 

--- a/blog/2022-06-19-tauri-1-0.mdx
+++ b/blog/2022-06-19-tauri-1-0.mdx
@@ -71,9 +71,9 @@ To illustrate this, we compiled some numbers on the ecological impact of your ap
 | 200 MB   | 16 seconds          | 1,000      | 200 GB  | 4.45 hours           | 20                    | 12                 | 72              |
 | 200 MB   | 16 seconds          | 100,000    | 20 TB   | 18.5 days            | 2,000                 | 1,200              | 7,200           |
 | 200 MB   | 16 seconds          | 10,000,000 | 2 PB    | 5 years              | 200,000               | 120,000            | 720,000         |
-| 600 MB   | 48 seconds          | 1,000      | 60 TB   | 13 hours             | 60                    | 36                 | 216             |
-| 600 MB   | 48 seconds          | 100,000    | 6 PB    | 54.2 days            | 6,000                 | 3,600              | 21,600          |
-| 600 MB   | 48 seconds          | 10,000,000 | 0.6 EB  | 14.8 years           | 600,000               | 360,000            | 2,160,000       |
+| 600 MB   | 48 seconds          | 1,000      | 0.6 TB  | 13 hours             | 60                    | 36                 | 216             |
+| 600 MB   | 48 seconds          | 100,000    | 60 TB   | 54.2 days            | 6,000                 | 3,600              | 21,600          |
+| 600 MB   | 48 seconds          | 10,000,000 | 5.6 PB  | 14.8 years           | 600,000               | 360,000            | 2,160,000       |
 
 <figcaption>
 


### PR DESCRIPTION
Updated to correct rounded estimates on memory size based on app downloads for the ecological impact table