### PR TITLE
Add caution message for major change to updater in Tauri 1-2 Migration Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 # dependencies
 node_modules/
 
+# IDE
+.idea/
+
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ dist/
 # dependencies
 node_modules/
 
-# IDE
-.idea/
-
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/src/content/docs/guides/upgrade-migrate/from-tauri-1.mdx
+++ b/src/content/docs/guides/upgrade-migrate/from-tauri-1.mdx
@@ -1004,12 +1004,7 @@ tauri::Builder::default()
 
 ### Migrate to Updater Plugin
 
-:::caution[Major Change]
-The updater in Tauri 1.x, unless otherwise configured, would automatically check endpoint(s) for updates
-and prompt the user for you if any were found. This is not the case with the 2.x updater. If you relied
-on this feature before migrating, please ensure you utilize the necessary Rust and/or JS APIs to check for
-and install updates before distributing your application to users.
-:::
+The built-in dialog with an automatic update check was removed, use the Rust and JS APIs to check for and install updates instead.
 
 The Rust `tauri::updater` and JavaScript `@tauri-apps/api-updater` APIs have been removed. To set a custom updater target with the `@tauri-apps/plugin-updater`:
 

--- a/src/content/docs/guides/upgrade-migrate/from-tauri-1.mdx
+++ b/src/content/docs/guides/upgrade-migrate/from-tauri-1.mdx
@@ -1004,6 +1004,13 @@ tauri::Builder::default()
 
 ### Migrate to Updater Plugin
 
+:::caution[Major Change]
+The updater in Tauri 1.x, unless otherwise configured, would automatically check endpoint(s) for updates
+and prompt the user for you if any were found. This is not the case with the 2.x updater. If you relied
+on this feature before migrating, please ensure you utilize the necessary Rust and/or JS APIs to check for
+and install updates before distributing your application to users.
+:::
+
 The Rust `tauri::updater` and JavaScript `@tauri-apps/api-updater` APIs have been removed. To set a custom updater target with the `@tauri-apps/plugin-updater`:
 
 1. Add to cargo dependencies:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- New or updated content
- Minor content fixes (a singular typo)

#### Description

- Addresses a major change in how the updater functions from 1.x to 2.x in the 1.0 Migration Guide
- More specifically, how in the 2.x updater plugin, there is no system to automatically check and eventually prompt users about updates for the developer in the updater plugin, unlike in 1.x's updater
- This caused me a pretty decent headache when I naively distributed my app to testers and then subsequently realized there was no way to push out updates to them 😅 hopefully this PR can prevent this pain for others, especially with 2.0 Beta coming up