### PR TITLE
fix(selenium): do not use localhost in server URL

### DIFF
--- a/docs/guides/testing/webdriver/example/selenium.md
+++ b/docs/guides/testing/webdriver/example/selenium.md
@@ -156,7 +156,7 @@ before(async function () {
   // start the webdriver client
   driver = await new Builder()
     .withCapabilities(capabilities)
-    .usingServer('http://localhost:4444/')
+    .usingServer('http://127.0.0.1:4444/')
     .build()
 })
 


### PR DESCRIPTION
By default, [most Windows environments resolve `localhost` to the IPv6 loopback address, `::1`](https://superuser.com/questions/668004/why-is-my-localhost-not-127-0-0-1-but-1-and-what-notation-is-that). However, the tauri-driver proxy server [creates a listen socket bound to the first IPv4 loopback address, `127.0.0.1`](https://github.com/tauri-apps/tauri/blob/3065c8aea375535763e1532951c4057a426fce80/tooling/webdriver/src/server.rs#L166). This address mismatch has caused the example test harness to fail to connect to tauri-driver for at least one Discord user. Let's remove the name resolution from the equation to make the example less flaky.