### PR TITLE
feat: add additional info about signing builds and C libraries

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -153,7 +153,7 @@ Make sure to check the [documentation for GitHub Actions][github actions] to und
 
 ## Experimental: Build Windows apps on Linux and macOS
 
-Tauri v1.3 added a new Windows installer type based on the [NSIS] installer framework. In contrast to WiX, NSIS itself can also work on Linux and macOS which makes it possible to build many Tauri apps on non-Windows hosts. Note that this is currently considered highly experimental and may not work on every system or for every project. Therefore it should only be used as a last resort if local VMs or CI solutions like GitHub Actions don't work for you.
+Tauri v1.3 added a new Windows installer type based on the [NSIS] installer framework. In contrast to WiX, NSIS itself can also work on Linux and macOS which makes it possible to build many Tauri apps on non-Windows hosts. Note that this is currently considered highly experimental and may not work on every system or for every project. Therefore it should only be used as a last resort if local VMs or CI solutions like GitHub Actions don't work for you. **Note that, at this time, signing cross-platform builds is currently unsupported.**
 
 Since Tauri officially only supports the MSVC Windows target, the setup is a bit more involved.
 
@@ -250,6 +250,15 @@ rustflags = [
 Keep in mind that this file is specific to your machine so we don't recommend checking it into git if your project is public or will be shared with anyone.
 
 #### Building the App
+
+:::note
+
+If your application has dependencies to C libraries such as `ring` or `libsqlite3-sys`, building your application cross-platform gets a little trickier, 
+as you will also need to set up the appropriate environment variables and packages to cross-compile those C libraries on your system. These may include 
+setting the `CC`, `CXX`, `AR` and other environment variables, although this depends heavily on the set up of your build environment. Please refer to 
+the documentation of the libraries you are using for more information about any additional configuration for cross-compilation.
+
+:::
 
 Now it should be as simple as adding the target to the `tauri build` command:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description
<!-- Delete any that don’t apply -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->

I added additional documentation about cross-platform that I didn't see. I thought this information would at least be useful to people who attempt to go down this rabbit hole.

About the signing addition, it wasn't working, so I did some code-spelunking [eventually found this](https://github.com/tauri-apps/tauri/blob/1bce7397a496ca0cecf67fb5e3ec69d90fc871b0/tooling/bundler/src/bundle/windows/nsis.rs#L175). I thought that it should be documented.

About the C library compilation addition, there were a number of environment variables I had to set in my Github runner in order to get this working. I had to cross-compile `libsqlite3-sys` and `ring` and found that the following worked for me, but wasn't sure if I should document it, so I added what I did.

```shell
xwin --accept-license --cache-dir ~/.xwin-cache/ splat --output ~/.xwin/
sudo ln -s $(which clang) /usr/bin/clang-cl
# this file contains all the environment variables necessary for cross-compilation of Tauri
{
    echo CC=/usr/bin/clang-cl
    echo CXX=/usr/bin/clang-cl
    echo TARGET_CC=/usr/bin/clang-cl
    echo TARGET_CXX=/usr/bin/clang-cl
    echo TARGET_AR=/usr/bin/llvm-link
    echo CC_x86_64_pc_windows_msvc=/usr/bin/clang-cl
    echo AR_x86_64_pc_windows_msvc=/usr/bin/llvm-lib
    echo CXX_x86_64_pc_windows_msvc=/usr/bin/clang-cl
    echo CFLAGS_x86_64_pc_windows_msvc="--target=x86_64-pc-windows-msvc -Wno-unused-command-line-argument -fuse-ld=lld-link /imsvc$HOME/.xwin/crt/include /imsvc$HOME/.xwin/sdk/include/ucrt /imsvc$HOME/.xwin/sdk/include/um /imsvc$HOME/.xwin/sdk/include/shared"
    echo CXXFLAGS_x86_64_pc_windows_msvc="--target=x86_64-pc-windows-msvc -Wno-unused-command-line-argument -fuse-ld=lld-link /imsvc$HOME/.xwin/crt/include /imsvc$HOME/.xwin/sdk/include/ucrt /imsvc$HOME/.xwin/sdk/include/um /imsvc$HOME/.xwin/sdk/include/shared"
    echo BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_msvc="-I$HOME/.xwin/crt/include -I$HOME/.xwin/sdk/include/ucrt -I$HOME/.xwin/sdk/include/um -I$HOME/.xwin/sdk/include/shared"
    echo RCFLAGS="-I$HOME/.xwin/crt/include -I$HOME/.xwin/sdk/include/ucrt -I$HOME/.xwin/sdk/include/um -I$HOME/.xwin/sdk/include/shared"
    echo CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=/usr/bin/lld-link
} >> $GITHUB_ENV

cat <<EOF >> $HOME/.cargo/config.toml                 
[target.x86_64-pc-windows-msvc]
linker = "lld"
rustflags = [
  "-C",
  "linker-flavor=lld-link",
  "-Lnative=$HOME/.xwin/crt/lib/x86_64",
  "-Lnative=$HOME/.xwin/sdk/lib/um/x86_64",
  "-Lnative=$HOME/.xwin/sdk/lib/ucrt/x86_64"
]
EOF
```

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->