### PR TITLE
Fix wrong variable name and adjust path

### DIFF
--- a/docs/guides/distribution/sign-windows.md
+++ b/docs/guides/distribution/sign-windows.md
@@ -55,7 +55,7 @@ We now need to import our `.pfx` file.
 
 1. Assign your export password to a variable using `$WINDOWS_PFX_PASSWORD = 'MYPASSWORD'`
 
-2. Now Import the certificate using `Import-PfxCertificate -FilePath Certs/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)`
+2. Now Import the certificate using `Import-PfxCertificate -FilePath certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $WINDOWS_PFX_PASSWORD -Force -AsPlainText)`
 
 ### C. Prepare Variables
    


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

When I followed this guide the last few times, I needed to change the variable name from `$env:WINDOWS_PFX_PASSWORD` to just `$WINDOWS_PFX_PASSWORD`, as defined in the step before. It's been a while, but I assume this is still the case. Additionally, I removed the `Certs` directory from the file path, since in step A2, we've already changed the current directory to `Documents/Certs`.

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->