### PR TITLE
Add Upgrade Badge

### DIFF
--- a/src/components/UpgradeBadge.astro
+++ b/src/components/UpgradeBadge.astro
@@ -1,0 +1,36 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { Icon } from '@astrojs/starlight/components';
+
+// Use the `href` prop to link to the respective page
+interface Props extends HTMLAttributes<'a'> {}
+---
+
+<div>
+  <a class="not-content" {...Astro.props}>Tauri 1.0 Upgrade Guide <Icon name="rocket" /></a>
+</div>
+
+<style>
+  div {
+    display: inline-block;
+  }
+
+  a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px solid var(--sl-color-orange-low);
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    box-shadow: var(--sl-shadow-sm);
+    color: var(--sl-color-gray-1) !important;
+    font-weight: 600;
+    line-height: var(--sl-line-height-headings);
+  }
+
+  a:hover {
+    background: var(--sl-color-orange-low);
+    border-color: var(--sl-color-orange-high);
+  }
+</style>


### PR DESCRIPTION
Used to consistently point people in the right direction for 1.0 upgrade paths

Default state:
<img width="384" alt="Screenshot 2023-08-10 at 20 35 44" src="https://github.com/tauri-apps/tauri-docs/assets/15347255/51887307-cd2d-4d78-9aee-8bbb33c2bda5">

Hover state:
<img width="314" alt="Screenshot 2023-08-10 at 20 35 50" src="https://github.com/tauri-apps/tauri-docs/assets/15347255/3224b02f-97f0-4d02-851f-1c417bb91517">

Pass the `href` prop to link to the respective section in the upgrade guide
