### PR TITLE
Update Troubleshooting part of prerequisites.md

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -356,7 +356,7 @@ rustup self uninstall
 
 ## Troubleshooting
 
-To check whether you have Rust installed correctly, open a shell and enter this command:
+To check whether you have Rust installed correctly, close your shell and open new one for the `.rustup` to be taken in consideration. Then enter this command:
 
 ```shell
 rustc --version


### PR DESCRIPTION
changes: in Troubleshooting, precising that the terminal should be closed an an other one should be used in order to check if Rust is installed correctly with the rustc --version command