### PR TITLE
feat: clipboard rust guide #1475

### DIFF
--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -96,9 +96,87 @@ console.log(content);
 </TabItem>
 <TabItem label="Rust">
 
-{/* TODO: */}
+{/* WRITE TO CLIPBOARD RUST */}
 
-<Stub />
+#### Write text to the clipboard:
+
+1. Set up the function in `main.rs` (Tauri backend)
+
+```rust
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+#[tauri::command]
+async fn write(content: String, app: tauri::AppHandle) {
+    // Copy content to the clipboard
+    let clipboard_content = tauri_plugin_clipboard_manager::ClipKind::PlainText {
+        label: Some("Label".to_string()),
+        text: content,
+    };
+    let result = app.clipboard().write(clipboard_content);
+    match result {
+        Ok(_) => println!("Successfully copied to clipboard"),
+        Err(error) => eprintln!("Error copying to clipboard: {:?}", error),
+    };
+}
+```
+
+2. Register in the generate_handler array:
+
+```rust
+    tauri::Builder::default()
+        // Register fn write to the existing array
+        .invoke_handler(tauri::generate_handler![write])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+
+```
+
+3. Call it from your frontend
+
+```js
+import { invoke } from '@tauri-apps/api/tauri';
+
+// When called, the backend write function will write "Tauri is awesome" to the clipboard
+await invoke('write', { content: 'Tauri is awesome' });
+```
+
+{/* READ FROM CLIPBOARD RUST */}
+
+#### Read text from the clipboard:
+
+1. Set up the function in `main.rs` (Tauri backend)
+
+```rust
+use tauri_plugin_clipboard_manager::ClipboardExt;
+#[tauri::command]
+async fn read(app: tauri::AppHandle) {
+    let content = app.clipboard().read();
+    // Print clipboard content once called from the front end
+    println!("{:?}", content.unwrap());
+}
+
+```
+
+2. Register in the generate_handler:
+
+```rust
+    tauri::Builder::default()
+        // Register fn read to the existing array
+        .invoke_handler(tauri::generate_handler![..., read])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+
+```
+
+3. Call it from your frontend
+
+```js
+import { invoke } from '@tauri-apps/api/tauri';
+
+await invoke('read');
+```
+
+{/* TODO: RUST FRONTEND */}
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -41,6 +41,8 @@ Install the clipboard plugin to get started.
     }
     ```
 
+
+
     </TabItem>
     <TabItem label="Manual">
 
@@ -87,7 +89,7 @@ import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 // Write text to the clipboard
 await writeText('Tauri is awesome!');
 
-// Read text from the clipboard
+// Read content from the clipboard
 const content = await readText();
 console.log(content);
 // Prints "Tauri is awesome!" to the console
@@ -100,83 +102,30 @@ console.log(content);
 
 #### Write text to the clipboard:
 
-1. Set up the function in `main.rs` (Tauri backend)
-
 ```rust
 use tauri_plugin_clipboard_manager::ClipboardExt;
+// Copy content to the clipboard
+let clipboard_content = tauri_plugin_clipboard_manager::ClipKind::PlainText {
+    label: Some("Label".to_string()),
+    text: "Tauri is Awesome".to_string(),
+};
+app.clipboard().write(clipboard_content).unwrap();
 
-#[tauri::command]
-async fn write(content: String, app: tauri::AppHandle) {
-    // Copy content to the clipboard
-    let clipboard_content = tauri_plugin_clipboard_manager::ClipKind::PlainText {
-        label: Some("Label".to_string()),
-        text: content,
-    };
-    let result = app.clipboard().write(clipboard_content);
-    match result {
-        Ok(_) => println!("Successfully copied to clipboard"),
-        Err(error) => eprintln!("Error copying to clipboard: {:?}", error),
-    };
-}
-```
-
-2. Register in the generate_handler array:
-
-```rust
-    tauri::Builder::default()
-        // Register fn write to the existing array
-        .invoke_handler(tauri::generate_handler![write])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-
-```
-
-3. Call it from your frontend
-
-```js
-import { invoke } from "@tauri-apps/api/primitives";
-
-// When called, the backend write function will write "Tauri is awesome" to the clipboard
-await invoke('write', { content: 'Tauri is awesome' });
 ```
 
 {/* READ FROM CLIPBOARD RUST */}
 
 #### Read text from the clipboard:
 
-1. Set up the function in `main.rs` (Tauri backend)
-
 ```rust
 use tauri_plugin_clipboard_manager::ClipboardExt;
-#[tauri::command]
-async fn read(app: tauri::AppHandle) {
-    let content = app.clipboard().read();
-    // Print clipboard content once called from the front end
-    println!("{:?}", content.unwrap());
-}
+
+// Read content from the clipboard
+let content = app.clipboard().read();
+println!("{:?}", content.unwrap());
+
 
 ```
-
-2. Register in the generate_handler:
-
-```rust
-    tauri::Builder::default()
-        // Register fn read to the existing array
-        .invoke_handler(tauri::generate_handler![..., read])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-
-```
-
-3. Call it from your frontend
-
-```js
-import { invoke } from "@tauri-apps/api/primitives";
-
-await invoke('read');
-```
-
-{/* TODO: RUST FRONTEND */}
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -134,7 +134,7 @@ async fn write(content: String, app: tauri::AppHandle) {
 3. Call it from your frontend
 
 ```js
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from "@tauri-apps/api/primitives";
 
 // When called, the backend write function will write "Tauri is awesome" to the clipboard
 await invoke('write', { content: 'Tauri is awesome' });
@@ -171,7 +171,7 @@ async fn read(app: tauri::AppHandle) {
 3. Call it from your frontend
 
 ```js
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from "@tauri-apps/api/primitives";
 
 await invoke('read');
 ```

--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -86,10 +86,10 @@ The clipboard plugin is available in both JavaScript and Rust.
 ```js
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 
-// Write text to the clipboard
+// Write content to clipboard
 await writeText('Tauri is awesome!');
 
-// Read content from the clipboard
+// Read content from clipboard
 const content = await readText();
 console.log(content);
 // Prints "Tauri is awesome!" to the console
@@ -98,31 +98,20 @@ console.log(content);
 </TabItem>
 <TabItem label="Rust">
 
-{/* WRITE TO CLIPBOARD RUST */}
-
-#### Write text to the clipboard:
-
 ```rust
 use tauri_plugin_clipboard_manager::ClipboardExt;
-// Copy content to the clipboard
+
+// Write content to clipboard
 let clipboard_content = tauri_plugin_clipboard_manager::ClipKind::PlainText {
     label: Some("Label".to_string()),
-    text: "Tauri is Awesome".to_string(),
+    text: "Tauri is awesome!".to_string(),
 };
 app.clipboard().write(clipboard_content).unwrap();
 
-```
-
-{/* READ FROM CLIPBOARD RUST */}
-
-#### Read text from the clipboard:
-
-```rust
-use tauri_plugin_clipboard_manager::ClipboardExt;
-
-// Read content from the clipboard
+// Read content from clipboard
 let content = app.clipboard().read();
 println!("{:?}", content.unwrap());
+// Prints "Tauri is awesome!" to the terminal
 
 
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- New or updated content

#### Description

- Related to #1475
- There's some wording and code choices regarding Rust syntax. To facilitate I wrote the 'Read' in one way and 'Write' part in another way. To clarify, examples:
1. 

With `...` to indicate that it's possible to generate multiple handles:
```rust
    .invoke_handler(tauri::generate_handler![write])
```

or without:
```rust
    .invoke_handler(tauri::generate_handler![write])
```
By the way, I don't know if there any difference between calling `invoke_handle `multiple times vs only one.

2.
Use `match`
```rust
  let content = app.clipboard().read();
    match content {
        Ok(content) => println!("Clipboard:{:?}", content),
        Err(error) => println!("{:?}", error),
    }
```

or `unwrap()`
```rust
    let content = app.clipboard().read();
    println!("{:?}", content.unwrap());
}
```

Then another situation: The JavaScript part seems too crude compared to Rust. We could Improve by adding the whole function in JS. I had to add function signature in Rust because of the handle part.

Another issue is regarding how to call those functions from Rust frontend. Afaik there's Yew, Leptos and Sycamore to Rust frontend and each one would have a different way to write. The vanilla option is html/css/js. 
Because of this I'm thinking in a different approach in the last step: "3. Call it from your frontend -> Tabs (Rust | JavaScript)" with links for the frameworks specific guides on how to call function from Tauri/Rust backend.

I was reading some past pr discussions but if there's anything relevant to read I appreciate. Thanks

Note: I'm still learning Rust.