### PR TITLE
Update splashscreen.md to account for distDir recreation for Vite-based projects

### DIFF
--- a/docs/guides/features/splashscreen.md
+++ b/docs/guides/features/splashscreen.md
@@ -16,7 +16,7 @@ First, create a `splashscreen.html` in your `distDir` that contains the HTML cod
   },
 ```
 
-This will copy the `splashscreen.html` into the `distDir` folder whenever you run `npm run tauri build`. In previous documentation, this npm command usually deleted the `splashscreen.html` that you were manually creating in the `distDir`, as it recreates the `distDir` folder each time you run the command.
+This will copy the `splashscreen.html` into the `distDir` folder whenever you run `npm run tauri build`.
 
 Then, update your `tauri.conf.json` like so:
 

--- a/docs/guides/features/splashscreen.md
+++ b/docs/guides/features/splashscreen.md
@@ -4,19 +4,7 @@ If your webpage could take some time to load, or if you need to run an initializ
 
 ### Setup
 
-First, create a `splashscreen.html` in your `distDir` that contains the HTML code for a splashscreen. Note that if you're using Tauri with a Vite-based project, it is better to create the `splashscreen.html` inside the root folder of your project right next to the `package.json`. Then, you will have to modify the `scripts` section of your `package.json` like so:
-
-```diff
-"scripts": {
-    "dev": "vite",
--   "build": "vue-tsc --noEmit && vite build",
-+   "build": "vue-tsc --noEmit && vite build && cp splashscreen.html dist",
-    "preview": "vite preview",
-    "tauri": "tauri"
-  },
-```
-
-This will copy the `splashscreen.html` into the `distDir` folder whenever you run `npm run tauri build`.
+First, create a `splashscreen.html` in your `distDir` that contains the HTML code for a splashscreen. Note that if you're using Tauri with a Vite-based project, it is advised to create the `splashscreen.html` inside the `public` folder of your project right next to the `package.json`.
 
 Then, update your `tauri.conf.json` like so:
 

--- a/docs/guides/features/splashscreen.md
+++ b/docs/guides/features/splashscreen.md
@@ -4,7 +4,21 @@ If your webpage could take some time to load, or if you need to run an initializ
 
 ### Setup
 
-First, create a `splashscreen.html` in your `distDir` that contains the HTML code for a splashscreen. Then, update your `tauri.conf.json` like so:
+First, create a `splashscreen.html` in your `distDir` that contains the HTML code for a splashscreen. Note that if you're using Tauri with a Vite-based project, it is better to create the `splashscreen.html` inside the root folder of your project right next to the `package.json`. Then, you will have to modify the `scripts` section of your `package.json` like so:
+
+```diff
+"scripts": {
+    "dev": "vite",
+-   "build": "vue-tsc --noEmit && vite build",
++   "build": "vue-tsc --noEmit && vite build && cp splashscreen.html dist",
+    "preview": "vite preview",
+    "tauri": "tauri"
+  },
+```
+
+This will copy the `splashscreen.html` into the `distDir` folder whenever you run `npm run tauri build`. In previous documentation, this npm command usually deleted the `splashscreen.html` that you were manually creating in the `distDir`, as it recreates the `distDir` folder each time you run the command.
+
+Then, update your `tauri.conf.json` like so:
 
 ```diff
 "windows": [


### PR DESCRIPTION
I noticed that the documentation causes unwated behaviours with the splash screen especially for Vite-based projects(I use Tauri with Vue). Manually creating the `splashscreen.html` inside the `distDir` causes the file to be deleted each time you rebuild the project using `npm run tauri build`. This documentation PR should allow the reader to automate this manual creation by copying the file from the root into their `distDir`