### PR TITLE
i18n(es): Translate `nextjs.mdx`, `nuxt.mdx` & `trunk.mdx`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -95,6 +95,9 @@ export default defineConfig({
 						},
 						{
 							label: 'Frontend Configuration',
+							translations: {
+								es: 'Configuración del Frontend',
+							},
 							link: '/2/guide/frontend/',
 						},
 						{

--- a/src/content/docs/es/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/es/2/guide/frontend/nextjs.mdx
@@ -6,12 +6,12 @@ i18nReady: true
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import CommandTabs from '@components/CommandTabs.astro';
 
-Next.js es un framework de React. Aprende más sobre Next.js en https://nextjs.org. Esta guía es precisa a partir de Next.js 13.4.19.
+Next.js es un framework para React. Aprende más sobre Next.js en https://nextjs.org. Esta guía es precisa a partir de Next.js 13.4.19.
 
 ## Checklist
 
 - Usa exports estáticos estableciendo `output: 'export'`. Tauri no soporta soluciones basadas en el servidor.
-- Usa `internal-ip` para compatibilidad con móviles para que puedas configurar `assetPrefix`. Esto es necesario para que el servidor resuelva correctamente los activos.
+- Usa `internal-ip` para compatibilidad con móviles para que puedas configurar `assetPrefix`. Esto es necesario para que el servidor resuelva correctamente los archivos.
 - Usa `out/` como `distDir` en `tauri.conf.json`.
 
 ## Configuración de ejemplo
@@ -81,7 +81,7 @@ Next.js es un framework de React. Aprende más sobre Next.js en https://nextjs.o
 const isProd = process.env.NODE_ENV === 'production';
 module.exports = async (phase, { defaultConfig }) => {
 	let internalHost = null;
-	// En modo de desarrollo usamos internal-ip para servir los activos
+	// En modo de desarrollo usamos internal-ip para servir los archivos
 	if (!isProd) {
 		const { internalIpV4 } = await import('internal-ip');
 		internalHost = await internalIpV4();
@@ -95,7 +95,7 @@ module.exports = async (phase, { defaultConfig }) => {
 		images: {
 			unoptimized: true,
 		},
-		// Configura assetPrefix o el servidor no resolverá correctamente tus activos.
+		// Configura assetPrefix o el servidor no resolverá correctamente tus archivos.
 		assetPrefix: isProd ? null : `http://${internalHost}:3000`,
 	};
 	return nextConfig;

--- a/src/content/docs/es/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/es/2/guide/frontend/nextjs.mdx
@@ -14,7 +14,7 @@ Next.js es un framework para React. Aprende más sobre Next.js en https://nextjs
 - Usa `internal-ip` para compatibilidad con móviles para que puedas configurar `assetPrefix`. Esto es necesario para que el servidor resuelva correctamente los archivos.
 - Usa `out/` como `distDir` en `tauri.conf.json`.
 
-## Configuración de ejemplo
+## Ejemplo de Configuración
 
 1. Instala `internal-ip` para el desarrollo móvil:
 

--- a/src/content/docs/es/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/es/2/guide/frontend/nextjs.mdx
@@ -1,0 +1,103 @@
+---
+title: Next.js
+i18nReady: true
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+
+Next.js es un framework de React. Aprende más sobre Next.js en https://nextjs.org. Esta guía es precisa a partir de Next.js 13.4.19.
+
+## Checklist
+
+- Usa exports estáticos estableciendo `output: 'export'`. Tauri no soporta soluciones basadas en el servidor.
+- Usa `internal-ip` para compatibilidad con móviles para que puedas configurar `assetPrefix`. Esto es necesario para que el servidor resuelva correctamente los activos.
+- Usa `out/` como `distDir` en `tauri.conf.json`.
+
+## Configuración de ejemplo
+
+1. Instala `internal-ip` para el desarrollo móvil:
+
+<CommandTabs
+	npm="npm install --save-dev internal-ip"
+	yarn="yarn add -D internal-ip"
+	pnpm="pnpm add -D internal-ip"
+/>
+
+2. Actualiza la configuración de Tauri:
+
+<Tabs>
+	<TabItem label="npm">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "npm run dev",
+		"beforeBuildCommand": "npm run build",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+<TabItem label="yarn">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "yarn dev",
+		"beforeBuildCommand": "yarn generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+<TabItem label="pnpm">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "pnpm dev",
+		"beforeBuildCommand": "pnpm generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+3. Actualiza la configuración de Next.js:
+
+```ts
+// next.conf.ts
+const isProd = process.env.NODE_ENV === 'production';
+module.exports = async (phase, { defaultConfig }) => {
+	let internalHost = null;
+	// En modo de desarrollo usamos internal-ip para servir los activos
+	if (!isProd) {
+		const { internalIpV4 } = await import('internal-ip');
+		internalHost = await internalIpV4();
+	}
+	const nextConfig = {
+		// Aségurate de que Next.js use SSG en lugar de SSR
+		// https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
+		output: 'export',
+		// Nota: Esta función experimental es necesaria para usar NextJS Image en modo SSG.
+		// Consulta https://nextjs.org/docs/messages/export-image-api para ver diferentes soluciones.
+		images: {
+			unoptimized: true,
+		},
+		// Configura assetPrefix o el servidor no resolverá correctamente tus activos.
+		assetPrefix: isProd ? null : `http://${internalHost}:3000`,
+	};
+	return nextConfig;
+};
+```

--- a/src/content/docs/es/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/es/2/guide/frontend/nuxt.mdx
@@ -1,0 +1,101 @@
+---
+title: Nuxt
+i18nReady: true
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Aprende más sobre Nuxt en https://nuxt.com. Esta guía es precisa a partir de Nuxt 3.7.
+
+## Checklist
+
+- Usa SSG estableciendo `ssr: false`. Tauri no soporta soluciones basadas en el servidor.
+- Configura el host a `0.0.0.0`.
+- Usa `dist/` como `distDir` en `tauri.conf.json`.
+- Compila usando `nuxi generate`.
+- (Opcional): Deshabilita la telemetría estableciendo `telemetry: false` en `nuxt.config.ts`.
+
+## Configuración de ejemplo
+
+1. Actualiza la configuración de Tauri:
+
+<Tabs>
+	<TabItem label="npm">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "npm run dev",
+		"beforeBuildCommand": "npm run generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+	<TabItem label="yarn">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "yarn dev",
+		"beforeBuildCommand": "yarn generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+	<TabItem label="pnpm">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "pnpm dev",
+		"beforeBuildCommand": "pnpm generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+</Tabs>
+
+2. Actualiza la configuración de Nuxt:
+
+```ts
+export default defineNuxtConfig({
+	// (opcional) Habilita las herramientas de desarrollo de Nuxt
+	devtools: { enabled: true },
+	// Habilita SSG
+	ssr: false,
+	vite: {
+		// Mejor soporte para la salida de Tauri CLI
+		clearScreen: false,
+		// Habilita las variables de entorno
+		// Las variables de entorno adicionales se pueden encontrar en
+		// https://tauri.app/2/reference/environment-variables/
+		envPrefix: ['VITE_', 'TAURI_'],
+		server: {
+			// Tauri requiere un puerto consistente
+			strictPort: true,
+			// Habilita el servidor de desarrollo para que sea descubierto por otros dispositivos para el desarrollo móvil
+			host: '0.0.0.0',
+			hmr: {
+				// Usa un websocket para la recarga rápida en móviles
+				protocol: 'ws',
+				// Asegúrate de que esté disponible en la red
+				host: '0.0.0.0',
+				// Usa un puerto específico para hmr
+				port: 5183,
+			},
+		},
+	},
+});
+```

--- a/src/content/docs/es/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/es/2/guide/frontend/nuxt.mdx
@@ -85,7 +85,7 @@ export default defineNuxtConfig({
 		server: {
 			// Tauri requiere un puerto consistente
 			strictPort: true,
-			// Habilita el servidor de desarrollo para que sea descubierto por otros dispositivos para el desarrollo móvil
+			// Habilita el servidor de desarrollo para pueda ser accedido por otros dispositivos para el desarrollo móvil
 			host: '0.0.0.0',
 			hmr: {
 				// Usa un websocket para la recarga rápida en móviles

--- a/src/content/docs/es/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/es/2/guide/frontend/nuxt.mdx
@@ -15,7 +15,7 @@ Aprende más sobre Nuxt en https://nuxt.com. Esta guía es precisa a partir de N
 - Compila usando `nuxi generate`.
 - (Opcional): Deshabilita la telemetría estableciendo `telemetry: false` en `nuxt.config.ts`.
 
-## Configuración de ejemplo
+## Ejemplo de Configuración
 
 1. Actualiza la configuración de Tauri:
 

--- a/src/content/docs/es/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/es/2/guide/frontend/trunk.mdx
@@ -1,0 +1,48 @@
+---
+title: Trunk
+i18nReady: true
+---
+
+Trunk es una herramienta de empaquetado de aplicaciones web WASM para Rust. Obtén más información sobre Trunk en https://trunkrs.dev. Esta guía es precisa a partir de Trunk 0.17.5.
+
+:::caution[Nota sobre el soporte móvil]
+
+El desarrollo móvil de Tauri no es posible actualmente con la versión oficial de Trunk. Si desarrollas para móviles deberás utilizar https://github.com/amrbashir/trunk hasta que https://github.com/thedodd/trunk/pull/494 y https://github.com/thedodd/trunk/pull/500 sean fusionados y publicados.
+
+Necesitarás utilizar `cargo install --git https://github.com/amrbashir/trunk` cuando instales Trunk y luego establecer `serve.ws_protocol = "ws"` en `Trunk.toml`.
+
+:::
+
+## Checklist
+
+- Usa SSG, Tauri no soporta oficialmente soluciones basadas en el servidor.
+- Usa `address = "0.0.0.0"` para que el servidor web esté disponible en la red para el desarrollo móvil.
+- Habilita `withGlobalTauri` para asegurarte de que las APIs de Tauri están disponibles en la variable `window.__TAURI__` y pueden ser importadas usando `wasm-bindgen`.
+
+## Ejemplo de configuración
+
+1. Actualiza la configuración de Tauri:
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "trunk serve",
+		"beforeBuildCommand": "trunk build",
+		"devPath": "http://localhost:8080",
+		"distDir": "../dist",
+		"withGlobalTauri": true
+	}
+}
+```
+
+2. Actualiza la configuración de Trunk:
+
+```toml
+# Trunk.toml
+[watch]
+ignore = ["./src-tauri"]
+
+[serve]
+address = "0.0.0.0"
+```

--- a/src/content/docs/es/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/es/2/guide/frontend/trunk.mdx
@@ -7,7 +7,7 @@ Trunk es una herramienta de empaquetado de aplicaciones web WASM para Rust. Obt�
 
 :::caution[Nota sobre el soporte móvil]
 
-El desarrollo móvil de Tauri no es posible actualmente con la versión oficial de Trunk. Si desarrollas para móviles deberás utilizar https://github.com/amrbashir/trunk hasta que https://github.com/thedodd/trunk/pull/494 y https://github.com/thedodd/trunk/pull/500 sean fusionados y publicados.
+El desarrollo móvil de Tauri no es posible actualmente con la versión oficial de Trunk. Si desarrollas para móviles deberás utilizar https://github.com/amrbashir/trunk hasta que https://github.com/thedodd/trunk/pull/494 y https://github.com/thedodd/trunk/pull/500 sean aceptados y publicados.
 
 Necesitarás utilizar `cargo install --git https://github.com/amrbashir/trunk` cuando instales Trunk y luego establecer `serve.ws_protocol = "ws"` en `Trunk.toml`.
 

--- a/src/content/docs/es/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/es/2/guide/frontend/trunk.mdx
@@ -19,7 +19,7 @@ Necesitarás utilizar `cargo install --git https://github.com/amrbashir/trunk` c
 - Usa `address = "0.0.0.0"` para que el servidor web esté disponible en la red para el desarrollo móvil.
 - Habilita `withGlobalTauri` para asegurarte de que las APIs de Tauri están disponibles en la variable `window.__TAURI__` y pueden ser importadas usando `wasm-bindgen`.
 
-## Ejemplo de configuración
+## Ejemplo de Configuración
 
 1. Actualiza la configuración de Tauri:
 


### PR DESCRIPTION
Translated `nextjs.mdx`, `nuxt.mdx` & `trunk.mdx` to spanish 🇪🇸