### PR TITLE
Fixed link to tauri-bundler

### DIFF
--- a/blog/2023-06-14-tauri-1-4.mdx
+++ b/blog/2023-06-14-tauri-1-4.mdx
@@ -92,7 +92,7 @@ Starting on v1.4.0, our changelog format has been improved. Check out the entire
 
 - [tauri](https://github.com/tauri-apps/tauri/releases/tag/tauri-v1.4.0)
 - [tauri-cli](https://github.com/tauri-apps/tauri/releases/tag/tauri-cli-v1.4.0)
-- [tauri-bundler](https://github.com/tauri-apps/tauri/releases/tag/tauri-bundler-v1.4.0)
+- [tauri-bundler](https://github.com/tauri-apps/tauri/releases/tag/tauri-bundler-v1.3.0)
 
 ## Audit
 


### PR DESCRIPTION
The url to the tauri-bundler was broken, as it pointed to a non-existing v1.4 release. As @lorenzolewis suggested, the url has been updated to point to the v1.3 release instead