### PR TITLE
fix: add missing semicolon to splashscreen close command

### DIFF
--- a/docs/guides/features/splashscreen.md
+++ b/docs/guides/features/splashscreen.md
@@ -40,7 +40,7 @@ use tauri::{Manager, Window};
 #[tauri::command]
 async fn close_splashscreen(window: Window) {
   // Close splashscreen
-  window.get_window("splashscreen").expect("no window labeled 'splashscreen' found").close().unwrap()
+  window.get_window("splashscreen").expect("no window labeled 'splashscreen' found").close().unwrap();
   // Show main window
   window.get_window("main").expect("no window labeled 'main' found").show().unwrap();
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
- Adds a missing semicolon to the example code for the splashscreen close command
- Without it, my Tauri v1 app did not compile and the cargo told me: `help: add ';' here` in the line I changed

If the semicolon is actually not needed and it's some kind of issue on my end, feel free to close the issue.

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->