### PR TITLE
Update adapter in SvelteKit guide

### DIFF
--- a/docs/guides/getting-started/setup/sveltekit.mdx
+++ b/docs/guides/getting-started/setup/sveltekit.mdx
@@ -80,7 +80,7 @@ First, we need to install [`@sveltejs/adapter-static`]:
   <TabItem value="npm">
 
 ```shell
-npm install --save-dev @sveltejs/adapter-static@next
+npm install --save-dev @sveltejs/adapter-static
 ```
 
   </TabItem>
@@ -88,7 +88,7 @@ npm install --save-dev @sveltejs/adapter-static@next
   <TabItem value="Yarn">
 
 ```shell
-yarn add -D @sveltejs/adapter-static@next
+yarn add -D @sveltejs/adapter-static
 ```
 
   </TabItem>
@@ -96,7 +96,7 @@ yarn add -D @sveltejs/adapter-static@next
   <TabItem value="pnpm">
 
 ```shell
-pnpm add -D @sveltejs/adapter-static@next
+pnpm add -D @sveltejs/adapter-static
 ```
 
   </TabItem>


### PR DESCRIPTION
- When using SvelteKit adapters, it is no longer recommended to install `@sveltejs/adapter-static@next`, which installs version `1.0.0-next.50` of the adapter.
- Instead, `@sveltejs/adapter-static` (without the `@next` part) should be used, which installs version `2.0.3` or greater of the adapter.
- This PR updates the Tauri SvelteKit guide to use `@sveltejs/adapter-static`, removing the `@next` part so that the latest version is used instead of the old `next` release.

Apologies for the extra commit. It seems I couldn't commit directly to `dev`, even on a fork, so I had to commit to a branch, merge it, and then create a PR to the actual repo.