### PR TITLE
i18n(es): Translate frontend configurations index.mdx to Spanish

### DIFF
--- a/src/content/docs/es/2/guide/frontend/index.mdx
+++ b/src/content/docs/es/2/guide/frontend/index.mdx
@@ -5,11 +5,11 @@ i18nReady: true
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Tauri es frontend agnóstico y soporta la mayoría de los frameworks de frontend sin necesidad de demasiada configuración. Sin embargo, en casos puntuales algún framework podría necesitar configuración extra para funcionar con Tauri. Debajo puedes consultar una lista de frameworks con sus configuraciones recomendadas.
+Tauri es agnóstico al frontend y soporta la mayoría de los frameworks de frontend sin necesidad de demasiada configuración. Sin embargo, en casos puntuales algún framework podría necesitar configuración extra para funcionar con Tauri. Debajo puedes consultar una lista de frameworks con sus configuraciones recomendadas.
 
 Si un framework no aparece en esta lista puede que funcione con Tauri sin necesidad de configuraciones adicionales o puede que aún no haya sido documentado. Todas las contribuciones para añadir un framework que requiera configuraciones adicionales son bienvenidas en la comunidad de Tauri.
 
-:::tip[¿No ves un framework concreto?]
+:::tip[¿No ves un framework en concreto?]
 
 ¿Falta algún framework en esta lista? Puede que funcione con Tauri sin necesidad de configuraciones adicionales. En la [checklist de configuración](#checklist-de-configuración) podrás encontrar configuraciones comunes.
 

--- a/src/content/docs/es/2/guide/frontend/index.mdx
+++ b/src/content/docs/es/2/guide/frontend/index.mdx
@@ -1,0 +1,50 @@
+---
+title: Configuración del frontend
+i18nReady: true
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Tauri es frontend agnóstico y soporta la mayoría de los frameworks de frontend sin necesidad de demasiada configuración. Sin embargo, en casos puntuales algún framework podría necesitar configuración extra para funcionar con Tauri. Debajo puedes consultar una lista de frameworks con sus configuraciones recomendadas.
+
+Si un framework no aparece en esta lista puede que funcione con Tauri sin necesidad de configuraciones adicionales o puede que aún no haya sido documentado. Todas las contribuciones para añadir un framework que requiera configuraciones adicionales son bienvenidas en la comunidad de Tauri.
+
+:::tip[¿No ves un framework concreto?]
+
+¿Falta algún framework en esta lista? Puede que funcione con Tauri sin necesidad de configuraciones adicionales. En la [checklist de configuración](#checklist-de-configuración) podrás encontrar configuraciones comunes.
+
+:::
+
+## JavaScript
+
+<CardGrid>
+	<LinkCard title="Next.js" href="/2/guide/frontend/nextjs" />
+	<LinkCard title="Nuxt" href="/2/guide/frontend/nuxt" />
+	<LinkCard title="Qwik" href="/2/guide/frontend/qwik" />
+	<LinkCard title="Svelte" href="/2/guide/frontend/svelte" />
+	<LinkCard title="Vite" href="/2/guide/frontend/vite" />
+	<LinkCard title="Webpack" href="/2/guide/frontend/webpack" />
+</CardGrid>
+
+## Rust
+
+<CardGrid>
+	<LinkCard title="Leptos" href="/2/guide/frontend/leptos" />
+	<LinkCard title="Sycamore" href="/2/guide/frontend/sycamore" />
+	<LinkCard title="Trunk" href="/2/guide/frontend/trunk" />
+	<LinkCard title="Yew" href="/2/guide/frontend/yew" />
+</CardGrid>
+
+## Checklist de configuración
+
+Conceptualmente Tauri desempeña el rol de un servidor web estático. Necesitas proveer a Tauri de un directorio con HTML, CSS, Javascript y posiblemente WASM que puedan ser servidos a la webview de Tauri.
+
+Debajo puedes consultar una checklist de escenarios comunes al integrar un frontend con Tauri:
+
+{/* TODO: Link to core concept of SSG/SSR, etc. */}
+{/* TODO: Link to mobile development server guide */}
+{/* TODO: Concept of how to do a client-server relationship? */}
+
+- Usa static site generation (SSG). Tauri no soporta alternativas basadas en servidores de manera oficial (como SSR).
+- Para el desarrollo de apps móviles, es necesario un servidor de desarrollo de algun tipo para servir el frontend desde tu IP interna.
+- Usa una relación cliente-servidor adecuada entre tu APP y tus APIs (no uses soluciones híbridas con SSR).

--- a/src/content/docs/es/2/guide/frontend/index.mdx
+++ b/src/content/docs/es/2/guide/frontend/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuración del frontend
+title: Configuración del Frontend
 i18nReady: true
 ---
 
@@ -35,7 +35,7 @@ Si un framework no aparece en esta lista puede que funcione con Tauri sin necesi
 	<LinkCard title="Yew" href="/2/guide/frontend/yew" />
 </CardGrid>
 
-## Checklist de configuración
+## Checklist de Configuración
 
 Conceptualmente Tauri desempeña el rol de un servidor web estático. Necesitas proveer a Tauri de un directorio con HTML, CSS, Javascript y posiblemente WASM que puedan ser servidos a la webview de Tauri.
 

--- a/src/content/docs/es/2/guide/frontend/index.mdx
+++ b/src/content/docs/es/2/guide/frontend/index.mdx
@@ -45,6 +45,6 @@ Debajo puedes consultar una checklist de escenarios comunes al integrar un front
 {/* TODO: Link to mobile development server guide */}
 {/* TODO: Concept of how to do a client-server relationship? */}
 
-- Usa static site generation (SSG). Tauri no soporta alternativas basadas en servidores de manera oficial (como SSR).
+- Usa la generación de sitios estáticos (SSG). Tauri no soporta alternativas basadas en servidores de manera oficial (como SSR).
 - Para el desarrollo de apps móviles, es necesario un servidor de desarrollo de algun tipo para servir el frontend desde tu IP interna.
 - Usa una relación cliente-servidor adecuada entre tu APP y tus APIs (no uses soluciones híbridas con SSR).


### PR DESCRIPTION
I've left a couple of works or expressions in English such as "checklist" and "static site generation" as I think developers are used to using these terms. If it's needed though I can come up with a translation for both.