### PR TITLE
Fixes typo in Discord invite link redirecting to incorrect site

### DIFF
--- a/src/content/docs/blog/partnership-crabnebula.md
+++ b/src/content/docs/blog/partnership-crabnebula.md
@@ -39,7 +39,7 @@ To our developers, contributors, users, and donors - we invite you to engage wit
 
 If you like, go over to the CrabNebula blog and read [their perspective](https://crabnebula.dev/blog/tauri-partnership) on this partnership.
 
-- [Discord Tauri](https://discorg.gg/tauri)
+- [Discord Tauri](https://discord.gg/tauri)
 - [X Tauri](https://x.com/TauriApps)
 - [Mastadon Tauri](https://fosstodon.org/@TauriApps)
 - [GitHub Tauri](https://github.com/tauri-apps)


### PR DESCRIPTION
Fixes a single letter typo in the Discord invite link which redirected users to a miscellaneous website, eventually leading to a fake Microsoft Windows site prompting for data. 'g' is now a 'd'

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)