### PR TITLE
Update next-js.mdx / output built directory

### DIFF
--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -74,8 +74,6 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-This will change the behavior of the `next build` to produce an `out/` folder containing the HTML/CSS/JS assets for your application instead of writing them to a `.next/` directory specific to Next.js' runtime.
-
 There are a few more possible configuration options, so make sure to read through the [Static Exports] docs as mentioned above and adapt the configuration file according to the needs of your project.
 
 ## Create the Rust Project
@@ -103,7 +101,7 @@ Now that we have scaffolded our frontend and initialized the Rust project you're
     "beforeBuildCommand": "npm run build",
     "beforeDevCommand": "npm run dev",
     "devPath": "http://localhost:3000",
-    "distDir": "../out"
+    "distDir": "../.next"
   },
 ```
 


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Installing Next.js with tauri.
- I removed the documentation led me to an error.

#### Description
<!-- Delete any that don’t apply -->
- No issue related
- I followed the original documentation. I had an issue because even with :
```js
const nextConfig = {
   output: 'export'
}
```
The project was built into `.next/`.
I updated `tauri.conj.json/build/distDir:"../.next"`, And it worked for me.
 
Personal configuration : Mac OS Ventura, MBP m1.
Next.js 13.5

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->