### PR TITLE
[fix] Arch dependencies on prerequisites docs page 

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -119,7 +119,7 @@ sudo apt install libwebkit2gtk-4.0-dev \
 ```sh
 sudo pacman -Syu
 sudo pacman -S --needed \
-    webkit2gtk \
+    webkit2gtk-4.1 \
     base-devel \
     curl \
     wget \


### PR DESCRIPTION
Compiling Tauri apps fail on Arch, when following the current dependencies guide within the documentation. 

This PR fixes that by replacing the faulty `webkit2gtk` with the expected `webkit2gtk-4.1` within the pacman install command. 