### PR TITLE
docs: add instructions for bun

### DIFF
--- a/docs/.templates/cli.md
+++ b/docs/.templates/cli.md
@@ -109,7 +109,7 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
   <TabItem value="bun">
 
 ```shell
-bunx tauricompletions --shell bash > tauri.sh
+bunx tauri completions --shell bash > tauri.sh
 mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
@@ -162,7 +162,7 @@ mv completions.zsh $HOME/.completions/_tauri
   <TabItem value="bun">
 
 ```shell
-bunx tauricompletions -- --shell zsh > completions.zsh
+bunx tauri completions -- --shell zsh > completions.zsh
 mv completions.zsh $HOME/.completions/_tauri
 ```
 
@@ -216,7 +216,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
   <TabItem value="bun">
 
 ```powershell
-bunx tauricompletions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
+bunx tauri completions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
 Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 

--- a/docs/.templates/cli.md
+++ b/docs/.templates/cli.md
@@ -106,7 +106,15 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
   </TabItem>
-    <TabItem value="Cargo">
+  <TabItem value="bun">
+
+```shell
+bunx tauricompletions --shell bash > tauri.sh
+mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
+```
+
+  </TabItem>
+  <TabItem value="Cargo">
 
 ```shell
 cargo tauri completions --shell bash > tauri.sh
@@ -151,7 +159,15 @@ mv completions.zsh $HOME/.completions/_tauri
 ```
 
   </TabItem>
-    <TabItem value="Cargo">
+  <TabItem value="bun">
+
+```shell
+bunx tauricompletions -- --shell zsh > completions.zsh
+mv completions.zsh $HOME/.completions/_tauri
+```
+
+  </TabItem>
+  <TabItem value="Cargo">
 
 ```shell
 cargo tauri completions --shell zsh > completions.zsh
@@ -193,6 +209,14 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 
 ```powershell
 pnpm tauri completions --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
+Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```powershell
+bunx tauricompletions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
 Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 

--- a/docs/.templates/cli.md
+++ b/docs/.templates/cli.md
@@ -106,7 +106,7 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx tauri completions --shell bash > tauri.sh
@@ -159,7 +159,7 @@ mv completions.zsh $HOME/.completions/_tauri
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx tauri completions -- --shell zsh > completions.zsh
@@ -213,7 +213,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```powershell
 bunx tauri completions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -243,7 +243,7 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx tauri completions --shell bash > tauri.sh
@@ -296,7 +296,7 @@ mv completions.zsh $HOME/.completions/_tauri
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx tauri completions -- --shell zsh > completions.zsh
@@ -350,7 +350,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```powershell
 bunx tauri completions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -246,7 +246,7 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
   <TabItem value="bun">
 
 ```shell
-bunx tauricompletions --shell bash > tauri.sh
+bunx tauri completions --shell bash > tauri.sh
 mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
@@ -299,7 +299,7 @@ mv completions.zsh $HOME/.completions/_tauri
   <TabItem value="bun">
 
 ```shell
-bunx tauricompletions -- --shell zsh > completions.zsh
+bunx tauri completions -- --shell zsh > completions.zsh
 mv completions.zsh $HOME/.completions/_tauri
 ```
 
@@ -353,7 +353,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
   <TabItem value="bun">
 
 ```powershell
-bunx tauricompletions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
+bunx tauri completions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
 Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -243,7 +243,15 @@ mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
 ```
 
   </TabItem>
-    <TabItem value="Cargo">
+  <TabItem value="bun">
+
+```shell
+bunx tauricompletions --shell bash > tauri.sh
+mv tauri.sh /usr/local/etc/bash_completion.d/tauri.bash
+```
+
+  </TabItem>
+  <TabItem value="Cargo">
 
 ```shell
 cargo tauri completions --shell bash > tauri.sh
@@ -288,7 +296,15 @@ mv completions.zsh $HOME/.completions/_tauri
 ```
 
   </TabItem>
-    <TabItem value="Cargo">
+  <TabItem value="bun">
+
+```shell
+bunx tauricompletions -- --shell zsh > completions.zsh
+mv completions.zsh $HOME/.completions/_tauri
+```
+
+  </TabItem>
+  <TabItem value="Cargo">
 
 ```shell
 cargo tauri completions --shell zsh > completions.zsh
@@ -330,6 +346,14 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 
 ```powershell
 pnpm tauri completions --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
+Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```powershell
+bunx tauricompletions -- --shell powershell > ((Split-Path -Path $profile)+"\_tauri.ps1")
 Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ```
 

--- a/docs/guides/development/updating-dependencies.md
+++ b/docs/guides/development/updating-dependencies.md
@@ -73,6 +73,14 @@ pnpm outdated @tauri-apps/cli
 ```
 
   </TabItem>
+  <TabItem value="Bun">
+
+```shell
+# Bun does not implement `outdated`
+npm outdated @tauri-apps/cli
+```
+
+  </TabItem>
 </Tabs>
 
 Alternatively, if you are using the `vue-cli-plugin-tauri` approach:

--- a/docs/guides/development/updating-dependencies.md
+++ b/docs/guides/development/updating-dependencies.md
@@ -40,7 +40,7 @@ pnpm update @tauri-apps/cli @tauri-apps/api --latest
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bun update @tauri-apps/cli @tauri-apps/api
@@ -106,7 +106,7 @@ pnpm update vue-cli-plugin-tauri --latest
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bun update vue-cli-plugin-tauri

--- a/docs/guides/development/updating-dependencies.md
+++ b/docs/guides/development/updating-dependencies.md
@@ -40,6 +40,13 @@ pnpm update @tauri-apps/cli @tauri-apps/api --latest
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun update @tauri-apps/cli @tauri-apps/api
+```
+
+  </TabItem>
 </Tabs>
 
 You can also detect what the latest version of Tauri is on the command line, using:
@@ -96,6 +103,13 @@ yarn up vue-cli-plugin-tauri
 
 ```shell
 pnpm update vue-cli-plugin-tauri --latest
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun update vue-cli-plugin-tauri
 ```
 
   </TabItem>

--- a/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
+++ b/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
@@ -38,7 +38,7 @@ pnpm tauri init
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bunx tauri init

--- a/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
+++ b/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
@@ -41,7 +41,7 @@ pnpm tauri init
 <TabItem value="bun">
 
 ```shell
-bunx tauriinit
+bunx tauri init
 ```
 
 </TabItem>

--- a/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
+++ b/docs/guides/getting-started/setup/_fragments/_tauri-init.mdx
@@ -38,6 +38,13 @@ pnpm tauri init
 ```
 
 </TabItem>
+<TabItem value="bun">
+
+```shell
+bunx tauriinit
+```
+
+</TabItem>
 <TabItem value="Cargo">
 
 ```shell

--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -54,6 +54,13 @@ pnpm create next-app --use-pnpm
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx create-next-app --use-bun
+```
+
+  </TabItem>
 </Tabs>
 
 1. _Project name_  

--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -54,7 +54,7 @@ pnpm create next-app --use-pnpm
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx create-next-app --use-bun

--- a/docs/guides/getting-started/setup/qwik.mdx
+++ b/docs/guides/getting-started/setup/qwik.mdx
@@ -51,7 +51,7 @@ pnpm create qwik@latest
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx create-qwik@latest
@@ -93,7 +93,7 @@ pnpm qwik add
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bun run qwik add
@@ -126,7 +126,7 @@ pnpm build
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bun run build

--- a/docs/guides/getting-started/setup/qwik.mdx
+++ b/docs/guides/getting-started/setup/qwik.mdx
@@ -51,6 +51,13 @@ pnpm create qwik@latest
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx create-qwik@latest
+```
+
+  </TabItem>
 </Tabs>
 
 1. _Project name_  
@@ -86,6 +93,13 @@ pnpm qwik add
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun run qwik add
+```
+
+  </TabItem>
 </Tabs>
 
 Select `Static site (.html files)` adapter. Then you can build static pages via:
@@ -109,6 +123,13 @@ yarn build
 
 ```shell
 pnpm build
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun run build
 ```
 
   </TabItem>

--- a/docs/guides/getting-started/setup/sveltekit.mdx
+++ b/docs/guides/getting-started/setup/sveltekit.mdx
@@ -53,6 +53,13 @@ pnpm create svelte
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx create-svelte
+```
+
+  </TabItem>
 </Tabs>
 
 1. _Project name_  
@@ -97,6 +104,13 @@ yarn add -D @sveltejs/adapter-static
 
 ```shell
 pnpm add -D @sveltejs/adapter-static
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun add --dev @sveltejs/adapter-static
 ```
 
   </TabItem>

--- a/docs/guides/getting-started/setup/sveltekit.mdx
+++ b/docs/guides/getting-started/setup/sveltekit.mdx
@@ -53,7 +53,7 @@ pnpm create svelte
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx create-svelte
@@ -107,7 +107,7 @@ pnpm add -D @sveltejs/adapter-static
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bun add --dev @sveltejs/adapter-static

--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -56,6 +56,13 @@ pnpm create vite
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx create-vite@latest
+```
+
+  </TabItem>
 </Tabs>
 
 1. _Project name_  

--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -56,7 +56,7 @@ pnpm create vite
 ```
 
   </TabItem>
-  <TabItem value="bun">
+  <TabItem value="Bun">
 
 ```shell
 bunx create-vite@latest

--- a/docs/guides/testing/webdriver/example/selenium.md
+++ b/docs/guides/testing/webdriver/example/selenium.md
@@ -74,7 +74,7 @@ yarn add mocha chai selenium-webdriver
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bun add mocha chai selenium-webdriver
@@ -106,7 +106,7 @@ yarn test
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bun run test
@@ -238,7 +238,7 @@ yarn test
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bun run test

--- a/docs/guides/testing/webdriver/example/selenium.md
+++ b/docs/guides/testing/webdriver/example/selenium.md
@@ -57,7 +57,7 @@ If you want to install the dependencies from scratch, just run the following com
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -74,6 +74,13 @@ yarn add mocha chai selenium-webdriver
 ```
 
 </TabItem>
+<TabItem value="bun">
+
+```shell
+bun add mocha chai selenium-webdriver
+```
+
+</TabItem>
 </Tabs>
 
 I suggest also adding a `"test": "mocha"` item in the `package.json` `"scripts"` key so that running Mocha can be called
@@ -82,7 +89,7 @@ simply with
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -96,6 +103,13 @@ npm test
 
 ```shell
 yarn test
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```shell
+bun run test
 ```
 
 </TabItem>
@@ -207,7 +221,7 @@ Now that we are all set up with our dependencies and our test script, let's run 
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -221,6 +235,13 @@ npm test
 
 ```shell
 yarn test
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```shell
+bun run test
 ```
 
 </TabItem>

--- a/docs/guides/testing/webdriver/example/webdriverio.md
+++ b/docs/guides/testing/webdriver/example/webdriverio.md
@@ -63,7 +63,7 @@ Let's add the [WebdriverIO] CLI to this npm project.
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -80,6 +80,13 @@ yarn add @wdio/cli
 ```
 
 </TabItem>
+<TabItem value="bun">
+
+```shell
+bun add @wdio/cli
+```
+
+</TabItem>
 </Tabs>
 
 To then run the interactive config command to set up a [WebdriverIO] test suite, you can then run:
@@ -87,7 +94,7 @@ To then run the interactive config command to set up a [WebdriverIO] test suite,
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -101,6 +108,13 @@ npx wdio config
 
 ```shell
 yarn wdio config
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```shell
+bunx wdio config
 ```
 
 </TabItem>
@@ -215,7 +229,7 @@ Now that we are all set up with config and a spec let's run it!
 <Tabs groupId="package-manager"
 defaultValue="yarn"
 values={[
-{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'},
+{label: 'npm', value: 'npm'}, {label: 'Yarn', value: 'yarn'}, {label: 'Bun', value: 'bun'},
 ]}>
 <TabItem value="npm">
 
@@ -229,6 +243,13 @@ npm test
 
 ```shell
 yarn test
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```shell
+bun run test
 ```
 
 </TabItem>

--- a/docs/guides/testing/webdriver/example/webdriverio.md
+++ b/docs/guides/testing/webdriver/example/webdriverio.md
@@ -80,7 +80,7 @@ yarn add @wdio/cli
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bun add @wdio/cli
@@ -111,7 +111,7 @@ yarn wdio config
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bunx wdio config
@@ -246,7 +246,7 @@ yarn test
 ```
 
 </TabItem>
-<TabItem value="bun">
+<TabItem value="Bun">
 
 ```shell
 bun run test

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -56,6 +56,11 @@ cargo create-tauri-app`}
           pnpm create tauri-app
         </CodeBlock>
       </TabItem>
+      <TabItem value="bun">
+        <CodeBlock className="language-shell" language="shell">
+          bunx create-tauri-app
+        </CodeBlock>
+      </TabItem>
     </Tabs>
   )
 }

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -56,7 +56,7 @@ cargo create-tauri-app`}
           pnpm create tauri-app
         </CodeBlock>
       </TabItem>
-      <TabItem value="bun">
+      <TabItem value="Bun">
         <CodeBlock className="language-shell" language="shell">
           bunx create-tauri-app
         </CodeBlock>

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -8,6 +8,7 @@ const types = [
   { value: 'npm', content: 'npm run tauri ' },
   { value: 'Yarn', content: 'yarn tauri ' },
   { value: 'pnpm', content: 'pnpm tauri ' },
+  { value: 'bun', content: 'bunx tauri ' },
   { value: 'Cargo', content: 'cargo tauri ' },
 ]
 
@@ -96,6 +97,11 @@ export const InstallTauriCli = () => {
           pnpm add -D @tauri-apps/cli
         </CodeBlock>
       </TabItem>
+      <TabItem value="Bun">
+        <CodeBlock className="language-shell" language="shell">
+          bun add -D @tauri-apps/cli
+        </CodeBlock>
+      </TabItem>
       <TabItem value="Cargo">
         <CodeBlock className="language-shell" language="shell">
           cargo install tauri-cli
@@ -121,6 +127,11 @@ export const InstallTauriApi = () => {
       <TabItem value="pnpm">
         <CodeBlock className="language-shell" language="shell">
           pnpm add @tauri-apps/api
+        </CodeBlock>
+      </TabItem>
+      <TabItem value="Bun">
+        <CodeBlock className="language-shell" language="shell">
+          bun add @tauri-apps/api
         </CodeBlock>
       </TabItem>
     </Tabs>


### PR DESCRIPTION
Adds code tabs for the Bun package manager.

Related:

- https://github.com/tauri-apps/tauri/pull/7723
- https://github.com/tauri-apps/create-tauri-app/pull/481

---


A few questions:

- Should I update to the i18n pages too?
- Should I be merging this PR to `next`?
- Should I remove the `bun` tab from the homepage?