### PR TITLE
[v2] fix: shikiConfig

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -194,7 +194,7 @@ export default defineConfig({
 	],
 	markdown: {
 		shikiConfig: {
-			langs: ['powershell'],
+			langs: ['powershell', 'ts', 'rust', 'bash', 'json', 'toml'],
 		},
 		rehypePlugins: [
 			rehypeHeadingIds,


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Closes #1634, tested locally with tauri-docs and with a starlight starter repo.

While this fixes the issue, I'm not sure this is the real solution. This seems related to the recent change from shiki to shikiji in Astro. From what I gather shikiji needs langs to be specified. On the other hand if `shikiConfig` is removed, then it seems to work too.
```
shikiConfig: {
			langs: ['powershell', 'ts', 'rust', 'bash', 'json', 'toml'],
		},
```
The added items is based on the warnings