### PR TITLE
Use libappindicator-gtk3-devel in fedora prereqs

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -140,7 +140,7 @@ sudo dnf install webkit2gtk4.0-devel \
     openssl-devel \
     curl \
     wget \
-    libappindicator-gtk3 \
+    libappindicator-gtk3-devel \
     librsvg2-devel
 sudo dnf group install "C Development Tools and Libraries"
 ```


### PR DESCRIPTION
not 100% sure if it's actually needed but we use the dev package in the other distros too and there were users having issues with this package.