### PR TITLE
i18french: translation of /plugins/index.mdx & /plugins/develop-mobile.mdx

### DIFF
--- a/src/content/docs/fr/guides/plugins/develop-mobile.mdx
+++ b/src/content/docs/fr/guides/plugins/develop-mobile.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 
 :::tip[Développment de plugin]
 
-Assurez-vous de bien connaître les concepts abordés dans le [Guide de développement de plugins](/fr/2/guide/plugins) car de nombreuses notions de ce guide reposent sur les concepts qui y sont couverts.
+Assurez-vous de bien connaître les concepts abordés dans le [Guide de développement de plugins](/fr/guide/plugins) car de nombreuses notions de ce guide reposent sur les concepts qui y sont couverts.
 
 :::
 
@@ -13,8 +13,7 @@ Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et
 
 ## Initialiser le projet de plugin
 
-Suivez les étapes dans le [Guide de développment de plugin](/fr/2/guide/plugins#initialize-plugin-project) pour initialiser un nouveau plugin.
-                            {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+Suivez les étapes dans le [Guide de développment de plugin](/fr/guide/plugins#initialiser-un-projet-de-plugin) pour initialiser un nouveau plugin.
 
 Si vous avez un plugin existant et souhaitez y ajouter des fonctionnalités Android ou iOS, vous pouvez utiliser `plugin android add` et `plugin ios add` pour démarrer les projets de librairies mobiles et vous guider durant les changements nécessaires.
 
@@ -26,9 +25,9 @@ L'implémentation pour ordinateur utilise le code Rust pour implémenter une fon
 // lib.rs
 use tauri::Runtime;
 
-impl<R: Runtime> <plugin-name><R> {
+impl<R: Runtime> <nom-du-plugin><R> {
   pub fn do_something(&self) {
-    // faire quelque chose qui est une implémentation partagée entre l'ordinateur et le mobile
+    // faire une implémentation partagée entre l'ordinateur et le mobile
   }
 }
 ```
@@ -49,8 +48,7 @@ Le plugin est défini comme un [package Swift](https://www.swift.org/package-man
 
 ## Configuration de plugins
 
-Référez-vous à la section de [configuration de plugin](/fr/2/guide/plugins/#plugin-configuration) du guide de développement de plugins pour plus de détails à propos du développement de configurations de plugin.
-                        {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+Référez-vous à la section de [configuration de plugin](/fr/guide/plugins#configuration-de-plugin) du guide de développement de plugins pour plus de détails à propos du développement de configurations de plugin.
 
 L'instance du plugin sur mobile possède un "getter" pour la configuration du plugin :
 
@@ -87,8 +85,7 @@ Les plugins peuvent se lier à plusieurs évènements du cycle de vie :
 - [load](#load): Lorsque le plugin est chargé dans la "web view"
 - [onNewIntent](#onnewintent): Seulement pour Android, lorsque l'activitée est relancée
 
-Il y a également les [évènements de cycle de vie supplémentaires pour les plugins](/fr/2/guide/plugins#lifecycle-events) dans le guide de développement de plugins.
-                                {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+Il y a également les [évènements de cycle de vie supplémentaires pour les plugins](/fr/guide/plugins#évènements-du-cycle-de-vie) dans le guide de développement de plugins.
 
 ### load
 
@@ -200,7 +197,7 @@ pub struct Photo {
 }
 
 
-impl<R: Runtime> <plugin-name;pascal-case><R> {
+impl<R: Runtime> <nom-du-plugin;pascal-case><R> {
   pub fn open_camera(&self, payload: CameraRequest) -> crate::Result<Photo> {
     self
       .0
@@ -212,7 +209,7 @@ impl<R: Runtime> <plugin-name;pascal-case><R> {
 
 ## Permissions
 
-Si un plugin requiert des permissions de l'utilisateur, Tauri simplifie le processus de verification et de demande d'autorisation.
+Si un plugin requiert des permissions de l'utilisateur, Tauri simplifie le processus de vérification et de demande d'autorisation.
 
 <Tabs>
 <TabItem label="Android">
@@ -241,7 +238,7 @@ class ExamplePlugin: Plugin {
 
   @objc public override func requestPermissions(_ invoke: Invoke) {
     // demander les permissions ici
-    // ensuite, résolvez la requête
+    // ensuite, puis résolvez la requête
     invoke.resolve(["postNotification": "granted"])
   }
 }
@@ -267,7 +264,7 @@ interface Permissions {
 }
 
 // vérifier l'état de la permission
-const permission = await invoke<Permissions>('plugin:<plugin-name>|checkPermissions')
+const permission = await invoke<Permissions>('plugin:<nom-du-plugin>|checkPermissions')
 
 if (permission.postNotification === 'prompt-with-rationale') {
   // afficher les informations à l'utilisateur pour lesquelles cette permission est nécessaire
@@ -275,7 +272,7 @@ if (permission.postNotification === 'prompt-with-rationale') {
 
 // demander la permission
 if (permission.postNotification.startsWith('prompt')) {
-  const state = await invoke<Permissions>('plugin:<plugin-name>|requestPermissions', { permissions: ['postNotification'] })
+  const state = await invoke<Permissions>('plugin:<nom-du-plugin>|requestPermissions', { permissions: ['postNotification'] })
 }
 ```
 
@@ -370,7 +367,7 @@ class ExamplePlugin: Plugin {
 </TabItem>
 </Tabs>
 
-Les fonctions d'aide peuvent ensuite être appelées à partir du package NPM en utilisant la fonction d'aide [`addPluginListener`](/fr/2/reference/js/core/namespacetauri/#addpluginlistener) :
+Les fonctions d'aide peuvent ensuite être appelées à partir du package NPM en utilisant la fonction d'aide [`addPluginListener`](/fr/reference/js/core/namespacetauri/#addpluginlistener) :
 
 ```javascript
 import { addPluginListener, PluginListener } from '@tauri-apps/api/tauri';

--- a/src/content/docs/fr/guides/plugins/develop-mobile.mdx
+++ b/src/content/docs/fr/guides/plugins/develop-mobile.mdx
@@ -1,0 +1,387 @@
+---
+title: Développement de plugin mobile
+i18nReady: true
+---
+
+:::tip[Développment de plugin]
+
+Assurez-vous de bien connaître les concepts abordés dans le [Guide de développement de plugins](/fr/2/guide/plugins) car de nombreuses notions de ce guide reposent sur les concepts qui y sont couverts.
+
+:::
+
+Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et Swift. Le modèle de plugin par défaut inclus un projet de librairie Android utilisant Kotlin, ainsi qu'un package Swift comprenant un exemple de commande mobile montrant comment déclencher son exécution à partir du code Rust.
+
+## Initialiser le projet de plugin
+
+Suivez les étapes dans le [Guide de développment de plugin](/fr/2/guide/plugins#initialize-plugin-project) pour initialiser un nouveau plugin.
+                            {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+
+Si vous avez un plugin existant et souhaitez y ajouter des fonctionnalités Android ou iOS, vous pouvez utiliser `plugin android add` et `plugin ios add` pour démarrer les projets de librairies mobiles et vous guider durant les changements nécessaires.
+
+Le modèle de plugin par défaut sépare l'implémentation du plugin en deux modules séparés : `desktop.rs` et `mobile.rs`.
+
+L'implémentation pour ordinateur utilise le code Rust pour implémenter une fonctionnalité, tandis que l'implémentation mobile envoie un message au code mobile natif pour exécuter une fonction et obtenir un résultat en retour. Si une logique partagée est entre les deux implémentations, elle peut être définie dans `lib.rs` :
+
+```rust
+// lib.rs
+use tauri::Runtime;
+
+impl<R: Runtime> <plugin-name><R> {
+  pub fn do_something(&self) {
+    // faire quelque chose qui est une implémentation partagée entre l'ordinateur et le mobile
+  }
+}
+```
+
+Cette implémentation simplifie le processus de partage d'API, qui peut être utilisée à la fois par les commandes et par le code Rust.
+
+### Développer un plugin Android
+
+Un plugin Tauri pour Android est défini comme une classe Kotlin qui étend `app.tauri.plugin.Plugin` et est annotée avec `app.tauri.annotation.TauriPlugin`. Chaque méthode annotée avec `app.tauri.annotation.Command` peut être appelée par Rust ou JavaScript.
+
+Tauri utilise Kotlin par défaut pour l'implémentation de plugins Android, mais vous pouvez passer à Java si vous préférez. Après avoir généré un plugin, faites un clique droit sur la classe (Kotlin) plugin dans Android Studio, puis sélectionnez l'option "Convert Kotlin file to Java file" {/* Seems like Android Studio is english only (on 14/09/2023) */} à partir du menu d'options. Android sutdio va vous guider tout au long de la migration vers Java.
+
+### Développer un plugin iOS
+
+Un plugin Tauri pour iOS est défini comme une classe Swift qui étend la classe `Plugin` du package `Tauri`. Chaque fonction avec l'attribut `@objc` et le paramètre `(_ invoke: Invoke)` (par exemple `@objc private func download(_ invoke: Invoke) { }`) peut être appelé par Rust ou JavaScript.
+
+Le plugin est défini comme un [package Swift](https://www.swift.org/package-manager/), vous pouvez donc utiliser son gestionnaire de package pour gérer les dépendances.
+
+## Configuration de plugins
+
+Référez-vous à la section de [configuration de plugin](/fr/2/guide/plugins/#plugin-configuration) du guide de développement de plugins pour plus de détails à propos du développement de configurations de plugin.
+                        {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+
+L'instance du plugin sur mobile possède un "getter" pour la configuration du plugin :
+
+<Tabs>
+<TabItem label="Android">
+
+```java
+@TauriPlugin
+class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+  override fun load(webView: WebView) {
+    val timeout = this.config.getInt("timeout", 30)
+  }
+}
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+```swift
+class ExamplePlugin: Plugin {
+  @objc public override func load(webview: WKWebView) {
+    let timeout = self.config["timeout"] as? Int ?? 30
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Évènement du cycle de vie.
+
+Les plugins peuvent se lier à plusieurs évènements du cycle de vie :
+
+- [load](#load): Lorsque le plugin est chargé dans la "web view"
+- [onNewIntent](#onnewintent): Seulement pour Android, lorsque l'activitée est relancée
+
+Il y a également les [évènements de cycle de vie supplémentaires pour les plugins](/fr/2/guide/plugins#lifecycle-events) dans le guide de développement de plugins.
+                                {/* french translation TODO : replace by the french translation of the title in the file ↑ */}
+
+### load
+
+- **Quand** : Lorsque le plugin est chargé dans la "web view"
+- **Pourquoi** : Exécute le code d'initialisation du plugin
+
+<Tabs>
+<TabItem label="Android">
+
+```java
+@TauriPlugin
+class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+  override fun load(webView: WebView) {
+    // effectuer l'installation du plugin ici
+  }
+}
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+```swift
+class ExamplePlugin: Plugin {
+  @objc public override func load(webview: WKWebView) {
+    let timeout = self.config["timeout"] as? Int ?? 30
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### onNewIntent
+
+**Note** : Ceci est seulement disponible pour Android.
+
+- **Quand** : Lorsque l'activité est relancée. Voir [Activité#onNewIntent](<https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)>) pour plus d'informations.
+- **Pourquoi** : Gérer le redémarrage de l'application, par exemple lors du click sur une notification ou à l'accès d'un lien profond.
+
+```java
+// import android.content.Intent
+
+@TauriPlugin
+class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+  override fun onNewIntent(intent: Intent) {
+    // gérer le nouvel évènement d'attention
+  }
+}
+```
+
+## Ajouter des commandes mobiles
+
+Une classe de plugin se trouve dans les projets mobiles respectifs, où les commandes peuvent être définies et peuvent être appelées par le code Rust :
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+<TabItem label="Android">
+
+```java
+@TauriPlugin
+class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+  @Command
+  fun openCamera(invoke: Invoke) {
+    val allowEdit = invoke.getBoolean("allowEdit", false)
+    val quality = invoke.getInt("quality", 100)
+
+    val ret = JSObject()
+    ret.put("path", "/chemin/vers/photo.jpg")
+    invoke.resolve(ret)
+  }
+}
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+```swift
+class ExamplePlugin: Plugin {
+	@objc public func openCamera(_ invoke: Invoke) {
+    let allowEdit = invoke.getBool("allowEdit", false)
+    let quality = invoke.getInt("quality", 100)
+
+    invoke.resolve(["path": "/chemin/vers/photo.jpg"])
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+Utilisez [`tauri::plugin::PluginHandle`](https://docs.rs/tauri/2.0.0-alpha/tauri/plugin/struct.PluginHandle.html) pour appeler une commande mobile à partir de Rust :
+
+```rust
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+use tauri::Runtime;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CameraRequest {
+  quality: usize,
+  allow_edit: bool,
+}
+
+#[derive(Deserialize)]
+pub struct Photo {
+  path: PathBuf,
+}
+
+
+impl<R: Runtime> <plugin-name;pascal-case><R> {
+  pub fn open_camera(&self, payload: CameraRequest) -> crate::Result<Photo> {
+    self
+      .0
+      .run_mobile_plugin("openCamera", payload)
+      .map_err(Into::into)
+  }
+}
+```
+
+## Permissions
+
+Si un plugin requiert des permissions de l'utilisateur, Tauri simplifie le processus de verification et de demande d'autorisation.
+
+<Tabs>
+<TabItem label="Android">
+
+Premièrement, définissez la liste des permissions nécessaires et un alias pour identifier chaque groupe dans le code. Ceci est réalisé dans l'annotation `TauriPlugin` :
+
+```java
+@TauriPlugin(
+  permissions = [
+    Permission(strings = [Manifest.permission.POST_NOTIFICATIONS], alias = "postNotification")
+  ]
+)
+class ExamplePlugin(private val activity: Activity): Plugin(activity) { }
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+D'abord, il faut override les fonctions `checkPermissions` et `requestPermissions` :
+
+```swift
+class ExamplePlugin: Plugin {
+  @objc open func checkPermissions(_ invoke: Invoke) {
+    invoke.resolve(["postNotification": "prompt"])
+  }
+
+  @objc public override func requestPermissions(_ invoke: Invoke) {
+    // demander les permissions ici
+    // ensuite, résolvez la requête
+    invoke.resolve(["postNotification": "granted"])
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Tauri implémente automatiquement deux commandes pour le plugin : `checkPermissions` et `requestPermissions`. Ces commandes peuvent être appelées directement depuis JavaScript ou Rust :
+
+{/* TODO: PermissionState type should be exported in Tauri */}
+
+<Tabs>
+<TabItem label="JavaScript">
+
+```javascript
+import { invoke } from '@tauri-apps/api/tauri'
+
+type PermissionState = 'granted' | 'denied' | 'prompt' | 'prompt-with-rationale'
+
+interface Permissions {
+  postNotification: PermissionState
+}
+
+// vérifier l'état de la permission
+const permission = await invoke<Permissions>('plugin:<plugin-name>|checkPermissions')
+
+if (permission.postNotification === 'prompt-with-rationale') {
+  // afficher les informations à l'utilisateur pour lesquelles cette permission est nécessaire
+}
+
+// demander la permission
+if (permission.postNotification.startsWith('prompt')) {
+  const state = await invoke<Permissions>('plugin:<plugin-name>|requestPermissions', { permissions: ['postNotification'] })
+}
+```
+
+</TabItem>
+<TabItem label="Rust">
+
+```rust
+use serde::{Serialize, Deserialize};
+use tauri::Runtime;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PermissionResponse {
+  pub post_notification: PermissionState,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestPermission {
+  post_notification: bool,
+}
+
+impl<R: Runtime> Notification<R> {
+  pub fn request_post_notification_permission(&self) -> crate::Result<PermissionState> {
+    self.0
+      .run_mobile_plugin::<PermissionResponse>("requestPermissions", RequestPermission { post_notification: true })
+      .map(|r| r.post_notification)
+      .map_err(Into::into)
+  }
+
+  pub fn check_permissions(&self) -> crate::Result<PermissionResponse> {
+    self.0
+      .run_mobile_plugin::<PermissionResponse>("checkPermissions", ())
+      .map_err(Into::into)
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Évènements liés aux plugins
+
+{/* TODO: Is this section a duplicate of Lifecycle Events above? */}
+
+Les plugins peuvent émettre (emit) à tout moment en utilisant la fonction `trigger` :
+
+<Tabs>
+<TabItem label="Android">
+
+```java
+@TauriPlugin
+class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+    override fun load(webView: WebView) {
+      trigger("load", JSObject())
+    }
+
+    override fun onNewIntent(intent: Intent) {
+      // gérer le nouvel évènement d'attention
+      if (intent.action == Intent.ACTION_VIEW) {
+        val data = intent.data.toString()
+        val event = JSObject()
+        event.put("data", data)
+        trigger("newIntent", event)
+      }
+    }
+
+    @Command
+    fun openCamera(invoke: Invoke) {
+      val payload = JSObject()
+      payload.put("open", true)
+      trigger("camera", payload)
+    }
+}
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+```swift
+class ExamplePlugin: Plugin {
+  @objc public override func load(webview: WKWebView) {
+    trigger("load", data: [:])
+  }
+
+  @objc public func openCamera(_ invoke: Invoke) {
+    trigger("camera", data: ["open": true])
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Les fonctions d'aide peuvent ensuite être appelées à partir du package NPM en utilisant la fonction d'aide [`addPluginListener`](/fr/2/reference/js/core/namespacetauri/#addpluginlistener) :
+
+```javascript
+import { addPluginListener, PluginListener } from '@tauri-apps/api/tauri';
+
+export async function onRequest(
+	handler: (url: string) => void
+): Promise<PluginListener> {
+	return await addPluginListener(
+		'<nom-du-plugin>',
+		'nom-du-plugin',
+		handler
+	);
+}
+```

--- a/src/content/docs/fr/guides/plugins/develop-mobile.mdx
+++ b/src/content/docs/fr/guides/plugins/develop-mobile.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 
 :::tip[Développment de plugin]
 
-Assurez-vous de bien connaître les concepts abordés dans le [Guide de développement de plugins](/fr/guide/plugins) car de nombreuses notions de ce guide reposent sur les concepts qui y sont couverts.
+Assurez-vous de bien connaître les concepts abordés dans le [Guide de développement de plugins](/fr/guides/plugins) car de nombreuses notions de ce guide reposent sur les concepts qui y sont couverts.
 
 :::
 
@@ -13,7 +13,7 @@ Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et
 
 ## Initialiser le projet de plugin
 
-Suivez les étapes dans le [Guide de développment de plugin](/fr/guide/plugins#initialiser-un-projet-de-plugin) pour initialiser un nouveau plugin.
+Suivez les étapes dans le [Guide de développment de plugin](/fr/guides/plugins#initialiser-un-projet-de-plugin) pour initialiser un nouveau plugin.
 
 Si vous avez un plugin existant et souhaitez y ajouter des fonctionnalités Android ou iOS, vous pouvez utiliser `plugin android add` et `plugin ios add` pour démarrer les projets de librairies mobiles et vous guider durant les changements nécessaires.
 
@@ -48,7 +48,7 @@ Le plugin est défini comme un [package Swift](https://www.swift.org/package-man
 
 ## Configuration de plugins
 
-Référez-vous à la section de [configuration de plugin](/fr/guide/plugins#configuration-de-plugin) du guide de développement de plugins pour plus de détails à propos du développement de configurations de plugin.
+Référez-vous à la section de [configuration de plugin](/fr/guides/plugins#configuration-de-plugin) du guide de développement de plugins pour plus de détails à propos du développement de configurations de plugin.
 
 L'instance du plugin sur mobile possède un "getter" pour la configuration du plugin :
 
@@ -85,7 +85,7 @@ Les plugins peuvent se lier à plusieurs évènements du cycle de vie :
 - [load](#load): Lorsque le plugin est chargé dans la "web view"
 - [onNewIntent](#onnewintent): Seulement pour Android, lorsque l'activitée est relancée
 
-Il y a également les [évènements de cycle de vie supplémentaires pour les plugins](/fr/guide/plugins#évènements-du-cycle-de-vie) dans le guide de développement de plugins.
+Il y a également les [évènements de cycle de vie supplémentaires pour les plugins](/fr/guides/plugins#évènements-du-cycle-de-vie) dans le guide de développement de plugins.
 
 ### load
 

--- a/src/content/docs/fr/guides/plugins/index.mdx
+++ b/src/content/docs/fr/guides/plugins/index.mdx
@@ -11,7 +11,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 
 :::tip[Développement de plugin]
 
-Ce guide couvre le développement de plugins pour Tauri. Si vous cherchez une liste des plugins actuellement disponibles et comment les utiliser, allez sur la [liste des fonctionnalitées et cas d'usages](/fr/2/guide/list).
+Ce guide couvre le développement de plugins pour Tauri. Si vous cherchez une liste des plugins actuellement disponibles et comment les utiliser, allez sur la [liste des fonctionnalitées et cas d'usages](/fr/guide/list).
 
 :::
 
@@ -19,7 +19,7 @@ Les plugins sont capables de se lier au cycle de vie de Tauri, expose le code Ru
 
 Tauri offre un système de fenêtrage avec sa fonctionnalité de web view, une manière d'envoyer des messages entre le processus Rust et la wab view, et un système d'évènement avec plusieurs outils pour améliorer l'expérience de développement. De par sa conception, le noyeau de Tauri ne contient pas de fonctionnalités dont tout le monde n'a pas besoin. au lieu de cela, il offre un méchanisme pour ajouter des fonctionnalités externes dans une application Tauri appelé plugin.
 
-Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel qui fournit des liaisons pour ses commandes et évènements. De plus, un plugin peut inclure un projet de librairie Android et un package Swift pour iOS. Vous pouvez en apprendre plus sur le développement de plugins pour Android et iOS dans le [guide de développement de plugin mobile](/fr/2/guide/plugins/develop-mobile).
+Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel qui fournit des liaisons pour ses commandes et évènements. De plus, un plugin peut inclure un projet de librairie Android et un package Swift pour iOS. Vous pouvez en apprendre plus sur le développement de plugins pour Android et iOS dans le [guide de développement de plugin mobile](/fr/guide/plugins/develop-mobile).
 
 {/* TODO: https://github.com/tauri-apps/tauri/issues/7749 */}
 
@@ -27,11 +27,11 @@ Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel q
 
 {/* TODO: Add link to allowlist */}
 
-Les plugins Tauri ont un préfixe (`tauri-plugin-` pour le nom de la crate Rust et `@tauri-apps/plugin-` pour le package NPM) suivi par le nom du plugin. Le nom du plugin est spécifié dans la configuration du plugin dans [`tauri.conf.json > plugin`](/fr/2/reference/config/#pluginconfig) et sur la configuration de la liste d'autorisations.
+Les plugins Tauri ont un préfixe (`tauri-plugin-` pour le nom de la crate Rust et `@tauri-apps/plugin-` pour le package NPM) suivi par le nom du plugin. Le nom du plugin est spécifié dans la configuration du plugin dans [`tauri.conf.json > plugin`](/fr/reference/config/#pluginconfig) et sur la configuration de la liste d'autorisations.
 
 Tauri préfixe par défaut votre crate de plugin avec `tauri-plugin-`. Cela aide votre plugin à être découvert par la communauté de Tauri, mais ce n'est pas un impératif. Lors de l'initialisation d'un nouveau projet de plugin, vous devez lui donner son nom. Le nom de la crate générée sera `tauri-plugin-{nom-du-plugin}` et le nom du package NPM sera `tauri-plugin-{nom-du-plugin}-api` (bien que nous recommendons l'utilisation d'un [scope NPM](https://docs.npmjs.com/about-scopes) si possible). La convention de nommage de Tauri pour NPM est `@scope-name/plugin-{nom-du-plugin}`.
 
-## Initialiser projet de plugin
+## Initialiser un projet de plugin
 
 Pour commencer un nouveau projet de plugin, exécutez `plugin init`. Si vous n'avez pas besoin du package NPM, utilisez l'indicateur CLI `--no-api`. 
 
@@ -67,7 +67,7 @@ Si vous avez un plugin existant et voulez lui ajouter des fonctionnalitées Andr
 
 Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et Swift. Le modèle de plugin par défaut inclue une librairie Android utilisant Kotlin et un package Swift. Il inclus aussi un example montrant comment utiliser son exécution à partir du code Rust.
 
-Apprenez-en plus à propos du développement de plugins pour mobiles dans le [guide de développement de plugins mobiles](/fr/2/guide/plugins/develop-mobile)
+Apprenez-en plus à propos du développement de plugins pour mobiles dans le [guide de développement de plugins mobiles](/fr/guide/plugins/develop-mobile)
 
 ## Configuration de plugin
 
@@ -111,17 +111,17 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 }
 ```
 
-## Evènements du cycle de vie
+## Évènements du cycle de vie
 
 Les plugins peuvent capter plusieurs évènements du cycle de vie :
 
 - [setup](#setup): Le plugin est initialisé
 - [on_navigation](#on_navigation): "Web view" essaie d'utiliser la navigation
 - [on_webview_ready](#on_webview_ready): Une nouvelle fenêtre est créée
-- [on_event](#on_event): Evènements de la boucles d'évènements
+- [on_event](#on_event): Évènements de la boucles d'évènements
 - [on_drop](#on_drop): Le plugin est en cours de déconstruction
 
-Il existe d'autres [évènements du cycle de vie pour des plugins mobiles](/fr/2/guide/plugins/develop-mobile#lifecycle-events).
+Il existe d'autres [évènements du cycle de vie pour des plugins mobiles](/fr/guide/plugins/develop-mobile#évènement-du-cycle-de-vie).
 
 ### setup
 
@@ -186,7 +186,7 @@ Builder::new("<nom-du-plugin>")
 
 ### on_event
 
-- **Quand** : Evènements de la boucles d'évènements
+- **Quand** : Évènements de la boucles d'évènements
 - **Pourquoi** : Gère les évènements principaux, tels que les évènements de la fenêtre, ceux du menu et la demande d'arrêt de l'application
 
 Avec ce capteur du cycle de vie, vous pouvez être notifiés de chacun des évènements de boucle d'[évènements](https://docs.rs/tauri/2.0.0-alpha/tauri/enum.RunEvent.html).
@@ -245,7 +245,7 @@ Builder::new("<nom-du-plugin>")
 
 Les API de plugins définis dans `desktop.rs` et `mobile.rs` du projet sont exportés à l'utilisateur en tant que structure avec le même nom que le plugin (en pascal case). Lors de l'initialisation du plugin, une instance de cette structure est créée et gérée comme un état pour que les utilisateurs puissent la retrouver à tout instant avec une instance de `Manager` (comme `AppHandle`, `App`, ou ` Window`), via le trait d'extension défini dans le plugin.
 
-Par exemple, le [plugin `global-shortcut`](/2/fr/guide/global-shortcut) défini une structure `GlobalShortcut` qui peut être accédée en utilisant la méthode `global_shortcut` du trait `GlobalShortcutExt` :
+Par exemple, le [plugin `global-shortcut`](/fr/guide/global-shortcut) défini une structure `GlobalShortcut` qui peut être accédée en utilisant la méthode `global_shortcut` du trait `GlobalShortcutExt` :
 
 ```rust
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
@@ -260,7 +260,7 @@ tauri::Builder::default()
 
 ## Ajout de commandes
 
-Les commandes sont définies dans le fichier `commands.rs`. Ce sont des commandes régulières des applications Tauri. Elles peuvent accéder aux instances `AppHandle` et `Window` directement, accéder aux états, et prendre les entrées de la même manière que les commandes d'application. Pour plus de détails sur les commandes tauri, voir le [guide des commandes](/2/fr/guide/commands)
+Les commandes sont définies dans le fichier `commands.rs`. Ce sont des commandes régulières des applications Tauri. Elles peuvent accéder aux instances `AppHandle` et `Window` directement, accéder aux états, et prendre les entrées de la même manière que les commandes d'application. Pour plus de détails sur les commandes tauri, voir le [guide des commandes](/fr/features/commands)
 
 Cette commande montre comment accéder aux instances de `AppHandle` et `Window` via l'injection de dépendances, et prend deux paramètres d'entrés (`on_progress` et `url`)
 
@@ -274,7 +274,7 @@ async fn upload<R: Runtime>(app: AppHandle<R>, window: Window<R>, on_progress: C
 }
 ```
 
-Pour exposer la commande à la "webview", vous devez capter les appells de `invoke_handler()` dans `lib.rs` :
+Pour exposer la commande à la "webview", vous devez capter les appels de `invoke_handler()` dans `lib.rs` :
 
 ```rust
 // lib.rs
@@ -283,7 +283,6 @@ Builder::new("<nom-du-plugin>")
 ```
 
 Définition d'une fonction de liaison dans `webview-src/index.ts` pour que l'utilisateur puisse facilement appeller la commande dans JavaScript :
-Define a binding function in  so that plugin users can easily call the command in JavaScript:
 
 ```js
 // webview-src/index.ts
@@ -300,4 +299,4 @@ Assurez-vous de compiler le code TypeScript avant de le tester.
 
 ## Gérer les états
 
-Un plugin peut gérer les états de la même manière qu'une application Tauri. Voir le [guide de gestion des états](/2/guide/state-management) pour plus d'informations.
+Un plugin peut gérer les états de la même manière qu'une application Tauri. Voir le [guide de gestion des états](/fr/guide/state-management) pour plus d'informations.

--- a/src/content/docs/fr/guides/plugins/index.mdx
+++ b/src/content/docs/fr/guides/plugins/index.mdx
@@ -1,0 +1,303 @@
+---
+title: Développement de plugin
+i18nReady: true
+---
+
+{/* TODO: Add a CLI section */}
+
+import CommandTabs from '@components/CommandTabs.astro';
+
+{/* TODO: Link to windowing system, commands for sending messages, and event system */}
+
+:::tip[Développement de plugin]
+
+Ce guide couvre le développement de plugins pour Tauri. Si vous cherchez une liste des plugins actuellement disponibles et comment les utiliser, allez sur la [liste des fonctionnalitées et cas d'usages](/fr/2/guide/list).
+
+:::
+
+Les plugins sont capables de se lier au cycle de vie de Tauri, expose le code Rust qui repose sur les APIs de web view, gérer les commandes avec Rust, Kotlin ou Swift, et bien plus.
+
+Tauri offre un système de fenêtrage avec sa fonctionnalité de web view, une manière d'envoyer des messages entre le processus Rust et la wab view, et un système d'évènement avec plusieurs outils pour améliorer l'expérience de développement. De par sa conception, le noyeau de Tauri ne contient pas de fonctionnalités dont tout le monde n'a pas besoin. au lieu de cela, il offre un méchanisme pour ajouter des fonctionnalités externes dans une application Tauri appelé plugin.
+
+Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel qui fournit des liaisons pour ses commandes et évènements. De plus, un plugin peut inclure un projet de librairie Android et un package Swift pour iOS. Vous pouvez en apprendre plus sur le développement de plugins pour Android et iOS dans le [guide de développement de plugin mobile](/fr/2/guide/plugins/develop-mobile).
+
+{/* TODO: https://github.com/tauri-apps/tauri/issues/7749 */}
+
+## Conventions de nommage
+
+{/* TODO: Add link to allowlist */}
+
+Les plugins Tauri ont un préfixe (`tauri-plugin-` pour le nom de la crate Rust et `@tauri-apps/plugin-` pour le package NPM) suivi par le nom du plugin. Le nom du plugin est spécifié dans la configuration du plugin dans [`tauri.conf.json > plugin`](/fr/2/reference/config/#pluginconfig) et sur la configuration de la liste d'autorisations.
+
+Tauri préfixe par défaut votre crate de plugin avec `tauri-plugin-`. Cela aide votre plugin à être découvert par la communauté de Tauri, mais ce n'est pas un impératif. Lors de l'initialisation d'un nouveau projet de plugin, vous devez lui donner son nom. Le nom de la crate générée sera `tauri-plugin-{nom-du-plugin}` et le nom du package NPM sera `tauri-plugin-{nom-du-plugin}-api` (bien que nous recommendons l'utilisation d'un [scope NPM](https://docs.npmjs.com/about-scopes) si possible). La convention de nommage de Tauri pour NPM est `@scope-name/plugin-{nom-du-plugin}`.
+
+## Initialiser projet de plugin
+
+Pour commencer un nouveau projet de plugin, exécutez `plugin init`. Si vous n'avez pas besoin du package NPM, utilisez l'indicateur CLI `--no-api`. 
+
+<CommandTabs
+	npm="npm run tauri plugin init"
+	yarn="yarn tauri plugin init"
+	pnpm="pnpm tauri plugin init"
+	cargo="cargo tauri plugin init"
+/>
+
+Ceci initialisera le plugin et le code résultant ressemblera à :
+
+```
+. nom-du-plugin/
+├── src/                - code Rust
+│ ├── commands.rs       - défini les commandes que "webview" peut utiliser
+| ├── desktop.rs        - implémentation de bureau
+│ ├── lib.rs            - implémentations appropriées rééxportées, état d'installation...
+│ └── mobile.rs         - implémentation pour mobile
+├── android             - librairie Android
+├── ios                 - package Swift
+├── webview-src         - code source des liaisons de l'API JavaScript
+├── webview-dist        - ressources transpilées depuis webview-src
+├── Cargo.toml          - métadonnées de la crate Cargo
+└── package.json        - métadonnées du package NPM
+```
+
+{/* TODO: https://github.com/tauri-apps/tauri/issues/7749 */}
+
+Si vous avez un plugin existant et voulez lui ajouter des fonctionnalitées Android ou iOS, vous pouvez utiliser `plugin android add` et `plugin ios add` pour commencer le projet de librairie mobile et vous guider à travers les changements nécéssaires.
+
+## Déceloppment de plugins mobiles
+
+Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et Swift. Le modèle de plugin par défaut inclue une librairie Android utilisant Kotlin et un package Swift. Il inclus aussi un example montrant comment utiliser son exécution à partir du code Rust.
+
+Apprenez-en plus à propos du développement de plugins pour mobiles dans le [guide de développement de plugins mobiles](/fr/2/guide/plugins/develop-mobile)
+
+## Configuration de plugin
+
+Dans l'application Tauri où le plugin est utilisé, la configuration de ce dernier est spécifié dans `tauri.conf.json` où `nom-du-plugin` est le nom du plugin :
+
+```json
+{
+  "build": { ... },
+  "tauri": { ... },
+  "plugins": {
+    "nom-du-plugin": {
+      "timeout": 30
+    }
+  }
+}
+```
+
+La configuration du plugin est définie sur `Builder` et est analysée à l'éxécution. Voici un example de la structure `Config` utilisée pour spécifier la configuration du plugin :
+
+```rust
+// lib.rs
+
+use tauri::plugin::{Builder, Runtime, TauriPlugin};
+use serde::Deserialize;
+
+// Définition de la config du plugin
+#[derive(Deserialize)]
+struct Config {
+  timeout: usize,
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+  // Rend la config du plugin optionnelle
+  // en utilisant `Builder::<R, Option<Config>>` à la place
+  Builder::<R, Config>::new("<nom-du-plugin>")
+    .setup(|app, api| {
+      let timeout = api.config.timeout;
+      Ok(())
+    })
+    .build()
+}
+```
+
+## Evènements du cycle de vie
+
+Les plugins peuvent capter plusieurs évènements du cycle de vie :
+
+- [setup](#setup): Le plugin est initialisé
+- [on_navigation](#on_navigation): "Web view" essaie d'utiliser la navigation
+- [on_webview_ready](#on_webview_ready): Une nouvelle fenêtre est créée
+- [on_event](#on_event): Evènements de la boucles d'évènements
+- [on_drop](#on_drop): Le plugin est en cours de déconstruction
+
+Il existe d'autres [évènements du cycle de vie pour des plugins mobiles](/fr/2/guide/plugins/develop-mobile#lifecycle-events).
+
+### setup
+
+- **Quand** : A l'initialisation du plugin
+- **Pourquoi** : Enregistrer les plugins mobiles, gérer l'état, exécuter des tâches en arrière-plan
+
+```rust
+use tauri::{Manager, plugin::Builder};
+use std::{collections::HashMap, sync::Mutex, time::Duration};
+
+struct DummyStore(Mutex<HashMap<String, String>>);
+
+Builder::new("<nom-du-plugin>")
+  .setup(|app, api| {
+    app.manage(DummyStore(Default::default()));
+
+    let app_ = app.clone();
+    std::thread::spawn(move || {
+      loop {
+        app_.emit("tick", ());
+        std::thread::sleep(Duration::from_secs(1));
+      }
+    });
+
+    Ok(())
+  })
+```
+
+### on_navigation
+
+- **Quand** : "Web view" essaie d'utiliser la navigation
+- **Pourquoi**: Valider la navigation ou suivre les changements d'URL
+
+Retourner `false` annule la navigation.
+
+```rust
+use tauri::plugin::Builder;
+
+Builder::new("<nom-du-plugin>")
+  .on_navigation(|window, url| {
+    println!("la fenêtre {} navigue vers {}", window.label(), url);
+    // Annule la navigation si interdite
+    url.scheme() != "forbidden"
+  })
+```
+
+### on_webview_ready
+
+- **Quand** : Une nouvelle fenêtre a été créée
+- **Pourquoi** : Exécute un script d'initialisation pour chaque fenêtre
+
+```rust
+use tauri::plugin::Builder;
+
+Builder::new("<nom-du-plugin>")
+  .on_webview_ready(|window| {
+    window.listen("content-loaded", |event| {
+      println!("contenu de webview chargé");
+    });
+  })
+```
+
+### on_event
+
+- **Quand** : Evènements de la boucles d'évènements
+- **Pourquoi** : Gère les évènements principaux, tels que les évènements de la fenêtre, ceux du menu et la demande d'arrêt de l'application
+
+Avec ce capteur du cycle de vie, vous pouvez être notifiés de chacun des évènements de boucle d'[évènements](https://docs.rs/tauri/2.0.0-alpha/tauri/enum.RunEvent.html).
+
+```rust
+use std::{collections::HashMap, fs::write, sync::Mutex};
+use tauri::{plugin::Builder, Manager, RunEvent};
+
+struct DummyStore(Mutex<HashMap<String, String>>);
+
+Builder::new("<nom-du-plugin>")
+  .setup(|app, _api| {
+    app.manage(DummyStore(Default::default()));
+    Ok(())
+  })
+  .on_event(|app, event| {
+    match event {
+      RunEvent::ExitRequested { api, .. } => {
+        // l'utilisateur a demandé la fermeture d'une fenêtre et il n'en reste plus
+
+        // on peut éviter la fermeture de l'application :
+        api.prevent_exit();
+      }
+      RunEvent::Exit => {
+        // l'application va se fermer, nous pouvez nettoyer ici
+
+        let store = app.state::<DummyStore>();
+        write(
+          app.path().app_local_data_dir().unwrap().join("store.json"),
+          serde_json::to_string(&*store.0.lock().unwrap()).unwrap(),
+        )
+        .unwrap();
+      }
+      _ => {}
+    }
+  })
+```
+
+### on_drop
+
+- **Quand** : Le plugin est déconstruit
+- **Pourquoi**: Exécute le code lors de la destruction du plugin
+
+Voir [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) pour plus d'information.
+
+```rust
+use tauri::plugin::Builder;
+
+Builder::new("<nom-du-plugin>")
+  .on_drop(|app| {
+    // le plugin a été détruit...
+  })
+```
+
+## Exposer les API Rust
+
+Les API de plugins définis dans `desktop.rs` et `mobile.rs` du projet sont exportés à l'utilisateur en tant que structure avec le même nom que le plugin (en pascal case). Lors de l'initialisation du plugin, une instance de cette structure est créée et gérée comme un état pour que les utilisateurs puissent la retrouver à tout instant avec une instance de `Manager` (comme `AppHandle`, `App`, ou ` Window`), via le trait d'extension défini dans le plugin.
+
+Par exemple, le [plugin `global-shortcut`](/2/fr/guide/global-shortcut) défini une structure `GlobalShortcut` qui peut être accédée en utilisant la méthode `global_shortcut` du trait `GlobalShortcutExt` :
+
+```rust
+use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+tauri::Builder::default()
+  .plugin(tauri_plugin_global_shortcut::init())
+  .setup(|app| {
+    app.global_shortcut().register(...);
+    Ok(())
+  })
+```
+
+## Ajout de commandes
+
+Les commandes sont définies dans le fichier `commands.rs`. Ce sont des commandes régulières des applications Tauri. Elles peuvent accéder aux instances `AppHandle` et `Window` directement, accéder aux états, et prendre les entrées de la même manière que les commandes d'application. Pour plus de détails sur les commandes tauri, voir le [guide des commandes](/2/fr/guide/commands)
+
+Cette commande montre comment accéder aux instances de `AppHandle` et `Window` via l'injection de dépendances, et prend deux paramètres d'entrés (`on_progress` et `url`)
+
+```rust
+use tauri::{command, ipc::Channel, AppHandle, Runtime, Window};
+
+#[command]
+async fn upload<R: Runtime>(app: AppHandle<R>, window: Window<R>, on_progress: Channel, url: String) {
+  // implémenter la logique de la commande ici
+  on_progress.send(100).unwrap();
+}
+```
+
+Pour exposer la commande à la "webview", vous devez capter les appells de `invoke_handler()` dans `lib.rs` :
+
+```rust
+// lib.rs
+Builder::new("<nom-du-plugin>")
+    .invoke_handler(tauri::generate_handler![commands::upload])
+```
+
+Définition d'une fonction de liaison dans `webview-src/index.ts` pour que l'utilisateur puisse facilement appeller la commande dans JavaScript :
+Define a binding function in  so that plugin users can easily call the command in JavaScript:
+
+```js
+// webview-src/index.ts
+import { invoke, Channel } from '@tauri-apps/api/tauri'
+
+export async function upload(url: string, onProgressHandler: (progress: number) => void): Promise<void> {
+  const onProgress = new Channel<number>()
+  onProgress.onmessage = onProgressHandler
+  await invoke('plugin:<nom-du-plugin>|upload', { url, onProgress })
+}
+```
+
+Assurez-vous de compiler le code TypeScript avant de le tester.
+
+## Gérer les états
+
+Un plugin peut gérer les états de la même manière qu'une application Tauri. Voir le [guide de gestion des états](/2/guide/state-management) pour plus d'informations.

--- a/src/content/docs/fr/guides/plugins/index.mdx
+++ b/src/content/docs/fr/guides/plugins/index.mdx
@@ -11,7 +11,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 
 :::tip[Développement de plugin]
 
-Ce guide couvre le développement de plugins pour Tauri. Si vous cherchez une liste des plugins actuellement disponibles et comment les utiliser, allez sur la [liste des fonctionnalitées et cas d'usages](/fr/guide/list).
+Ce guide couvre le développement de plugins pour Tauri. Si vous cherchez une liste des plugins actuellement disponibles et comment les utiliser, allez sur la [liste des fonctionnalitées et cas d'usages](/fr/guides/list).
 
 :::
 
@@ -19,7 +19,7 @@ Les plugins sont capables de se lier au cycle de vie de Tauri, expose le code Ru
 
 Tauri offre un système de fenêtrage avec sa fonctionnalité de web view, une manière d'envoyer des messages entre le processus Rust et la wab view, et un système d'évènement avec plusieurs outils pour améliorer l'expérience de développement. De par sa conception, le noyeau de Tauri ne contient pas de fonctionnalités dont tout le monde n'a pas besoin. au lieu de cela, il offre un méchanisme pour ajouter des fonctionnalités externes dans une application Tauri appelé plugin.
 
-Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel qui fournit des liaisons pour ses commandes et évènements. De plus, un plugin peut inclure un projet de librairie Android et un package Swift pour iOS. Vous pouvez en apprendre plus sur le développement de plugins pour Android et iOS dans le [guide de développement de plugin mobile](/fr/guide/plugins/develop-mobile).
+Un plugin Tauri est constitué d'une crate Cargo et d'un package NPM optionnel qui fournit des liaisons pour ses commandes et évènements. De plus, un plugin peut inclure un projet de librairie Android et un package Swift pour iOS. Vous pouvez en apprendre plus sur le développement de plugins pour Android et iOS dans le [guide de développement de plugin mobile](/fr/guides/plugins/develop-mobile).
 
 {/* TODO: https://github.com/tauri-apps/tauri/issues/7749 */}
 
@@ -67,7 +67,7 @@ Si vous avez un plugin existant et voulez lui ajouter des fonctionnalitées Andr
 
 Les plugins peuvent exécuter du code mobile natif écrit en Kotlin (ou Java) et Swift. Le modèle de plugin par défaut inclue une librairie Android utilisant Kotlin et un package Swift. Il inclus aussi un example montrant comment utiliser son exécution à partir du code Rust.
 
-Apprenez-en plus à propos du développement de plugins pour mobiles dans le [guide de développement de plugins mobiles](/fr/guide/plugins/develop-mobile)
+Apprenez-en plus à propos du développement de plugins pour mobiles dans le [guide de développement de plugins mobiles](/fr/guides/plugins/develop-mobile)
 
 ## Configuration de plugin
 
@@ -121,7 +121,7 @@ Les plugins peuvent capter plusieurs évènements du cycle de vie :
 - [on_event](#on_event): Évènements de la boucles d'évènements
 - [on_drop](#on_drop): Le plugin est en cours de déconstruction
 
-Il existe d'autres [évènements du cycle de vie pour des plugins mobiles](/fr/guide/plugins/develop-mobile#évènement-du-cycle-de-vie).
+Il existe d'autres [évènements du cycle de vie pour des plugins mobiles](/fr/guides/plugins/develop-mobile#évènement-du-cycle-de-vie).
 
 ### setup
 
@@ -245,7 +245,7 @@ Builder::new("<nom-du-plugin>")
 
 Les API de plugins définis dans `desktop.rs` et `mobile.rs` du projet sont exportés à l'utilisateur en tant que structure avec le même nom que le plugin (en pascal case). Lors de l'initialisation du plugin, une instance de cette structure est créée et gérée comme un état pour que les utilisateurs puissent la retrouver à tout instant avec une instance de `Manager` (comme `AppHandle`, `App`, ou ` Window`), via le trait d'extension défini dans le plugin.
 
-Par exemple, le [plugin `global-shortcut`](/fr/guide/global-shortcut) défini une structure `GlobalShortcut` qui peut être accédée en utilisant la méthode `global_shortcut` du trait `GlobalShortcutExt` :
+Par exemple, le [plugin `global-shortcut`](/fr/guides/global-shortcut) défini une structure `GlobalShortcut` qui peut être accédée en utilisant la méthode `global_shortcut` du trait `GlobalShortcutExt` :
 
 ```rust
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
@@ -299,4 +299,4 @@ Assurez-vous de compiler le code TypeScript avant de le tester.
 
 ## Gérer les états
 
-Un plugin peut gérer les états de la même manière qu'une application Tauri. Voir le [guide de gestion des états](/fr/guide/state-management) pour plus d'informations.
+Un plugin peut gérer les états de la même manière qu'une application Tauri. Voir le [guide de gestion des états](/fr/guides/state-management) pour plus d'informations.

--- a/src/content/docs/guides/plugins/develop-mobile.mdx
+++ b/src/content/docs/guides/plugins/develop-mobile.mdx
@@ -367,7 +367,7 @@ class ExamplePlugin: Plugin {
 </TabItem>
 </Tabs>
 
-The helper functionss can then be called from the NPM package by using the [`addPluginListener`](/2/reference/js/core/namespacetauri/#addpluginlistener) helper function:
+The helper functions can then be called from the NPM package by using the [`addPluginListener`](/2/reference/js/core/namespacetauri/#addpluginlistener) helper function:
 
 ```javascript
 import { addPluginListener, PluginListener } from '@tauri-apps/api/tauri';

--- a/src/content/docs/guides/plugins/index.mdx
+++ b/src/content/docs/guides/plugins/index.mdx
@@ -260,7 +260,7 @@ tauri::Builder::default()
 
 ## Adding Commands
 
-Commands are defined in the `commands.rs` file. They are regular Tauri applications commands. They can access the AppHandle and Window instances directly, access state, and take input the same way as application commands. Read the [Commands guide](/features/commands) for more details on Tauri commands.
+Commands are defined in the `commands.rs` file. They are regular Tauri applications commands. They can access the `AppHandle` and `Window` instances directly, access state, and take input the same way as application commands. Read the [Commands guide](/features/commands) for more details on Tauri commands.
 
 This command shows how to get access to the `AppHandle` and `Window` instance via dependency injection, and takes two input parameters (`on_progress` and `url`):
 


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes : very small typos changes in the original doc
- Translated content : /guides/plugins/index.mdx + /guides/plugins/develop-mobile.mdx translated in french

#### Description
- What does this PR change? 1 new folder : /fr/plugins and 2 new translated files : index.mdx & develop-mobile.mdx.