### PR TITLE
docs: dialog persisted scope link

### DIFF
--- a/docs/api/js/dialog.md
+++ b/docs/api/js/dialog.md
@@ -306,7 +306,7 @@ When security is more important than the easy of use of this API,
 prefer writing a dedicated command instead.
 
 Note that the allowlist scope change is not persisted, so the values are cleared when the application is restarted.
-You can save it to the filesystem using [tauri-plugin-persisted-scope](https://github.com/tauri-apps/tauri-plugin-persisted-scope).
+You can save it to the filesystem using [tauri-plugin-persisted-scope](https://github.com/tauri-apps/plugins-workspace/tree/v1/plugins/persisted-scope).
 
 **Example**
 


### PR DESCRIPTION

#### What kind of changes does this PR include?
- Changes to the docs site code

#### Description
- Closes tauri-apps/tauri#8302
- Changes the link In docs for the open function in the Dialog JS API from the deprecated [tauri-plugin-persisted-scope](https://github.com/tauri-apps/tauri-plugin-persisted-scope) repository to the new [plugins-workspace](https://github.com/tauri-apps/plugins-workspace) repository
