### PR TITLE
feat: added `fr` translation for "Why Tauri?" page

### DIFF
--- a/src/content/docs/fr/2/guide/index.mdx
+++ b/src/content/docs/fr/2/guide/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Pourquoi Tauri ?
+description:
+---
+
+import { Card } from '@astrojs/starlight/components';
+import Stub from '@components/Stub.astro';
+
+<Stub />
+
+:::caution[Logiciel en Pré-sortie]
+Cette documentation concerne la version en pré-sortie de Tauri 2.0 et est susceptible de changer au fur et à mesure que le développement se poursuit. Si vous recherchez la documentation de Tauri 1.0, visitez https://tauri.app.
+:::
+
+<Card title="Prochaines Étapes" icon="rocket">
+	Préparez-vous à créer un projet Tauri en installant les
+	[prérequis](/2/guide/prerequisites).
+</Card>
+
+<Card title="Ressources Supplémentaires" icon="document">
+
+- 🎥 [Tauri en 100 Secondes](https://www.youtube.com/watch?v=-X8evddpu7M), Fireship (YouTube)
+  {/* - 🎧 [Podcast] */}
+  {/* - 📝 [Article] */}
+
+</Card>

--- a/src/content/docs/fr/2/guide/index.mdx
+++ b/src/content/docs/fr/2/guide/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Pourquoi Tauri ?
-description:
 ---
 
 import { Card } from '@astrojs/starlight/components';


### PR DESCRIPTION
> [!NOTE]  
> This is a test commit to see how the pr workflow would look like and should not be merged.
> 
> This Pull Request is powered by GPT-4 to provide a French translation of "Why Tauri?" page.

I've translated "Why Tauri?" page for `fr`.

I'm not sure if the English video "Tauri in 100 Seconds" from the source page should be translated into "Tauri en 100 Secondes" or not. Maybe I should leave it as "Tauri in 100 Seconds (Vidéo en anglais)".

> Need places to mention page (how? by name and/or by path?) and target language.
> Need a place to mention concerns about the translation to ask for feedback.

Extra notes:
- How should the title be formatted? and again, how should the source page be reference in title?
- Should pr be enforced to be written in English? or is it okay to write entirely in target language?
- How to ask for review from locale specific reviewer?
- What is the `description:` for? The source text doesn't seem to have it.
- Is translator allowed to swap out resources to a more locale specific choice? e.g. a French video explaining Tauri in this case.