### PR TITLE
i18n(fr): Translate `index.mdx`, `frontend/index.mdx`, `nextjs.mdx`, `nuxt.mdx`, `trunk.mdx`

### DIFF
--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Tauri est "frontend agnostique" et supporte la plupart des frameworks frontend prêts à l'emploi. Cependant, un framework a parfois besoin d'un peu plus de configuration pour l'intégrer à Tauri. Ci-dessous se trouve une liste des frameworks avec les configurations recommandées.
+Tauri est un "frontend agnostique" et supporte la plupart des frameworks frontend prêts à l'emploi. Cependant, un framework a parfois besoin d'un peu plus de configuration pour l'intégrer à Tauri. Ci-dessous se trouve une liste des frameworks avec les configurations recommandées.
 
 Si un framework n'est pas listé, il est possible qu'il fonctionne avec Tauri sans configuration supplémentaire ou qu'il n'ait pas encore été documenté. Toute contribution pour ajouter des frameworks qui requerrait une configuration supplémentaire est la bienvenue pour aider les autres membres de la communautée de Tauri.
 

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Frontend Configuration
+i18nReady: true
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Tauri est "frontend agnostique" et supporte la plupart des frameworks frontend prêts à l'emploi. Cependant, un framework a parfois besoin d'un peu plus de configuration pour l'intégrer à Tauri. Ci-dessous se trouve une liste des frameworks avec les configurations recommandées.
+
+Si un framework n'est pas listé, il est possible qu'il fonctionne avec Tauri sans configuration supplémentaire ou qu'il n'ait pas encore été documenté. Toute contribution pour ajouter des frameworks qui requerrait une configuration supplémentaire est la bienvenue pour aider les autres membres de la communautée de Tauri.
+
+:::tip[Framework Non Listé ?]
+
+Un framework manque à la liste ? Il peut fonctionner avec Tauri sans configuration supplémentaire requise. Lisez les [instructions de configuration](#instructions-de-configuration) pour une configuration commune.
+
+:::
+
+## JavaScript
+
+<CardGrid>
+	<LinkCard title="Next.js" href="fr/2/guide/frontend/nextjs" />
+	<LinkCard title="Nuxt" href="fr/2/guide/frontend/nuxt" />
+	<LinkCard title="Qwik" href="fr/2/guide/frontend/qwik" />
+	<LinkCard title="Svelte" href="fr/2/guide/frontend/svelte" />
+	<LinkCard title="Vite" href="fr/2/guide/frontend/vite" />
+	<LinkCard title="Webpack" href="fr/2/guide/frontend/webpack" />
+</CardGrid>
+
+## Rust
+
+<CardGrid>
+	<LinkCard title="Leptos" href="fr/2/guide/frontend/leptos" />
+	<LinkCard title="Sycamore" href="fr/2/guide/frontend/sycamore" />
+	<LinkCard title="Trunk" href="fr/2/guide/frontend/trunk" />
+	<LinkCard title="Yew" href="fr/2/guide/frontend/yew" />
+</CardGrid>
+
+## Instructions de Configuration
+
+Théoriquement Tauri agit comme un hôte web statique. Vous avez besoin de fournir à Tauri un dossier contenant un mix de HTML, CSS, Javascript et possiblement de WASM qui peut servir à la vue web que tauri fourni.
+Ci-dessous se trouve une liste des scénarios communs nécessaires pour intégrer un frontend avec Tauri :
+
+{/* TODO: Link to core concept of SSG/SSR, etc. */}
+{/* TODO: Link to mobile development server guide */}
+{/* TODO: Concept of how to do a client-server relationship? */}
+
+- Utilisez la génération statique de site (SSG). Tauri ne supporte pas officiellent les solutions basées sur serveur (par exemple SSR).
+- Pour le développement mobile, un serveur de développement d'un certain type est nécessaire pour héberger le frontend de votre IP locale.
+- Utilisez une relation client-serveur appropriée entre votre application et vos API (pas de solutions hybride avec SSR).

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -38,7 +38,8 @@ Un framework manque à la liste ? Il peut fonctionner avec Tauri sans configurat
 
 ## Instructions de Configuration
 
-Théoriquement Tauri agit comme un hôte web statique. Vous avez besoin de fournir à Tauri un dossier contenant un mix de HTML, CSS, Javascript et possiblement de WASM qui peut servir à la vue web que tauri fourni.
+Théoriquement, Tauri agit comme un hôte web statique. Vous avez besoin de fournir à Tauri un dossier contenant un mix de HTML, CSS, Javascript et possiblement de WASM qui peut servir à la vue web que Tauri fourni.
+
 Ci-dessous se trouve une liste des scénarios communs nécessaires pour intégrer un frontend avec Tauri :
 
 {/* TODO: Link to core concept of SSG/SSR, etc. */}

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -18,22 +18,23 @@ Un framework manque à la liste ? Il peut fonctionner avec Tauri sans configurat
 ## JavaScript
 
 <CardGrid>
-	<LinkCard title="Next.js" href="fr/2/guide/frontend/nextjs" />
-	<LinkCard title="Nuxt" href="fr/2/guide/frontend/nuxt" />
-	<LinkCard title="Qwik" href="fr/2/guide/frontend/qwik" />
-	<LinkCard title="Svelte" href="fr/2/guide/frontend/svelte" />
-	<LinkCard title="Vite" href="fr/2/guide/frontend/vite" />
-	<LinkCard title="Webpack" href="fr/2/guide/frontend/webpack" />
+	<LinkCard title="Next.js" href="/fr/2/guide/frontend/nextjs" />
+	<LinkCard title="Nuxt" href="/fr/2/guide/frontend/nuxt" />
+	<LinkCard title="Qwik" href="/fr/2/guide/frontend/qwik" />
+	<LinkCard title="Svelte" href="/fr/2/guide/frontend/svelte" />
+	<LinkCard title="Vite" href="/fr/2/guide/frontend/vite" />
+	<LinkCard title="Webpack" href="/fr/2/guide/frontend/webpack" />
 </CardGrid>
 
 ## Rust
 
 <CardGrid>
-	<LinkCard title="Leptos" href="fr/2/guide/frontend/leptos" />
-	<LinkCard title="Sycamore" href="fr/2/guide/frontend/sycamore" />
-	<LinkCard title="Trunk" href="fr/2/guide/frontend/trunk" />
-	<LinkCard title="Yew" href="fr/2/guide/frontend/yew" />
+	<LinkCard title="Leptos" href="/fr/2/guide/frontend/leptos" />
+	<LinkCard title="Sycamore" href="/fr/2/guide/frontend/sycamore" />
+	<LinkCard title="Trunk" href="/fr/2/guide/frontend/trunk" />
+	<LinkCard title="Yew" href="/fr/2/guide/frontend/yew" />
 </CardGrid>
+
 
 ## Instructions de Configuration
 

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Frontend Configuration
+title: Configuration Frontend
+
 i18nReady: true
 ---
 

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Tauri est un "frontend agnostique" et supporte la plupart des frameworks frontend prêts à l'emploi. Cependant, un framework a parfois besoin d'un peu plus de configuration pour l'intégrer à Tauri. Ci-dessous se trouve une liste des frameworks avec les configurations recommandées.
+Tauri est "frontend agnostique" et supporte la plupart des frameworks frontend prêts à l'emploi. Cependant, un framework a parfois besoin d'un peu plus de configuration pour l'intégrer à Tauri. Ci-dessous se trouve une liste des frameworks avec les configurations recommandées.
 
 Si un framework n'est pas listé, il est possible qu'il fonctionne avec Tauri sans configuration supplémentaire ou qu'il n'ait pas encore été documenté. Toute contribution pour ajouter des frameworks qui requerrait une configuration supplémentaire est la bienvenue pour aider les autres membres de la communautée de Tauri.
 

--- a/src/content/docs/fr/2/guide/frontend/index.mdx
+++ b/src/content/docs/fr/2/guide/frontend/index.mdx
@@ -47,5 +47,6 @@ Ci-dessous se trouve une liste des scénarios communs nécessaires pour intégre
 {/* TODO: Concept of how to do a client-server relationship? */}
 
 - Utilisez la génération statique de site (SSG). Tauri ne supporte pas officiellent les solutions basées sur serveur (par exemple SSR).
-- Pour le développement mobile, un serveur de développement d'un certain type est nécessaire pour héberger le frontend de votre IP locale.
+- Pour le développement mobile, un serveur de développement d'un certain type est nécessaire pour héberger le frontend sur votre IP locale.
+
 - Utilisez une relation client-serveur appropriée entre votre application et vos API (pas de solutions hybride avec SSR).

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -1,0 +1,103 @@
+---
+title: Next.js
+i18nReady: true
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+
+Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur https://nextjs.org. Ce guide est valable à partir de Next.js 13.4.19.
+
+## Liste des Vérifications
+
+- Utilisez des exports statiques en définissant `output: 'export'`. Tauri ne supporte pas les solutions basées sur serveur.
+- Utilisez `internal-ip` pour une compatibilité sur mobile pour pouvoir configurer `assetPrefix`. Ceci est requis pour que le serveur résolve correctement les assets.
+- Utilisez `out/` en tant que `distDir` dans `tauri.conf.json`.
+
+## Configuration d'Example
+
+1. Installez `internal-ip` pour le développement mobile:
+
+<CommandTabs
+	npm="npm install --save-dev internal-ip"
+	yarn="yarn add -D internal-ip"
+	pnpm="pnpm add -D internal-ip"
+/>
+
+2. Mettez à jour la configuration Tauri:
+
+<Tabs>
+	<TabItem label="npm">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "npm run dev",
+		"beforeBuildCommand": "npm run build",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+<TabItem label="yarn">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "yarn dev",
+		"beforeBuildCommand": "yarn generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+<TabItem label="pnpm">
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "pnpm dev",
+		"beforeBuildCommand": "pnpm generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+3. Mettez à jour la configuration Next.js:
+
+```ts
+// next.conf.ts
+const isProd = process.env.NODE_ENV === 'production';
+module.exports = async (phase, { defaultConfig }) => {
+	let internalHost = null;
+	// Dans le mode développeur on utilise "internal-ip" pour se servir des assets.
+	if (!isProd) {
+		const { internalIpV4 } = await import('internal-ip');
+		internalHost = await internalIpV4();
+	}
+	const nextConfig = {
+		// Assurez-vous que Next.js utilise SSG au lieu de SSR
+		// https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
+		output: 'export',
+		// Note: Cette fonctionnalité expérimentale est requise pour utiliser NextJS Image en mode SSG.
+		// Voir https://nextjs.org/docs/messages/export-image-api pour des solutions différentes.
+		images: {
+			unoptimized: true,
+		},
+		// Configurez assetPrefix sinon le server ne résoudra pas correctement vos assets.
+		assetPrefix: isProd ? null : `http://${internalHost}:3000`,
+	};
+	return nextConfig;
+};
+```

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -11,7 +11,8 @@ Next.js est un framework React. Apprenez-en plus au sujet de Next.js sur https:/
 
 ## Liste de contrôle
 
-- Utilisez des exports statiques en définissant `output: 'export'`. Tauri ne supporte pas les solutions basées sur serveur.
+- Utilisez des exports statiques en définissant `output: 'export'`. Tauri ne supporte pas les solutions basées sur un serveur.
+
 - Utilisez `internal-ip` pour une compatibilité sur mobile pour pouvoir configurer `assetPrefix`. Ceci est requis pour que le serveur résolve correctement les assets.
 - Utilisez `out/` en tant que `distDir` dans `tauri.conf.json`.
 

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -15,7 +15,8 @@ Next.js est un framework React. Apprenez-en plus au sujet de Next.js sur https:/
 - Utilisez `internal-ip` pour une compatibilité sur mobile pour pouvoir configurer `assetPrefix`. Ceci est requis pour que le serveur résolve correctement les assets.
 - Utilisez `out/` en tant que `distDir` dans `tauri.conf.json`.
 
-## Configuration d'Exemple
+## Exemple de configuration
+
 
 1. Installez `internal-ip` pour le développement mobile :
 

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -16,7 +16,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 
 ## Configuration d'Exemple
 
-1. Installez `internal-ip` pour le développement mobile:
+1. Installez `internal-ip` pour le développement mobile :
 
 <CommandTabs
 	npm="npm install --save-dev internal-ip"
@@ -24,7 +24,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 	pnpm="pnpm add -D internal-ip"
 />
 
-2. Mettez à jour la configuration de Tauri:
+2. Mettez à jour la configuration de Tauri :
 
 <Tabs>
 	<TabItem label="npm">
@@ -74,7 +74,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 </TabItem>
 </Tabs>
 
-3. Mettez à jour la configuration de Next.js:
+3. Mettez à jour la configuration de Next.js :
 
 ```ts
 // next.conf.ts

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -9,7 +9,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 Next.js est un framework React. Apprenez-en plus au sujet de Next.js sur https://nextjs.org. Ce guide est valable à partir de Next.js 13.4.19.
 
 
-## Liste des Vérifications
+## Liste de contrôle
 
 - Utilisez des exports statiques en définissant `output: 'export'`. Tauri ne supporte pas les solutions basées sur serveur.
 - Utilisez `internal-ip` pour une compatibilité sur mobile pour pouvoir configurer `assetPrefix`. Ceci est requis pour que le serveur résolve correctement les assets.

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -14,7 +14,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 - Utilisez `internal-ip` pour une compatibilité sur mobile pour pouvoir configurer `assetPrefix`. Ceci est requis pour que le serveur résolve correctement les assets.
 - Utilisez `out/` en tant que `distDir` dans `tauri.conf.json`.
 
-## Configuration d'Example
+## Configuration d'Exemple
 
 1. Installez `internal-ip` pour le développement mobile:
 

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -24,7 +24,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 	pnpm="pnpm add -D internal-ip"
 />
 
-2. Mettez à jour la configuration Tauri:
+2. Mettez à jour la configuration de Tauri:
 
 <Tabs>
 	<TabItem label="npm">
@@ -74,7 +74,7 @@ Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur http
 </TabItem>
 </Tabs>
 
-3. Mettez à jour la configuration Next.js:
+3. Mettez à jour la configuration de Next.js:
 
 ```ts
 // next.conf.ts

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -83,7 +83,8 @@ Next.js est un framework React. Apprenez-en plus au sujet de Next.js sur https:/
 const isProd = process.env.NODE_ENV === 'production';
 module.exports = async (phase, { defaultConfig }) => {
 	let internalHost = null;
-	// Dans le mode développeur on utilise "internal-ip" pour se servir des assets.
+	// En mode développement, on utilise "internal-ip" pour se servir des assets.
+
 	if (!isProd) {
 		const { internalIpV4 } = await import('internal-ip');
 		internalHost = await internalIpV4();

--- a/src/content/docs/fr/2/guide/frontend/nextjs.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nextjs.mdx
@@ -6,7 +6,8 @@ i18nReady: true
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import CommandTabs from '@components/CommandTabs.astro';
 
-Next.js est un framework de React. Apprenez-en plus au sujet de Next.js sur https://nextjs.org. Ce guide est valable à partir de Next.js 13.4.19.
+Next.js est un framework React. Apprenez-en plus au sujet de Next.js sur https://nextjs.org. Ce guide est valable à partir de Next.js 13.4.19.
+
 
 ## Liste des Vérifications
 

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -17,7 +17,8 @@ Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable à 
 - Compilez en utilisant `nuxi generate`.
 - (Optionnel): Désactivez la télémétrie en définisant `telemetry: false` dans `nuxt.config.ts`.
 
-## Configuration d'Exemple
+## Exemple de configuration
+
 
 1. Mettez à jour la configuration de Tauri :
 

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -91,7 +91,8 @@ export default defineNuxtConfig({
 			// Active le serveur de développement pour être visible par les autres appareils pour le développement mobile
 			host: '0.0.0.0',
 			hmr: {
-				// Utiliser le websocket pour le rechargement à chaud
+				// Utilisez le websocket pour le rechargement à chaud
+
 				protocol: 'ws',
 				// Assurez-vous que ce soit disponible sur le réseau
 				host: '0.0.0.0',

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -8,7 +8,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable à partir de Nuxt 3.7.
 
 
-## Liste des Vérifications
+## Liste de contrôle
+
 
 - Utilisez SSG en définissant `ssr: false`. Tauri ne supporte pas les solutions basées sur serveur.
 - Définisez "host" sur `0.0.0.0`.

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -17,7 +17,7 @@ Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable dep
 
 ## Configuration d'Exemple
 
-1. Mettez à jour la configuration de Tauri:
+1. Mettez à jour la configuration de Tauri :
 
 <Tabs>
 	<TabItem label="npm">
@@ -67,7 +67,7 @@ Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable dep
 	</TabItem>
 </Tabs>
 
-2. Mettez à jour la configuration de Nuxt:
+2. Mettez à jour la configuration de Nuxt :
 
 ```ts
 export default defineNuxtConfig({

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -1,0 +1,101 @@
+---
+title: Nuxt
+i18nReady: true
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Apprenez-en plus à propos de Nuxt sur https://nuxt.com. Ce guide est valable depuis Nuxt 3.7.
+
+## Liste des Vérifications
+
+- Utilisez SSG en définissant `ssr: false`. Tauri ne supporte pas les solutions basées sur serveur.
+- Définisez "host" sur `0.0.0.0`.
+- Utilisez `dist/` en tant que `distDir` dans `tauri.conf.json`.
+- Compilez en utilisant `nuxi generate`.
+- (Optionnel): Désactivez la télémétrie en définisant `telemetry: false` dans `nuxt.config.ts`.
+
+## Configuration d'Exemple
+
+1. Mettez à jour la configuration de Tauri:
+
+<Tabs>
+	<TabItem label="npm">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "npm run dev",
+		"beforeBuildCommand": "npm run generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+	<TabItem label="yarn">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "yarn dev",
+		"beforeBuildCommand": "yarn generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+	<TabItem label="pnpm">
+	
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "pnpm dev",
+		"beforeBuildCommand": "pnpm generate",
+		"devPath": "http://localhost:3000",
+		"distDir": "../dist"
+	}
+}
+```
+	
+	</TabItem>
+</Tabs>
+
+2. Mettez à jour la configuration Nuxt:
+
+```ts
+export default defineNuxtConfig({
+	// (optionnel) Activez les outils de développement Nuxt
+	devtools: { enabled: true },
+	// Activez SSG
+	ssr: false,
+	vite: {
+		// Meilleur compatibilité pour la sortie "Tauri CLI"
+		clearScreen: false,
+		// Activez les variables d'environnement
+		// Vous pouvez trouver les variables d'environnements additionnelles sur
+		// https://tauri.app/2/reference/environment-variables/
+		envPrefix: ['VITE_', 'TAURI_'],
+		server: {
+			// Tauri requiert un port constant
+			strictPort: true,
+			// Active le serveur de développement pour être visible par les autres appareils pour le développement mobile
+			host: '0.0.0.0',
+			hmr: {
+				// Utiliser le websocket pour le rechargement à chaud
+				protocol: 'ws',
+				// Assurez-vous que ce soit disponible sur le réseau
+				host: '0.0.0.0',
+				// Utilisez un port spécifique pour hmr
+				port: 5183,
+			},
+		},
+	},
+});
+```

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -5,7 +5,8 @@ i18nReady: true
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable depuis Nuxt 3.7.
+Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable à partir de Nuxt 3.7.
+
 
 ## Liste des Vérifications
 

--- a/src/content/docs/fr/2/guide/frontend/nuxt.mdx
+++ b/src/content/docs/fr/2/guide/frontend/nuxt.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Apprenez-en plus à propos de Nuxt sur https://nuxt.com. Ce guide est valable depuis Nuxt 3.7.
+Apprenez-en plus au sujet de Nuxt sur https://nuxt.com. Ce guide est valable depuis Nuxt 3.7.
 
 ## Liste des Vérifications
 
@@ -67,7 +67,7 @@ Apprenez-en plus à propos de Nuxt sur https://nuxt.com. Ce guide est valable de
 	</TabItem>
 </Tabs>
 
-2. Mettez à jour la configuration Nuxt:
+2. Mettez à jour la configuration de Nuxt:
 
 ```ts
 export default defineNuxtConfig({

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -1,0 +1,48 @@
+---
+title: Trunk
+i18nReady: true
+---
+
+Trunk est un bundler d'applications web WASM pour Rust. Apprenez-en plus au sujet de Trunk sur https://trunkrs.dev. Ce guide est valable à partir de Trunk 0.17.5.
+
+:::caution[Note sur le Support Mobile]
+
+Le développement mobile avec Tauri n'est pas possible actuellement avec la version officielle de Trunk. Si vous développez pour mobile vous allez avoir besoin d'utiliser https://github.com/amrbashir/trunk jusqu'à ce que https://github.com/thedodd/trunk/pull/494 et https://github.com/thedodd/trunk/pull/500 soient fusionnées et disponnible.
+
+Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` lorsque vous installez Trunk, ensuite définissez `serve.ws_protocol = "ws"` dans `Trunk.toml`.
+
+:::
+
+## Liste des Vérifications
+
+- Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur serveur.
+- Utilisez `address = "0.0.0.0"` pour que le serveur web soit disponible sur le réseau pour le développement mobile.
+- Activez `withGlobalTauri` pour assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
+
+## Configuration d'Exemple
+
+1. Mettez à jour votre configuration de Tauri:
+
+```json
+// tauri.conf.json
+{
+	"build": {
+		"beforeDevCommand": "trunk serve",
+		"beforeBuildCommand": "trunk build",
+		"devPath": "http://localhost:8080",
+		"distDir": "../dist",
+		"withGlobalTauri": true
+	}
+}
+```
+
+2. Mettez à jour la configuration de Trunk:
+
+```toml
+# Trunk.toml
+[watch]
+ignore = ["./src-tauri"]
+
+[serve]
+address = "0.0.0.0"
+```

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -20,7 +20,7 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` po
 - Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur un serveur.
 
 - Utilisez `address = "0.0.0.0"` pour que le serveur web soit disponible sur le réseau pour le développement mobile.
-- Activez `withGlobalTauri` pour vous assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
+- Activez `withGlobalTauri` pour vous assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent être importées en utilisant `wasm-bindgen`.
 
 
 ## Exemple de configuration

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -17,7 +17,8 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` po
 ## Liste de contrôle
 
 
-- Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur serveur.
+- Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur un serveur.
+
 - Utilisez `address = "0.0.0.0"` pour que le serveur web soit disponible sur le réseau pour le développement mobile.
 - Activez `withGlobalTauri` pour vous assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
 

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -22,7 +22,8 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` po
 - Activez `withGlobalTauri` pour vous assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
 
 
-## Configuration d'Exemple
+## Exemple de configuration
+
 
 1. Mettez à jour votre configuration de Tauri :
 

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -19,7 +19,8 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` po
 
 - Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur serveur.
 - Utilisez `address = "0.0.0.0"` pour que le serveur web soit disponible sur le réseau pour le développement mobile.
-- Activez `withGlobalTauri` pour assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
+- Activez `withGlobalTauri` pour vous assurer que les APIs de Tauri sont disponibles dans la variable `window.__TAURI__` et peuvent importées en utilisant `wasm-bindgen`.
+
 
 ## Configuration d'Exemple
 

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -14,7 +14,8 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` po
 
 :::
 
-## Liste des Vérifications
+## Liste de contrôle
+
 
 - Utilisez SSG, Tauri ne supporte pas officielement les solutions basées sur serveur.
 - Utilisez `address = "0.0.0.0"` pour que le serveur web soit disponible sur le réseau pour le développement mobile.

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -21,7 +21,7 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` lo
 
 ## Configuration d'Exemple
 
-1. Mettez à jour votre configuration de Tauri:
+1. Mettez à jour votre configuration de Tauri :
 
 ```json
 // tauri.conf.json
@@ -36,7 +36,7 @@ Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` lo
 }
 ```
 
-2. Mettez à jour la configuration de Trunk:
+2. Mettez à jour la configuration de Trunk :
 
 ```toml
 # Trunk.toml

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -9,7 +9,8 @@ Trunk est un bundler d'applications web WASM pour Rust. Apprenez-en plus au suje
 
 Le développement mobile avec Tauri n'est pas possible actuellement avec la version officielle de Trunk. Si vous développez pour mobile vous allez avoir besoin d'utiliser https://github.com/amrbashir/trunk jusqu'à ce que https://github.com/thedodd/trunk/pull/494 et https://github.com/thedodd/trunk/pull/500 soient fusionnées et disponnible.
 
-Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` lorsque vous installez Trunk, ensuite définissez `serve.ws_protocol = "ws"` dans `Trunk.toml`.
+Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` pour installer Trunk, ensuite définissez `serve.ws_protocol = "ws"` dans `Trunk.toml`.
+
 
 :::
 

--- a/src/content/docs/fr/2/guide/frontend/trunk.mdx
+++ b/src/content/docs/fr/2/guide/frontend/trunk.mdx
@@ -7,7 +7,7 @@ Trunk est un bundler d'applications web WASM pour Rust. Apprenez-en plus au suje
 
 :::caution[Note sur le Support Mobile]
 
-Le développement mobile avec Tauri n'est pas possible actuellement avec la version officielle de Trunk. Si vous développez pour mobile vous allez avoir besoin d'utiliser https://github.com/amrbashir/trunk jusqu'à ce que https://github.com/thedodd/trunk/pull/494 et https://github.com/thedodd/trunk/pull/500 soient fusionnées et disponnible.
+Le développement mobile avec Tauri est actuellement impossible avec la version officielle de Trunk. Si vous développez pour mobile vous aurez besoin d'utiliser https://github.com/amrbashir/trunk jusqu'à ce que https://github.com/thedodd/trunk/pull/494 et https://github.com/thedodd/trunk/pull/500 soient fusionnées et disponibles.
 
 Vous devrez utiliser `cargo install --git https://github.com/amrbashir/trunk` lorsque vous installez Trunk, ensuite définissez `serve.ws_protocol = "ws"` dans `Trunk.toml`.
 

--- a/src/content/docs/fr/2/guide/upgrade-migrate/from-tauri-1.mdx
+++ b/src/content/docs/fr/2/guide/upgrade-migrate/from-tauri-1.mdx
@@ -28,8 +28,6 @@ Tauri v2 contient la commande `migrate` qui simplifie votre migration:
 
 Apprenez-en plus à-propos de la commande `migrate` dans l'[interface de référence des commandes](/2/reference/cli#migrate)
 
-Learn more about the `migrate` command in the [Command Line Interface reference](/2/reference/cli#migrate)
-
 ## Sommaire des Changements
 
 Voici ci-dessous un sommaire des changement entre Tauri 1.0 et Tauri 2.0:

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -41,8 +41,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		pas besoin de changer votre configuration.
 	</Card>
 	<Card title="Multiplatforme" icon="rocket">
-		Développez vos applications pour Linux, macOS, Windows, Android et iOS
-		- tout cela à partir du même code.
+		Développez vos applications pour Linux, macOS, Windows, Android et iOS - tout cela à partir du même code.
 	</Card>
 	<Card title="Communication Inter-Processus" icon="rocket">
 		Écrivez votre frontend en Javascript, la logique de l'application en Rust,

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -51,7 +51,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	</Card>
 	<Card title="Communication Inter-Processus" icon="rocket">
 		Écrivez votre frontend en Javascript, la logique de l'application en Rust,
-		puis intégrez-là profondément dans le système avec Swift et Kotlin.
+		puis intégrez le tout profondément dans le système avec Swift et Kotlin.
 	</Card>
 	<Card title="Sécurité Maximale" icon="rocket">
 		C'est la première préoccupation de l'équipe Tauri, qui dirige nos priorités et nos plus

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Base renforcée pour vos applications web.
+description: Les outils de création d'applications multiplatformes
+i18nReady: true
+template: splash
+hero:
+  image:
+    file: ../../assets/logo-outline.svg
+  actions:
+    - text: Commencer
+      link: fr/2/guide/
+      icon: right-arrow
+      variant: primary
+    - text: Directives de Contrubution
+      link: fr/contribute/
+      icon: open-book
+      variant: minimal
+    - text: Documentation de Tauri 1.0
+      link: https://tauri.app
+      icon: external
+      variant: minimal
+banner:
+  content: |
+    Vous êtes sur l'avant-première du site pour Tauri 2.0 -
+    <a href="https://tauri.app">Aller au site de Tauri 1.0</a>
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<div class="hero-bg">
+	<div class="bg-logo"></div>
+	<div class="bg-grad"></div>
+	<div class="bg-grad-red"></div>
+</div>
+
+<CardGrid stagger>
+	<Card title="Frontend Indépendant" icon="rocket">
+		Importez votre configuration web existant dans Tauri ou démarrez ce nouveau
+		projet de rêve.
+		Tauri supporte n'importe quel framework de frontend, vous n'avez donc
+		pas besoin de changer votre configuration.
+	</Card>
+	<Card title="Multiplatforme" icon="rocket">
+		Développez vos applications pour Linux, macOS, Windows, Android et iOS
+		- tout cela à partir du même code.
+	</Card>
+	<Card title="Communication Inter-Processus" icon="rocket">
+		Écrivez votre frontend en Javascript, la logique de l'application en Rust,
+		puis intégrez-là profondément dans le système avec Swift et Kotlin.
+	</Card>
+	<Card title="Sécurité Maximale" icon="rocket">
+		Un élément important pour l'équipe Tauri, qui dirige nos priorités et nos plus
+		grandes innovations.
+	</Card>
+	<Card title="Poids Minimal" icon="rocket">
+		En utilisant le moteur de rendu web natif du système d'exploitation,
+		le poids d'une application Tauri peut être bas comme 600 Ko.
+	</Card>
+	<Card title="Fonctionne avec Rust" icon="rocket">
+		Avec les performance et la sécurité pour priorités, Rust est le langage
+		destiné à la nouvelle génération d'applications.
+	</Card>
+</CardGrid>

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -39,7 +39,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Frontend Indépendant" icon="rocket">
-		Importez votre configuration web existant dans Tauri ou démarrez ce nouveau
+		Importez votre configuration web existant dans Tauri ou démarrez votre nouveau
+
 		projet de rêve.
 		Tauri supporte n'importe quel framework de frontend, vous n'avez donc
 		pas besoin de changer votre configuration.

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -60,7 +60,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	</Card>
 	<Card title="Poids Minimal" icon="rocket">
 		En utilisant le moteur de rendu web natif du système d'exploitation,
-		le poids d'une application Tauri peut être bas comme 600 Ko.
+		le poids d'une application Tauri peut atteindre 600 Ko.
+
 	</Card>
 	<Card title="Fonctionne avec Rust" icon="rocket">
 		Avec les performance et la sécurité pour priorités, Rust est le langage

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -42,8 +42,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		pas besoin de changer votre configuration.
 	</Card>
 	<Card title="Multiplatforme" icon="rocket">
-		Développez vos applications pour Linux, macOS, Windows, Android et iOS
-		- tout cela à partir du même code.
+		Développez vos applications pour Linux, macOS, Windows, Android et iOS - tout cela à partir du même code.
+
 	</Card>
 	<Card title="Communication Inter-Processus" icon="rocket">
 		Écrivez votre frontend en Javascript, la logique de l'application en Rust,

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -25,7 +25,8 @@ hero:
 banner:
   content: |
     Vous êtes sur l'avant-première du site pour Tauri 2.0 -
-    <a href="https://tauri.app">Aller au site de Tauri 1.0</a>
+    <a href="https://tauri.app">Aller sur le site de Tauri 1.0</a>
+
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Base renforcée pour vos applications web.
+title: Une fondation robuste pour vos applications web.
+
 description: Les outils de création d'applications multiplatformes
 i18nReady: true
 template: splash

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -8,11 +8,12 @@ hero:
     file: ../../../assets/logo-outline.svg
   actions:
     - text: Commencer
-      link: fr/2/guide/
+      link: /fr/2/guide/
       icon: right-arrow
       variant: primary
     - text: Directives de Contrubution
-      link: fr/contribute/
+      link: /fr/contribute/
+
       icon: open-book
       variant: minimal
     - text: Documentation de Tauri 1.0

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 template: splash
 hero:
   image:
-    file: ../../assets/logo-outline.svg
+    file: ../../../assets/logo-outline.svg
   actions:
     - text: Commencer
       link: fr/2/guide/

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -66,6 +66,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	<Card title="Fonctionne avec Rust" icon="rocket">
 		Avec la performance et la sécurité au cœur de ses priorités, Rust est le langage
 
-		destiné à la nouvelle génération d'applications.
+		de la nouvelle génération d'applications.
 	</Card>
 </CardGrid>

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -42,7 +42,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		Importez votre configuration web existant dans Tauri ou démarrez votre nouveau
 
 		projet de rêve.
-		Tauri supporte n'importe quel framework de frontend, vous n'avez donc
+		Tauri supporte n'importe quel framework frontend, vous n'avez donc
+
 		pas besoin de changer votre configuration.
 	</Card>
 	<Card title="Multiplatforme" icon="rocket">

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -12,7 +12,8 @@ hero:
       link: /fr/2/guide/
       icon: right-arrow
       variant: primary
-    - text: Directives de Contrubution
+    - text: Règles de contribution
+
       link: /fr/contribute/
 
       icon: open-book

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -54,7 +54,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		puis intégrez-là profondément dans le système avec Swift et Kotlin.
 	</Card>
 	<Card title="Sécurité Maximale" icon="rocket">
-		Un élément important pour l'équipe Tauri, qui dirige nos priorités et nos plus
+		C'est la première préoccupation de l'équipe Tauri, qui dirige nos priorités et nos plus
+
 		grandes innovations.
 	</Card>
 	<Card title="Poids Minimal" icon="rocket">

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -64,7 +64,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 	</Card>
 	<Card title="Fonctionne avec Rust" icon="rocket">
-		Avec les performance et la sécurité pour priorités, Rust est le langage
+		Avec la performance et la sécurité au cœur de ses priorités, Rust est le langage
+
 		destiné à la nouvelle génération d'applications.
 	</Card>
 </CardGrid>


### PR DESCRIPTION
Here it is, it may needs a double check but
- [fr/index.mdx](https://github.com/0ri0nexe/tauri-docs/blob/next/src/content/docs/fr/index.mdx)
- fr/2/guide/frontend/
   - [index.mdx](https://github.com/0ri0nexe/tauri-docs/blob/next/src/content/docs/fr/2/guide/frontend/index.mdx)
   - [nextjs.mdx](https://github.com/0ri0nexe/tauri-docs/blob/next/src/content/docs/fr/2/guide/frontend/nextjs.mdx)
   - [nuxt.mdx](https://github.com/0ri0nexe/tauri-docs/blob/next/src/content/docs/fr/2/guide/frontend/nuxt.mdx)
   - [trunk.mdx](https://github.com/0ri0nexe/tauri-docs/blob/next/src/content/docs/fr/2/guide/frontend/trunk.mdx)

are translated into french