### PR TITLE
Update gentoo webkit-gtk package slot: 4 => 4.1

### DIFF
--- a/src/content/docs/2/guide/prerequisites/index.mdx
+++ b/src/content/docs/2/guide/prerequisites/index.mdx
@@ -80,7 +80,7 @@ sudo dnf group install "C Development Tools and Libraries"
 
 ```sh
 sudo emerge --ask \
-  net-libs/webkit-gtk:4 \
+  net-libs/webkit-gtk:4.1 \
   dev-libs/libappindicator \
   net-misc/curl \
   net-misc/wget \


### PR DESCRIPTION
Fix outdated package version (for Gentoo only)

With webkit4.0 installed I get this error:
```
error: could not find system library 'webkit2gtk-4.1' required by the 'webkit2gtk-sys' crate
```