### PR TITLE
Add feature/guide/recipe list page and component

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -85,7 +85,7 @@ export default defineConfig({
 				},
 				{
 					label: 'Features & Recipes',
-					link: '2/recipe',
+					link: '2/guide/list',
 				},
 				{
 					label: 'References',

--- a/src/components/list/Community.astro
+++ b/src/components/list/Community.astro
@@ -1,0 +1,24 @@
+---
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+type Entry = {
+  name: string;
+  description: string;
+  href: string;
+};
+
+const list: Entry[] = [
+  {
+    name: 'Have something to share?',
+    description: 'Open a pull request to show us your amazing resource',
+    href: 'https://github.com/tauri-apps/tauri-docs/pulls',
+  },
+];
+---
+
+<CardGrid>
+  {
+    list
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((item) => <LinkCard title={item.name} href={item.href} description={item.description} />)
+  }
+</CardGrid>

--- a/src/components/list/Guides.astro
+++ b/src/components/list/Guides.astro
@@ -1,0 +1,37 @@
+---
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+const entries = [
+  '2/guide/authenticator',
+  '2/guide/autostart',
+  '2/guide/localhost',
+  '2/guide/persisted-scope',
+  '2/guide/positioner',
+  '2/guide/single-instance',
+  '2/guide/sql',
+  '2/guide/store',
+  '2/guide/stronghold',
+  '2/guide/upload',
+  '2/guide/websocket',
+  '2/guide/window-state',
+];
+
+const list = (await Promise.all(
+  entries.flatMap((entry) => getEntry('docs', entry))
+)) as CollectionEntry<'docs'>[];
+---
+
+<CardGrid>
+  {
+    list
+      .sort((a, b) => a.data.title.localeCompare(b.data.title))
+      .map((item) => (
+        <LinkCard
+          title={item.data.title}
+          href={`/${item.slug}`}
+          description={item.data.description}
+        />
+      ))
+  }
+</CardGrid>

--- a/src/components/list/Recipes.astro
+++ b/src/components/list/Recipes.astro
@@ -1,0 +1,24 @@
+---
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+const entries = ['2/guide/recipe/stub'];
+
+const list = (await Promise.all(
+  entries.flatMap((entry) => getEntry('docs', entry))
+)) as CollectionEntry<'docs'>[];
+---
+
+<CardGrid>
+  {
+    list
+      .sort((a, b) => a.data.title.localeCompare(b.data.title))
+      .map((item) => (
+        <LinkCard
+          title={item.data.title}
+          href={`/${item.slug}`}
+          description={item.data.description}
+        />
+      ))
+  }
+</CardGrid>

--- a/src/content/docs/2/guide/authenticator.mdx
+++ b/src/content/docs/2/guide/authenticator.mdx
@@ -1,0 +1,8 @@
+---
+title: Authenticator
+description: Interface with hardware security keys.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/autostart.mdx
+++ b/src/content/docs/2/guide/autostart.mdx
@@ -1,0 +1,8 @@
+---
+title: Autostart
+description: Automatically launch your app at system startup.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/list.mdx
+++ b/src/content/docs/2/guide/list.mdx
@@ -1,0 +1,33 @@
+---
+title: List of Features & Recipes
+---
+
+import GuideList from '@components/list/Guides.astro';
+import RecipeList from '@components/list/Recipes.astro';
+import CommunityList from '@components/list/Community.astro';
+
+Tauri comes with extensibility in mind. On this page you'll find:
+
+- **[Features](#features)**: Built-in Tauri features and functionality
+- **[Recipes](#recipes)**: Common usages that build on top of features
+- **[Community Resources](#community-resources)**: More plugins and recipes built by the Tauri community
+
+{/* TODO: Search bar component that syncs/filters across this whole list */}
+
+## Features
+
+<GuideList />
+
+## Recipes
+
+<RecipeList />
+
+## Community Resources
+
+<CommunityList />
+
+:::tip[Have something cool to share?]
+
+If you've created a plugin, guide, or recipe we'd love to have it included here! [Submit a pull request](https://github.com/tauri-apps/tauri-docs/pulls) to add it to this page.
+
+:::

--- a/src/content/docs/2/guide/localhost.mdx
+++ b/src/content/docs/2/guide/localhost.mdx
@@ -1,0 +1,8 @@
+---
+title: Localhost
+description: Use a localhost server in production apps.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/log.mdx
+++ b/src/content/docs/2/guide/log.mdx
@@ -1,0 +1,8 @@
+---
+title: Log
+description: Configurable logging.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/persisted-scope.mdx
+++ b/src/content/docs/2/guide/persisted-scope.mdx
@@ -1,0 +1,8 @@
+---
+title: Persisted Scope
+description: Persist runtime scope changes on the filesystem.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/positioner.mdx
+++ b/src/content/docs/2/guide/positioner.mdx
@@ -1,0 +1,8 @@
+---
+title: Positioner
+description: Move windows to common locations.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/recipe/stub.mdx
+++ b/src/content/docs/2/guide/recipe/stub.mdx
@@ -1,0 +1,8 @@
+---
+title: No recipes yet
+description: Stay tuned while we work on some delicious recipes.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/single-instance.mdx
+++ b/src/content/docs/2/guide/single-instance.mdx
@@ -1,0 +1,8 @@
+---
+title: Single Instance
+description: Ensure a single instance of your tauri app is running.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/sql.mdx
+++ b/src/content/docs/2/guide/sql.mdx
@@ -1,0 +1,8 @@
+---
+title: SQL
+description: Interface with SQL databases.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/store.mdx
+++ b/src/content/docs/2/guide/store.mdx
@@ -1,0 +1,8 @@
+---
+title: Store
+description: Persistent key value storage.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/stronghold.mdx
+++ b/src/content/docs/2/guide/stronghold.mdx
@@ -1,0 +1,8 @@
+---
+title: Stronghold
+description: Encrypted, secure database.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/upload.mdx
+++ b/src/content/docs/2/guide/upload.mdx
@@ -1,0 +1,8 @@
+---
+title: Upload
+description: File uploads through HTTP.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/websocket.mdx
+++ b/src/content/docs/2/guide/websocket.mdx
@@ -1,0 +1,8 @@
+---
+title: Websocket
+description: Open a WebSocket connection using a Rust client in JavaScript.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/2/guide/window-state.mdx
+++ b/src/content/docs/2/guide/window-state.mdx
@@ -1,0 +1,8 @@
+---
+title: Window State
+description: Persist window sizes and positions.
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />


### PR DESCRIPTION
Created a landing page to hold the list of all plugins/features, recipes, and community contributions (https://deploy-preview-1384--tauri-docs-starlight.netlify.app/2/guide/list/).

In the future I'd love to add in a search bar for client-side filtering, but keeping it simple for now.

Not exactly sure how this will behave with i18n and fallbacks, so might need to keep that in mind once we get some first transition tests in.