### PR TITLE
docs: add pkg-config env variable example

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -123,6 +123,7 @@ There are two solutions to this issue:
 
 1. [Uninstall Homebrew]
 2. Set the `PKG_CONFIG_PATH` environment variable to point to the correct `pkg-config` before building a Tauri app
+    - Example: `export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig`
 
 [crates.io]: https://crates.io/crates/tauri-cli
 [via npm]: https://www.npmjs.com/package/@tauri-apps/cli


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Add example command to export environment variable required for "Build Conflict with Homebrew on Linux" section

#### Description
Docs states set the env variable, but doesn't explains what to do very well.
https://github.com/tauri-apps/tauri/issues/2798#issuecomment-1089822619 I thought adding this to the docs will be nice for new users who uses brew on linux.