### PR TITLE
feat: update `actions/checkout@3` & `actions/setup-node@3` to v4

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -70,8 +70,8 @@ This workflow sets up the environment on Windows, Ubuntu, and macOS latest versi
 
 The steps this workflow takes are:
 
-1. Checkout the repository using `actions/checkout@v3`
-2. Set up Node LTS and a cache for global npm/yarn/pnpm package data using `actions/setup-node@v3`.
+1. Checkout the repository using `actions/checkout@v4`
+2. Set up Node LTS and a cache for global npm/yarn/pnpm package data using `actions/setup-node@v4`.
 3. Set up Rust and a cache for the `target/` folder using `dtolnay/rust-toolchain@stable` and `swatinem/rust-cache@v2`.
 4. Installs all the dependencies and run the build script (for the web app).
 5. Finally, it uses `tauri-apps/tauri-action@v0` to run `tauri build`, generate the artifacts, and create the GitHub release.
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
@@ -114,7 +114,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Sync node version and setup cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'yarn' # Set this to npm, yarn or pnpm.


### PR DESCRIPTION
Hi Tauri team,

Thanks for the great docs—it has been incredibly helpful.

#### What kind of changes does this PR include?

- updated content

#### Description

- What does this PR change? Give us a brief description.

  Recently, I was working on setting up my CI pipeline and discovered that both [actions/checkout](https://github.com/actions/checkout) and [actions/setup-node](https://github.com/actions/setup-node) have been upgraded to v4. The update worked seamlessly, as demonstrated [here](https://github.com/EastSun5566/hackdesk/actions/runs/6800624240/job/18489605956). Therefore, I have also updated the documentation to reflect the changes to v4.
