### PR TITLE
fix: update required xcode version for notarization during build process

### DIFF
--- a/docs/guides/distribution/sign-macos.md
+++ b/docs/guides/distribution/sign-macos.md
@@ -16,7 +16,7 @@ If you are not utilizing GitHub Actions to perform builds of OSX DMGs, you will 
 ## Requirements
 
 - macOS 10.13.6 or later
-- Xcode 10 or later
+- Xcode 14 or later 
 - An Apple Developer account enrolled in the [Apple Developer Program]
 
 For more details please read the developer article on [notarizing macOS software before distribution].


### PR DESCRIPTION
#### What kind of changes does this PR include?
- New or updated content to reflect the requirement of the newer Xcode version from Apple on notarization stage

#### Description
- Closes #7665 [https://github.com/tauri-apps/tauri/issues/7665](https://github.com/tauri-apps/tauri/issues/7665)
- Fixing the documentation to reflect the requirement from Apple as per the quoted disclaimer below from the linked page. Any lower version of xcode fails with an issue on notarization stage of the build process 
``Important
Starting November 1, 2023, the Apple notary service no longer accepts uploads from altool or Xcode 13 or earlier. If you notarize your Mac software with the Apple notary service using the altool command-line utility or Xcode 13 or earlier, you need to transition to the notarytool command-line utility or upgrade to Xcode 14 or later.``

[https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)