### PR TITLE
feat: added examples-generator

### DIFF
--- a/packages/examples-generator/build.ts
+++ b/packages/examples-generator/build.ts
@@ -1,0 +1,18 @@
+import { join, dirname } from 'node:path';
+import { readdirSync, writeFileSync, readFileSync, mkdir } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const rootPath = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const examplesPath = join(rootPath, 'packages', 'tauri', 'examples');
+const examplesOutputPath = join(rootPath, 'src', 'content', 'docs', '2', 'example');
+
+async function main() {
+	console.log('Copying examples', examplesPath);
+	for (const example of readdirSync(examplesPath, { withFileTypes: true })) {
+		if (example.name.startsWith('.') || example.isFile()) continue;
+		const sourcePath = join(examplesPath, example.name, 'README.md');
+		const outPath = join(examplesOutputPath, example.name) + '.md';
+		writeFileSync(outPath, readFileSync(sourcePath, 'utf-8'));
+	}
+}
+main();

--- a/packages/examples-generator/package.json
+++ b/packages/examples-generator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "examples-generator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsm ./build.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "tsm": "^2.3.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
         specifier: ^0.14.3
         version: 0.14.3
 
+  packages/examples-generator:
+    dependencies:
+      tsm:
+        specifier: ^2.3.0
+        version: 2.3.0
+
   packages/i18n-tracker:
     devDependencies:
       '@types/html-escaper':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - 'packages/examples-generator'
   - 'packages/i18n-tracker'
   - 'packages/js-api-generator'
   - 'packages/tauri-typedoc-theme'

--- a/src/components/list/Examples.astro
+++ b/src/components/list/Examples.astro
@@ -1,0 +1,36 @@
+---
+import { join, dirname } from 'node:path';
+import { readdirSync, writeFileSync, readFileSync, mkdir } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+type Entry = {
+	name: string;
+	description: string;
+	href: string;
+};
+
+const list: Entry[] = [];
+
+const rootPath = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const examplesOutputPath = join(rootPath, 'content', 'docs', '2', 'example');
+
+for (const example of readdirSync(examplesOutputPath)) {
+	const contents = readFileSync(join(examplesOutputPath,example), 'utf8')
+	const headlines = contents.split('---')[1].split('\n')
+	const title = headlines[1].replace('title: ', '').trim()
+	const description = headlines[2].replace('description: ', '').trim()
+	list.push({
+		name: title,
+		description: description,
+		href: '/2/example/' + example.split('.').slice(0, -1).join('.'),
+	})	
+}
+---
+
+<CardGrid>
+	{
+		list
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map((item) => <LinkCard title={item.name} href={item.href} description={item.description} />)
+	}
+</CardGrid>

--- a/src/components/list/Examples.astro
+++ b/src/components/list/Examples.astro
@@ -1,6 +1,6 @@
 ---
 import { join, dirname } from 'node:path';
-import { readdirSync, writeFileSync, readFileSync, mkdir } from 'node:fs';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 type Entry = {
@@ -12,7 +12,9 @@ type Entry = {
 const list: Entry[] = [];
 
 const rootPath = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-const examplesOutputPath = join(rootPath, 'content', 'docs', '2', 'example');
+// TODO: Dirty hack to make building work
+const hackPath = existsSync(join(rootPath, 'src')) ? join(rootPath, 'src', 'content') : join(rootPath, 'content')
+const examplesOutputPath = join(hackPath, 'docs', '2', 'example');
 
 for (const example of readdirSync(examplesOutputPath)) {
 	const contents = readFileSync(join(examplesOutputPath,example), 'utf8')

--- a/src/components/list/Examples.astro
+++ b/src/components/list/Examples.astro
@@ -1,38 +1,26 @@
 ---
-import { join, dirname } from 'node:path';
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { getCollection } from 'astro:content';
+
 type Entry = {
-	name: string;
-	description: string;
-	href: string;
+  name: string;
+  description: string;
+  href: string;
 };
 
-const list: Entry[] = [];
-
-const rootPath = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-// TODO: Dirty hack to make building work
-const hackPath = existsSync(join(rootPath, 'src')) ? join(rootPath, 'src', 'content') : join(rootPath, 'content')
-const examplesOutputPath = join(hackPath, 'docs', '2', 'example');
-
-for (const example of readdirSync(examplesOutputPath)) {
-	const contents = readFileSync(join(examplesOutputPath,example), 'utf8')
-	const headlines = contents.split('---')[1].split('\n')
-	const title = headlines[1].replace('title: ', '').trim()
-	const description = headlines[2].replace('description: ', '').trim()
-	list.push({
-		name: title,
-		description: description,
-		href: '/2/example/' + example.split('.').slice(0, -1).join('.'),
-	})	
-}
+const list: Entry[] = (await getCollection('docs', ({ id }) => id.startsWith('2/example'))).map((val) => {
+  return {
+    name: val.data.title,
+    description: val.data.description ?? '',
+    href: '/' + val.slug,
+  };
+});
 ---
 
 <CardGrid>
-	{
-		list
-			.sort((a, b) => a.name.localeCompare(b.name))
-			.map((item) => <LinkCard title={item.name} href={item.href} description={item.description} />)
-	}
+  {
+    list
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((item) => <LinkCard title={item.name} href={item.href} description={item.description} />)
+  }
 </CardGrid>

--- a/src/content/docs/2/example/api.md
+++ b/src/content/docs/2/example/api.md
@@ -1,0 +1,47 @@
+---
+title: API
+description: Placeholder description
+---
+
+# API example
+This example demonstrates Tauri's API capabilities using the `@tauri-apps/api` package. It's used as the main validation app, serving as the testbed of our development process.
+In the future, this app will be used on Tauri's integration tests.
+
+<!-- ![App screenshot](./screenshot.png?raw=true) -->
+
+## Running the example
+
+- Compile Tauri
+go to root of the Tauri repo and run:
+Linux / Mac:
+```
+# choose to install node cli (1)
+bash .scripts/setup.sh
+```
+
+Windows:
+```
+./.scripts/setup.ps1
+```
+
+- Install dependencies (Run inside of this folder `examples/api/`)
+```bash
+# with yarn
+$ yarn
+# with npm
+$ npm install
+```
+
+- Run the app in development mode (Run inside of this folder `examples/api/`)
+```bash
+# with yarn
+$ yarn tauri dev
+# with npm
+$ npm run tauri dev
+```
+
+- Build an run the release app (Run inside of this folder `examples/api/`)
+```bash
+$ yarn tauri build
+$ ./src-tauri/target/release/app
+```

--- a/src/content/docs/2/example/commands.md
+++ b/src/content/docs/2/example/commands.md
@@ -1,0 +1,10 @@
+---
+title: Commands
+description: Placeholder description
+---
+
+# Commands Example
+
+A simple Tauri Application showcasing the command API.
+
+To execute run the following on the root directory of the repository: `cargo run --example commands`.

--- a/src/content/docs/2/example/helloworld.md
+++ b/src/content/docs/2/example/helloworld.md
@@ -1,0 +1,8 @@
+---
+title: Hello World
+description: Placeholder description
+---
+
+# Hello World Example
+
+To execute run the following on the root directory of the repository: `cargo run --example helloworld`.

--- a/src/content/docs/2/example/isolation.md
+++ b/src/content/docs/2/example/isolation.md
@@ -1,0 +1,8 @@
+---
+title: Isolation
+description: Placeholder description
+---
+
+# Isolation Example
+
+To execute run the following on the root directory of the repository: `cargo run --example isolation --features isolation`.

--- a/src/content/docs/2/example/multiwindow.md
+++ b/src/content/docs/2/example/multiwindow.md
@@ -1,0 +1,10 @@
+---
+title: Multi Window
+description: Placeholder description
+---
+
+# Multi-Window Example
+
+An example Tauri Multi-Window Application.
+
+To execute run the following on the root directory of the repository: `cargo run --example multiwindow --features window-create`.

--- a/src/content/docs/2/example/navigation.md
+++ b/src/content/docs/2/example/navigation.md
@@ -1,0 +1,10 @@
+---
+title: Navigation
+description: Placeholder description
+---
+
+# Navigation Example
+
+A very simple Tauri Application with frontend navigation.
+
+To execute run the following on the root directory of the repository: `cargo run --example navigation --features window-create`.

--- a/src/content/docs/2/example/parent-window.md
+++ b/src/content/docs/2/example/parent-window.md
@@ -1,0 +1,8 @@
+---
+title: Parent Window
+description: Placeholder description
+---
+
+# Parent Window Example
+
+Run the following at the root directory of the repository to try it out: `cargo run --example parent-window`.

--- a/src/content/docs/2/example/resources.md
+++ b/src/content/docs/2/example/resources.md
@@ -1,0 +1,48 @@
+---
+title: Resources
+description: Placeholder description
+---
+
+# Resource example
+
+This example demonstrates the Tauri bundle resources functionality. The example adds `src-tauri/assets/index.js` as a resource (defined on `tauri.conf.json > tauri > bundle > resources`) and executes it using `Node.js`, locating the JavaScript file using the `tauri::App::path_resolver` APIs.
+
+## Running the example
+
+- Compile Tauri
+go to root of the Tauri repo and run:
+Linux / Mac:
+```
+# choose to install node cli (1)
+bash .scripts/setup.sh
+```
+
+Windows:
+```
+./.scripts/setup.ps1
+```
+
+- Install dependencies (Run inside of this folder `examples/resources/`)
+```bash
+# with yarn
+$ yarn
+# with npm
+$ npm install
+
+$ yarn tauri
+$ yarn package
+```
+
+- Run the app in development mode (Run inside of this folder `examples/resources/`)
+```bash
+# with yarn
+$ yarn tauri dev
+# with npm
+$ npm run tauri dev
+```
+
+- Build an run the release app (Run inside of this folder `examples/resources/`)
+```bash
+$ yarn tauri build
+$ ./src-tauri/target/release/app
+```

--- a/src/content/docs/2/example/splashscreen.md
+++ b/src/content/docs/2/example/splashscreen.md
@@ -1,0 +1,16 @@
+---
+title: Splashscreen
+description: Placeholder description
+---
+
+# Splashscreen example
+
+This example demonstrates how a splashscreen can be implemented when waiting on an initialization code on Rust or on the UI.
+
+## Running the example
+
+Run the following scripts on the root directory of the repository:
+
+```bash
+$ cargo run --example splashscreen
+```

--- a/src/content/docs/2/example/state.md
+++ b/src/content/docs/2/example/state.md
@@ -1,0 +1,10 @@
+---
+title: State
+description: Placeholder description
+---
+
+# State example
+
+A simple Tauri Application showcase the application State usage.
+
+To execute run the following on the root directory of the repository: `cargo run --example state`

--- a/src/content/docs/2/example/streaming.md
+++ b/src/content/docs/2/example/streaming.md
@@ -1,0 +1,12 @@
+---
+title: Streaming
+description: Placeholder description
+---
+
+# Streaming example
+
+A simple Tauri Application showcase the streaming functionality.
+
+To execute run the following on the root directory of the repository: `cargo run --example streaming`.
+
+By default the example uses a custom URI scheme protocol. To use the builtin `asset` protocol, run `cargo run --example streaming --features protocol-asset`.

--- a/src/content/docs/2/example/tauri-dynamic-lib.md
+++ b/src/content/docs/2/example/tauri-dynamic-lib.md
@@ -1,0 +1,41 @@
+---
+title: Dynamic Library
+description: Placeholder description
+---
+
+# Readme
+
+This is an example of compiling tauri as a dynamic shared library and running it from another app.
+
+  * src-tauri is an example of a library containing code to launch a tauri webview window.
+  * src-app1 is a small example of calling tauri from a dynamic shared library through FFI.
+
+Note that bundling of resources via tauri.conf.json may not work in some cases due to the nature of the build.
+So you have to be aware of copying any files needed to the correct paths for html / js etc.
+
+## Rust libraries
+
+Typically there are 3 types of libraries rust can generate
+
+  * rlib - rust static libraries
+  * dylib - rust shared libraries
+  * cdylib - dynamic shared libraries that can be used to interop with other languages.
+
+Typically cdylib libraries are used for interop with C / C++ Projects but this can also include other languages.
+The src-tauri example uses the cdylib crate type
+
+## Building / Running
+
+``` bash
+# First build the library
+cd src-tauri
+cargo build
+cd ..
+
+# Next build the app
+cd src-app1
+cargo build
+
+# Next run the app
+cargo run
+```

--- a/src/content/docs/2/example/web.md
+++ b/src/content/docs/2/example/web.md
@@ -1,0 +1,40 @@
+---
+title: Web
+description: Placeholder description
+---
+
+# Desktop / Web Example
+
+This example showcases an application that has shares code between a desktop and a Web target.
+
+The Web application uses WASM to communicate with the Rust backend, while the desktop app leverages Tauri commands.
+
+## Architecture
+
+The Rust code lives in the `core/` folder and it is a Cargo workspace with three crates:
+
+- tauri: desktop application. Contains the commands that are used by the frontend to access the Rust APIs;
+- wasm: library that is compiled to WASM to be used by the Web application;
+- api: code shared between the Tauri and the WASM crates. Most of the logic should live here, with only the specifics in the tauri and wasm crates.
+
+The Rust code bridge is defined in the `src/api/` folder, which defines `desktop/index.js` and a `web/index.js` interfaces.
+To access the proper interface according to the build target, a resolve alias is defined in vite.config.js, so the API can be imported
+with `import * as api from '$api'`.
+
+## Running the desktop application
+
+Use the following commands to run the desktop application:
+
+```
+yarn
+yarn tauri dev
+```
+
+## Running the Web application
+
+Use the following commands to run the Web application:
+
+```
+yarn
+yarn dev:web
+```

--- a/src/content/docs/2/example/workspace.md
+++ b/src/content/docs/2/example/workspace.md
@@ -1,0 +1,6 @@
+---
+title: Workspace
+description: Placeholder description
+---
+
+This one didn't have a README.md

--- a/src/content/docs/2/guide/list.mdx
+++ b/src/content/docs/2/guide/list.mdx
@@ -4,6 +4,7 @@ title: List of Features & Recipes
 
 import GuideList from '@components/list/Guides.astro';
 import RecipeList from '@components/list/Recipes.astro';
+import ExampleList from '@components/list/Examples.astro';
 import CommunityList from '@components/list/Community.astro';
 
 Tauri comes with extensibility in mind. On this page you'll find:
@@ -21,6 +22,10 @@ Tauri comes with extensibility in mind. On this page you'll find:
 ## Recipes
 
 <RecipeList />
+
+## Examples
+
+<ExampleList />
 
 ## Community Resources
 


### PR DESCRIPTION
Started work on something that fetches examples from upstream so we can focus on writing recipes there instead.

Currently I'm calling it `examples-generator` and keeping it as a separate thing, but I would prefer it if we went all in on this and made it the `recipe-generator`. If we decide that recipes are different from examples we could still use this to raise awareness of the examples folder seeing as so many people don't know it's a thing.

For this PR I've manually edited the upstream README's to make them compatible.

TODO:
- [ ] Fix upstream examples, their README's are either bad, missing or causes errors (mainly an image that isn't required or that we could look into pulling as well if that's desired)