### PR TITLE
docs: Disable outdated and unused benchmarks page

### DIFF
--- a/blog/2022-06-19-tauri-1-0.mdx
+++ b/blog/2022-06-19-tauri-1-0.mdx
@@ -57,7 +57,7 @@ Tauri allows you to build "[local first](https://twitter.com/schickling/status/1
 
 ### Environment
 
-The apps you make are [lean and performant](/v1/references/benchmarks), which reduces electricity, storage space, and general natural resource consumption. Every byte saved is a leaf on a tree that gets to grow.
+The apps you make are lean and performant, which reduces electricity, storage space, and general natural resource consumption. Every byte saved is a leaf on a tree that gets to grow.
 
 To illustrate this, we compiled some numbers on the ecological impact of your app's size. As you can see, even small increases in size have a hefty impact on the environment!
 

--- a/docs/references/architecture/readme.md
+++ b/docs/references/architecture/readme.md
@@ -12,7 +12,7 @@ import { Mermaid } from 'mdx-mermaid/Mermaid';
 
 Tauri is a polyglot and generic toolkit that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for desktop computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API and Rust API so that webviews can control the system via message passing. Developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
-Tauri apps can have [custom menus](../../guides/features/menu.md) and [tray-type interfaces](../../guides/features/system-tray.md). They can be [updated](../../guides/distribution/updater.md) and are managed by the user's operating system as expected. They are [very small](../benchmarks.md) because they use the OS's webview. They do not ship a runtime since the final binary is compiled from Rust. This makes the [reversing of Tauri apps not a trivial task](./security.md).
+Tauri apps can have [custom menus](../../guides/features/menu.md) and [tray-type interfaces](../../guides/features/system-tray.md). They can be [updated](../../guides/distribution/updater.md) and are managed by the user's operating system as expected. They are very small because they use the OS's webview. They do not ship a runtime since the final binary is compiled from Rust. This makes the [reversing of Tauri apps not a trivial task](./security.md).
 
 ### What Tauri is Not
 

--- a/docs/references/benchmarks.md
+++ b/docs/references/benchmarks.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 description: View the current benchmarks of Tauri for binary size, memory usage, and other metrics.
 ---
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,12 +87,12 @@ function Cards() {
             <h2>{card.label}</h2>
             <p>{card.description}</p>
             <div className={classNames(styles.cardSpacer)}></div>
-            card.link ?? <Link
+            {card.link ?? <Link
               className={'button button--primary'}
               href={(card.isDoc ? latestVersion.path : '') + card.link}
             >
               {card.linkText}
-            </Link>
+            </Link>}
           </div>
           <div className={classNames(styles.cardSide, styles.cardImage)}>
             <img src={card.imageUrl} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,6 +52,7 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
+      link: '#'
       isDoc: true,
       imageUrl: 'img/index/illustrations/box.svg',
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
-      link: '#',
+      link: 'https://tauri.app/',
       isDoc: true,
       imageUrl: 'img/index/illustrations/box.svg',
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,7 +87,7 @@ function Cards() {
             <h2>{card.label}</h2>
             <p>{card.description}</p>
             <div className={classNames(styles.cardSpacer)}></div>
-            {card.link ?? <Link
+            {card.link && <Link
               className={'button button--primary'}
               href={(card.isDoc ? latestVersion.path : '') + card.link}
             >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,8 +52,7 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
-      link: 'https://tauri.app/',
-      isDoc: true,
+      link: '#',
       imageUrl: 'img/index/illustrations/box.svg',
     },
     {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,6 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
-      link: '#',
       imageUrl: 'img/index/illustrations/box.svg',
     },
     {
@@ -88,7 +87,7 @@ function Cards() {
             <h2>{card.label}</h2>
             <p>{card.description}</p>
             <div className={classNames(styles.cardSpacer)}></div>
-            <Link
+            card.link ?? <Link
               className={'button button--primary'}
               href={(card.isDoc ? latestVersion.path : '') + card.link}
             >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
-      link: '#'
+      link: '#',
       isDoc: true,
       imageUrl: 'img/index/illustrations/box.svg',
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,9 +52,7 @@ function Cards() {
         message:
           "By using the OS's native web renderer, the size of a Tauri app can be less than 600KB.",
       }),
-      link: '/references/benchmarks',
       isDoc: true,
-      linkText: translate({ message: 'Learn More' }),
       imageUrl: 'img/index/illustrations/box.svg',
     },
     {


### PR DESCRIPTION
*unused in the context of how it was meant to be used, for us a control mechanism.

Edit: iirc we won't add this to the new docs anyway, so may as well pull the plug already.