### PR TITLE
fix: Remove extra line breaks in French home page

### DIFF
--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -37,34 +37,28 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Frontend Indépendant" icon="rocket">
-		Importez votre configuration web existant dans Tauri ou démarrez votre nouveau
-
-    	projet de rêve.
-    	Tauri supporte n'importe quel framework frontend, vous n'avez donc
-
-    	pas besoin de changer votre configuration.
-    </Card>
-    <Card title="Multiplatforme" icon="rocket">
-    	Développez vos applications pour Linux, macOS, Windows, Android et iOS - tout cela à partir du même code.
-    </Card>
-    <Card title="Communication Inter-Processus" icon="rocket">
-    	Écrivez votre frontend en Javascript, la logique de l'application en Rust,
-    	puis intégrez le tout profondément dans le système avec Swift et Kotlin.
-    </Card>
-    <Card title="Sécurité Maximale" icon="rocket">
-    	C'est la première préoccupation de l'équipe Tauri, qui dirige nos priorités et nos plus
-
-    	grandes innovations.
-    </Card>
-    <Card title="Poids Minimal" icon="rocket">
-    	En utilisant le moteur de rendu web natif du système d'exploitation,
-    	le poids d'une application Tauri peut atteindre 600 Ko.
-
-    </Card>
-    <Card title="Fonctionne avec Rust" icon="rocket">
-    	Avec la performance et la sécurité au cœur de ses priorités, Rust est le langage
-
-    	de la nouvelle génération d'applications.
-    </Card>
-
+		Importez votre configuration web existant dans Tauri ou démarrez votre
+		nouveau projet de rêve. Tauri supporte n'importe quel framework frontend,
+		vous n'avez donc pas besoin de changer votre configuration.
+	</Card>
+	<Card title="Multiplatforme" icon="rocket">
+		Développez vos applications pour Linux, macOS, Windows, Android et iOS -
+		tout cela à partir du même code.
+	</Card>
+	<Card title="Communication Inter-Processus" icon="rocket">
+		Écrivez votre frontend en Javascript, la logique de l'application en Rust,
+		puis intégrez le tout profondément dans le système avec Swift et Kotlin.
+	</Card>
+	<Card title="Sécurité Maximale" icon="rocket">
+		C'est la première préoccupation de l'équipe Tauri, qui dirige nos priorités
+		et nos plus grandes innovations.
+	</Card>
+	<Card title="Poids Minimal" icon="rocket">
+		En utilisant le moteur de rendu web natif du système d'exploitation, le
+		poids d'une application Tauri peut atteindre 600 Ko.
+	</Card>
+	<Card title="Fonctionne avec Rust" icon="rocket">
+		Avec la performance et la sécurité au cœur de ses priorités, Rust est le
+		langage de la nouvelle génération d'applications.
+	</Card>
 </CardGrid>


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
French home page had extra line breaks in paragraphs. This was related to a malformed MDX, with spaces instead of tabs (curiously, prettier did not format the whole `<CardGrid>` element until I replaced all spaces by tabs).

Before:
![image](https://github.com/tauri-apps/tauri-docs/assets/628140/a5774bf2-cf6d-453c-835a-d41d754ae9ed)

After:
![image](https://github.com/tauri-apps/tauri-docs/assets/628140/c43aee8f-deec-409f-b487-a2390dcbbf55)
