### PR TITLE
fix: bun pm supported, not runtime

### DIFF
--- a/src/content/docs/blog/tauri-1-5.mdx
+++ b/src/content/docs/blog/tauri-1-5.mdx
@@ -40,7 +40,7 @@ In the future, this might change, so please adjust your publish pipelines accord
 
 ### Bun support
 
-The Tauri CLI now supports the [Bun](https://bun.sh/) runtime and package manager.
+The Tauri CLI now supports the [Bun](https://bun.sh/) package manager.
 
 We would like to thank [@colinhacks](https://github.com/colinhacks) for submitting the pull requests for this feature!
 


### PR DESCRIPTION
Removing the runtime part makes it clearer Bun isn't an alternative backend

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description
<!-- Delete any that don’t apply -->
- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->