### PR TITLE
Smooth transition from hero to page background

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -165,6 +165,14 @@
 		256px 256px;
 }
 
+/* Transition hero background grid smoothly to page background color. */
+.hero-bg::after {
+	content: '';
+	position: absolute;
+	inset: 70% 0 0;
+	background: linear-gradient(transparent, var(--sl-color-bg));
+}
+
 .hero > img {
 	opacity: 0.3;
 	animation: 3s intro;


### PR DESCRIPTION
This PR adds a linear gradient to the bottom of the landing page hero section to smooth over the transition from the grid pattern to the solid color of the rest of the page.

| Before | After |
|--------|--------|
| <img width="1272" alt="image" src="https://github.com/tauri-apps/tauri-docs/assets/357379/e85c2506-c502-4132-b3fb-38e6bd35bd6a"> | <img width="1270" alt="image" src="https://github.com/tauri-apps/tauri-docs/assets/357379/00cb828f-947a-4d14-a0b0-e0fd675f348a"> |

Currently the gradient is over the bottom 30% of the hero, but this could be tweaked to more or less to match preferences.