### PR TITLE
Add set up installations for Enterprise Linux distributions (RHEL)

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -151,7 +151,7 @@ sudo dnf group install "C Development Tools and Libraries"
 Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `webkit2gtk3-devel`.
 
   </TabItem>
-    <TabItem value="rhel" label="Enterprise Linux (Redhat, Alma, Rocky, CentOS)">
+    <TabItem value="rhel" label="Enterprise Linux">
 
 ```sh
 sudo dnf check-update
@@ -164,7 +164,7 @@ sudo dnf install webkit2gtk3-devel \
     librsvg2-devel
 sudo dnf group install "Development Tools"
 ```
-
+This includes Redhat Enterprise Linux, and all its downstreams such as Alma Linux, Rocky Linux, and a few others.
   </TabItem>
   <TabItem value="gentoo" label="Gentoo">
 

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -136,7 +136,7 @@ sudo pacman -S --needed \
   </TabItem>
   <TabItem value="fedora" label="Fedora/Redhat">
 
-```sh
+```sh title=Fedora
 sudo dnf check-update
 sudo dnf install webkit2gtk4.0-devel \
     openssl-devel \
@@ -148,9 +148,9 @@ sudo dnf install webkit2gtk4.0-devel \
 sudo dnf group install "C Development Tools and Libraries"
 ```
 
-Note that for Fedora 36 and below, and all Enterprise Linux Distributions, use a older package called `webkit2gtk3-devel` instead of `webkit2gtk4.0-devel`.
-For Enterprise Linux, use "Development Tools" instead of "C Development Tools and Libraries. For example:
-```sh
+Note that for Fedora 36 and below, and all Enterprise Linux Distributions, you need to install `webkit2gtk3-devel` instead of `webkit2gtk4.0-devel`.
+For Enterprise Linux, you also need `"Development Tools"` instead of `"C Development Tools and Libraries"`. For example:
+```sh title="Enterprise Linux"
 sudo dnf check-update
 sudo dnf install webkit2gtk3-devel \
     openssl-devel \

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -134,7 +134,7 @@ sudo pacman -S --needed \
 ```
 
   </TabItem>
-  <TabItem value="fedora" label="Fedora/REHL">
+  <TabItem value="fedora" label="Fedora/RHEL">
 
 ```sh title=Fedora
 sudo dnf check-update

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -134,7 +134,7 @@ sudo pacman -S --needed \
 ```
 
   </TabItem>
-  <TabItem value="fedora" label="Fedora">
+  <TabItem value="fedora" label="Fedora/Redhat">
 
 ```sh
 sudo dnf check-update
@@ -148,11 +148,8 @@ sudo dnf install webkit2gtk4.0-devel \
 sudo dnf group install "C Development Tools and Libraries"
 ```
 
-Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `webkit2gtk3-devel`.
-
-  </TabItem>
-    <TabItem value="rhel" label="Enterprise Linux">
-
+Note that for Fedora 36 and below, and all Enterprise Linux Distributions, use a older package called `webkit2gtk3-devel` instead of `webkit2gtk4.0-devel`.
+For Enterprise Linux, use "Development Tools" instead of "C Development Tools and Libraries. For example:
 ```sh
 sudo dnf check-update
 sudo dnf install webkit2gtk3-devel \
@@ -164,7 +161,7 @@ sudo dnf install webkit2gtk3-devel \
     librsvg2-devel
 sudo dnf group install "Development Tools"
 ```
-This includes Redhat Enterprise Linux, and all its downstreams such as Alma Linux, Rocky Linux, and a few others.
+
   </TabItem>
   <TabItem value="gentoo" label="Gentoo">
 

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -134,7 +134,7 @@ sudo pacman -S --needed \
 ```
 
   </TabItem>
-  <TabItem value="fedora" label="Fedora/Redhat">
+  <TabItem value="fedora" label="Fedora/REHL">
 
 ```sh title=Fedora
 sudo dnf check-update

--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -151,6 +151,21 @@ sudo dnf group install "C Development Tools and Libraries"
 Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `webkit2gtk3-devel`.
 
   </TabItem>
+    <TabItem value="rhel" label="Enterprise Linux (Redhat, Alma, Rocky, CentOS)">
+
+```sh
+sudo dnf check-update
+sudo dnf install webkit2gtk3-devel \
+    openssl-devel \
+    curl \
+    wget \
+    file \
+    libappindicator-gtk3-devel \
+    librsvg2-devel
+sudo dnf group install "Development Tools"
+```
+
+  </TabItem>
   <TabItem value="gentoo" label="Gentoo">
 
 ```sh


### PR DESCRIPTION
Minor PR:
Redhat Enterprise Linux 9 and before use a Fedora version <36, (based on Fedora 34), so this is a minor PR that adds clarity for those that are not using Fedora and instead using RHEL/ one of its downstreams.

Basically the Fedora one copied over, but changed the name of C Development tool to "Development Tools" and defaulted to webkit2-3. 