### PR TITLE
fix: workflow update-docs 1.x

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: tauri-apps/tauri
-          ref: ${{ github.event.inputs.tauriBranch }}
+          ref: ${{inputs.tauriBranch || '1.x'}}
           path: tauri
 
       - name: Checkout tauri-docs


### PR DESCRIPTION
As discussed on [discord](https://discord.com/channels/616186924390023171/662624589037436928/1167849747625820180) @FabianLars 

right now it considers the input, is this ok or should I hardcode to '1.x'?

thank you
