### PR TITLE
Fixes for non-main ref in translation status page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
 				twitter: 'https://twitter.com/TauriApps',
 				mastodon: 'https://fosstodon.org/@TauriApps',
 			},
+			// TODO: Be sure this is updated when the branch is switched
 			editLink: {
 				baseUrl: 'https://github.com/tauri-apps/tauri-docs/edit/next',
 			},

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
 				mastodon: 'https://fosstodon.org/@TauriApps',
 			},
 			editLink: {
-				baseUrl: 'https://github.com/tauri-apps/tauri-docs/edit/starlight',
+				baseUrl: 'https://github.com/tauri-apps/tauri-docs/edit/next',
 			},
 			customCss: ['./src/styles/custom.css'],
 			sidebar: [

--- a/packages/i18n-tracker/build.ts
+++ b/packages/i18n-tracker/build.ts
@@ -13,6 +13,7 @@ const translationStatusBuilder = new TranslationStatusBuilder({
 		.filter((loc) => loc.lang !== 'en')
 		.reduce((acc, curr) => ({ [curr.lang]: curr.label, ...acc }), {}),
 	githubRepo: process.env.GITHUB_REPOSITORY || 'tauri-apps/tauri-docs',
+	gitHubRef: 'next',
 	githubToken: process.env.GITHUB_TOKEN,
 });
 

--- a/packages/i18n-tracker/lib/translation-status/builder.ts
+++ b/packages/i18n-tracker/lib/translation-status/builder.ts
@@ -38,6 +38,7 @@ export class TranslationStatusBuilder {
 		targetLanguages: string[];
 		languageLabels: { [key: string]: string };
 		githubRepo: string;
+		gitHubRef: string;
 		githubToken?: string | undefined;
 	}) {
 		this.pageSourceDir = config.pageSourceDir;
@@ -46,6 +47,7 @@ export class TranslationStatusBuilder {
 		this.targetLanguages = config.targetLanguages;
 		this.languageLabels = config.languageLabels;
 		this.githubRepo = config.githubRepo;
+		this.githubRef = config.gitHubRef;
 		this.githubToken = config.githubToken ?? '';
 		this.git = simpleGit({
 			maxConcurrentProcesses: Math.max(2, Math.min(32, os.cpus().length)),
@@ -58,6 +60,7 @@ export class TranslationStatusBuilder {
 	readonly targetLanguages;
 	readonly languageLabels;
 	readonly githubRepo;
+	readonly githubRef;
 	readonly githubToken;
 	readonly git;
 
@@ -252,7 +255,6 @@ export class TranslationStatusBuilder {
 
 	getPageUrl({
 		type = 'blob',
-		refName = 'main',
 		lang,
 		subpath,
 		query = '',
@@ -263,9 +265,9 @@ export class TranslationStatusBuilder {
 		subpath: string;
 		query?: string;
 	}) {
-		const noDotSrcDir = this.pageSourceDir.replace(/^\.+\//, '');
+		const noDotSrcDir = this.pageSourceDir.replaceAll(/\.+\//g, '');
 		const isSrcLang = lang === this.sourceLanguage;
-		return `https://github.com/${this.githubRepo}/${type}/${refName}/${noDotSrcDir}${
+		return `https://github.com/${this.githubRepo}/${type}/${this.githubRef}/${noDotSrcDir}${
 			isSrcLang ? '' : `/${lang}`
 		}/${subpath}${query}`;
 	}
@@ -427,7 +429,9 @@ export class TranslationStatusBuilder {
 	 */
 	renderCreatePageButton(lang: string, filename: string): string {
 		// We include `lang` twice because GitHub eats the last path segment when setting filename.
-		const createUrl = new URL(`https://github.com/${this.githubRepo}/new/main/src/content/docs`);
+		const createUrl = new URL(
+			`https://github.com/${this.githubRepo}/new/${this.githubRef}/src/content/docs`
+		);
 		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\ntitle:\ndescription:\n---\n');
 		return this.renderLink(createUrl.href, `Create\xa0page\xa0+`, 'create-button');


### PR DESCRIPTION
@dklassic would you be able to test the contributing page now to make sure all the links work as expected? We won't really be able to test the "Translations that need reviews" section until we cross that path, but I think this should resolve all the broken links I hit yesterday during the call.

Might still be a few weird things around CI, but I'll fix that separately because it won't impact the i18n flow