### PR TITLE
rename 'plugin add' command to 'add' #1373

### DIFF
--- a/src/content/docs/2/reference/cli.mdx
+++ b/src/content/docs/2/reference/cli.mdx
@@ -32,7 +32,7 @@ For CLI commands related to developing plugins visit the [Develop a Tauri Plugin
 | [`icon`](#icon)               | Generates various icons for all major platforms                      |
 | [`info`](#info)               | Shows information about Tauri dependencies and project configuration |
 | [`init`](#init)               | Initializes a Tauri project                                          |
-| [`plugin add`](#plugin-add)   | Manage Tauri plugins                                                 |
+| [`add`](#add)   | Manage Tauri plugins                                                 |
 | [`signer`](#signer)           | Tauri updater signer                                                 |
 | [`completions`](#completions) | Shell completions                                                    |
 | [`ios`](#ios)                 | iOS commands                                                         |
@@ -216,19 +216,19 @@ Options:
           Print version
 ```
 
-## `plugin add`
+## `add`
 
 <CommandTabs
-	npm="npm tauri plugin add"
-	yarn="yarn tauri plugin add"
-	pnpm="pnpm tauri plugin add"
-	cargo="cargo tauri plugin add"
+	npm="npm tauri add"
+	yarn="yarn tauri add"
+	pnpm="pnpm tauri add"
+	cargo="cargo tauri add"
 />
 
 ```
 Installs a plugin on the project
 
-Usage: cargo tauri plugin add [OPTIONS] <PLUGIN>
+Usage: cargo tauri add [OPTIONS] <PLUGIN>
 
 Arguments:
   <PLUGIN>  The plugin to add

--- a/src/content/docs/features/notification.mdx
+++ b/src/content/docs/features/notification.mdx
@@ -22,10 +22,10 @@ Install the notifications plugin to get started.
 
     1. Use your project's package manager to add the dependency:
 
-    <CommandTabs npm="npm run tauri plugin add notification"
-    yarn="yarn run tauri plugin add notification"
-    pnpm="pnpm tauri plugin add notification"
-    cargo="cargo tauri plugin add notification" />
+    <CommandTabs npm="npm run tauri add notification"
+    yarn="yarn run tauri add notification"
+    pnpm="pnpm tauri add notification"
+    cargo="cargo tauri add notification" />
 
     2. Modify `lib.rs` to initialize the plugin:
 

--- a/src/content/docs/fr/features/notification.mdx
+++ b/src/content/docs/fr/features/notification.mdx
@@ -22,10 +22,10 @@ Pour commencer, installez le plugin de notifications.
 
     1. Utilisez le gestionnaire de package (package manager) de votre projet pour ajouter la dépendance:
 
-    <CommandTabs npm="npm run tauri plugin add notification"
-    yarn="yarn run tauri plugin add notification"
-    pnpm="pnpm tauri plugin add notification"
-    cargo="cargo tauri plugin add notification" />
+    <CommandTabs npm="npm run tauri add notification"
+    yarn="yarn run tauri add notification"
+    pnpm="pnpm tauri add notification"
+    cargo="cargo tauri add notification" />
 
     2. Modifiez `lib.rs` pour initialiser le plugin:
 


### PR DESCRIPTION
- Renamed CLI command per cli update [[2.0.0-alpha.13]](https://github.com/tauri-apps/tauri/blob/713f84db2b5bf17e4217053a229f9c11cbb22c74/tooling/cli/node/CHANGELOG.md#200-alpha13)

Task in #1373

Note: The commands `tauri plugin android add` and `tauri plugin ios add` are unmodified. 
At least the android command I'm sure as I tried locally with tauri cli 2.0.0-alpha.15