### PR TITLE
[v2] fix: info aside in `/references/v1/cli/`

### DIFF
--- a/src/content/docs/references/v1/cli.mdx
+++ b/src/content/docs/references/v1/cli.mdx
@@ -26,7 +26,7 @@ Options:
 
 It shows a concise list of information about the environment, Rust, Node.js and their versions as well as some relevant configurations.
 
-:::info
+:::note
 
 This command is pretty helpful when you need to have a quick overview of your application. When requesting some help, it can be useful that you share this report with us.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
`:::info` to `:::note` in https://beta.tauri.app/references/v1/cli/

refer to: https://starlight.astro.build/guides/authoring-content/#asides

after:
<img src="https://github.com/tauri-apps/tauri-docs/assets/61759797/4104d75b-1568-43da-b939-b00e79147dd8" width="50%"/>
before:
<img src="https://github.com/tauri-apps/tauri-docs/assets/61759797/3981407a-3c27-4772-b323-d61ebebd1e9f" width="50%"/>

Thank you, happy new year, and happy holidays!