### PR TITLE
docs: Added NixOS prerequisites

### DIFF
--- a/src/content/docs/guides/prerequisites/index.mdx
+++ b/src/content/docs/guides/prerequisites/index.mdx
@@ -104,7 +104,45 @@ sudo zypper in -t pattern devel_basis
   </TabItem>
   <TabItem label="NixOS">
 
-TODO: Need to build out NixOS instructions
+`flake.nix`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+      in {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [
+            (pkgs.rust-bin.fromRustupToolchain {
+              channel = "nightly-2023-12-19"; # feel free to change the channel
+              components = [ "rustfmt" "rust-src" ];
+              targets = [ "wasm32-unknown-unknown" ];
+              profile = "minimal";
+            })
+            pkgs.pkg-config
+            pkgs.atk
+            pkgs.pango
+            pkgs.libsoup_3
+            pkgs.webkitgtk_4_1
+            pkgs.openssl
+            pkgs.cargo-tauri
+            pkgs.trunk
+          ];
+        };
+      }
+    );
+}
+```
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
I added a minimal `flake.nix` sample that provides a dev shell with all required packages. This might be a lot when compared to other distributions prerequisites, but I figured I'd contribute anyways since I'm running NixOS right now and I can `cargo tauri dev` and `cargo tauri build` using this flake.