### PR TITLE
Update gentoo webkit-gtk package slot: 4 => 4.1

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -155,7 +155,7 @@ Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `w
 
 ```sh
 sudo emerge --ask \
-    net-libs/webkit-gtk:4 \
+    net-libs/webkit-gtk:4.1 \
     dev-libs/libappindicator \
     net-misc/curl \
     net-misc/wget \

--- a/i18n/fr/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
@@ -151,7 +151,7 @@ Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `w
 
 ```sh
 sudo emerge --ask \
-    net-libs/webkit-gtk:4 \
+    net-libs/webkit-gtk:4.1 \
     dev-libs/libappindicator \
     net-misc/curl \
     net-misc/wget

--- a/i18n/it/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
@@ -151,7 +151,7 @@ Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `w
 
 ```sh
 sudo emerge --ask \
-    net-libs/webkit-gtk:4 \
+    net-libs/webkit-gtk:4.1 \
     dev-libs/libappindicator \
     net-misc/curl \
     net-misc/wget

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
@@ -151,7 +151,7 @@ Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `w
 
 ```sh
 sudo emerge --ask \
-    net-libs/webkit-gtk:4 \
+    net-libs/webkit-gtk:4.1 \
     dev-libs/libappindicator \
     net-misc/curl \
     net-misc/wget

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/getting-started/prerequisites.md
@@ -151,7 +151,7 @@ Note that on Fedora 36 and below the `webkit2gtk4.0-devel` package was called `w
 
 ```sh
 sudo emerge --ask \
-    net-libs/webkit-gtk:4 \
+    net-libs/webkit-gtk:4.1 \
     dev-libs/libappindicator \
     net-misc/curl \
     net-misc/wget


### PR DESCRIPTION
Fix outdated package version (for Gentoo only)

With webkit4.0 installed I get this error:
```
error: could not find system library 'webkit2gtk-4.1' required by the 'webkit2gtk-sys' crate
```