### PR TITLE
Create clipboard guide #1475

### DIFF
--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -5,10 +5,98 @@ description: Read and write to the system clipboard.
 
 import Stub from '@components/Stub.astro';
 import PluginLinks from '@components/PluginLinks.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
 
 <PluginLinks plugin="clipboard-manager" />
 
-<Stub>
-	Based on
-	https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/clipboard-manager
-</Stub>
+Read and write to the system clipboard using the clipboard plugin.
+
+## Setup
+
+Install the clipboard plugin to get started.
+
+<Tabs>
+    <TabItem label="Automatic">
+
+    1. Use your project's package manager to add the dependency:
+
+    <CommandTabs npm="npm run tauri plugin add clipboard-manager"
+    yarn="yarn run tauri plugin add clipboard-manager"
+    pnpm="pnpm tauri plugin add clipboard-manager"
+    cargo="cargo tauri plugin add clipboard-manager" />
+
+    2. Modify `lib.rs` to initialize the plugin:
+
+    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
+
+    ```rust
+    #[cfg_attr(mobile, tauri::mobile_entry_point)]
+    pub fn run() {
+        tauri::Builder::default()
+            // Initialize the plugin
+            .plugin(tauri_plugin_clipboard_manager::init())
+            .run(tauri::generate_context!())
+            .expect("error while running tauri application");
+    }
+    ```
+
+    </TabItem>
+    <TabItem label="Manual">
+
+    1. Run `cargo add tauri-plugin-clipboard-manager` to add the plugin to the project's dependencies in `Cargo.toml`.
+
+    2. Modify `lib.rs` to initialize the plugin:
+
+    ```rust
+    // lib.rs
+    #[cfg_attr(mobile, tauri::mobile_entry_point)]
+    pub fn run() {
+        tauri::Builder::default()
+            // Initialize the plugin
+            .plugin(tauri_plugin_clipboard_manager::init())
+            .run(tauri::generate_context!())
+            .expect("error while running tauri application");
+    }
+    ```
+
+    3. If you'd like to manage the clipboard in JavaScript then install the npm package as well:
+
+    <CommandTabs
+        npm="npm install @tauri-apps/plugin-clipboard-manager"
+        yarn="yarn add @tauri-apps/plugin-clipboard-manager"
+        pnpm="pnpm add @tauri-apps/plugin-clipboard-manager"
+    />
+
+    </TabItem>
+
+</Tabs>
+
+## Usage
+
+{/* TODO: Link to which language to use, frontend vs. backend guide when it's made */}
+
+The clipboard plugin is available in both JavaScript and Rust.
+
+<Tabs>
+<TabItem label="JavaScript">
+
+```js
+import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
+
+// Write text to the clipboard
+await writeText('Tauri is awesome!');
+
+// Read text from the clipboard
+assert(await readText(), 'Tauri is awesome!');
+```
+
+</TabItem>
+<TabItem label="Rust">
+
+{/* TODO: */}
+
+<Stub />
+
+</TabItem>
+</Tabs>

--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -88,7 +88,9 @@ import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 await writeText('Tauri is awesome!');
 
 // Read text from the clipboard
-assert(await readText(), 'Tauri is awesome!');
+const content = await readText()
+console.log(content)
+// Prints "Tauri is awesome!" to the console
 ```
 
 </TabItem>

--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -21,10 +21,10 @@ Install the clipboard plugin to get started.
 
     1. Use your project's package manager to add the dependency:
 
-    <CommandTabs npm="npm run tauri plugin add clipboard-manager"
-    yarn="yarn run tauri plugin add clipboard-manager"
-    pnpm="pnpm tauri plugin add clipboard-manager"
-    cargo="cargo tauri plugin add clipboard-manager" />
+    <CommandTabs npm="npm run tauri add clipboard-manager"
+    yarn="yarn run tauri add clipboard-manager"
+    pnpm="pnpm tauri add clipboard-manager"
+    cargo="cargo tauri add clipboard-manager" />
 
     2. Modify `lib.rs` to initialize the plugin:
 


### PR DESCRIPTION
- New or updated content
#### Description
- Address #1475 but not fully <!-- Add an issue number if this PR will close it. -->

The content is based on the [README.md](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/clipboard-manager) from the plugin's repo but I'm not sure about the use of `assert`, shouldn't be `console.assert`?

Still have to write the Rust part.

I'm looking at writing the other plugins guides, is it enough to adapt the content from each plugin's README.md*? I could just copy over and adapt. But my intention is to first try to use locally when possible.

\* Most stubs give v2 plugin README as a reference to get started, and at least [windows customization](https://beta.tauri.app/features/window-customization/) points to [v1 docs](https://tauri.app/v1/guides/features/window-customization/).

Since I'm learning Tauri as I write these docs, I don't want to claim this current issue, for me there's no problem if someone else does.
<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->