### PR TITLE
Docs: fixed plugin command for mobile plugin development

### DIFF
--- a/src/content/docs/guides/plugins/develop-mobile.mdx
+++ b/src/content/docs/guides/plugins/develop-mobile.mdx
@@ -15,7 +15,7 @@ Plugins can run native mobile code written in Kotlin (or Java) and Swift. The de
 
 Follow the steps in the [Plugin Development guide](/guides/plugins#initialize-plugin-project) to initialize a new plugin project.
 
-If you have an existing plugin and would like to add Android or iOS capabilities to it, you can use `plugin android add` and `plugin ios add` to bootstrap the mobile library projects and guide you through the changes needed.
+If you have an existing plugin and would like to add Android or iOS capabilities to it, you can use `plugin android init` and `plugin ios init` to bootstrap the mobile library projects and guide you through the changes needed.
 
 The default plugin template splits the plugin's implementation into two separate modules: `desktop.rs` and `mobile.rs`.
 


### PR DESCRIPTION
minor bug fix in docs


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->

mobile plugin development command changed from `plugin android/ios add` to `plugin android/ios init`


- Did you change something visual? A before/after screenshot can be helpful.

nothing visual

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->