### PR TITLE
Benchmark charts: use straight strokes for readability

### DIFF
--- a/src/theme/BenchmarkChart/index.js
+++ b/src/theme/BenchmarkChart/index.js
@@ -154,7 +154,7 @@ function createOptions(columnName, colorMode) {
     },
     stroke: {
       width: 2,
-      curve: 'smooth',
+      curve: 'straight',
     },
     xaxis: {
       type: 'datetime',


### PR DESCRIPTION

#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description
For its [benchmarks page](https://tauri.app/v1/references/benchmarks/), Tauri uses ApexCharts with [`curve` strokes](https://apexcharts.com/docs/options/stroke/). They are nice, BUT when when two points are very close in time, it sometimes creates an additional stroke, which makes the chart unreadable. This PR changes to `straight` strokes, which removes the issue.

Before:

![image](https://github.com/tauri-apps/tauri-docs/assets/628140/3bd7c866-4e5e-40ab-a5e9-2b6caf9c048e)

After:

![image](https://github.com/tauri-apps/tauri-docs/assets/628140/a7641e78-dadb-493d-93b9-d38671cdd592)

The whole chart, with **straight** strokes:

![image](https://github.com/tauri-apps/tauri-docs/assets/628140/48205749-35f0-4d14-a500-3587c4fd295f)

