### PR TITLE
Update sveltekit.mdx

### DIFF
--- a/docs/guides/getting-started/setup/sveltekit.mdx
+++ b/docs/guides/getting-started/setup/sveltekit.mdx
@@ -107,7 +107,7 @@ Then update the `adapter` import in the `svelte.config.js` file:
 ```javascript title=svelte.config.js
 // highlight-next-line
 import adapter from '@sveltejs/adapter-static' // This was changed from adapter-auto
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
SvelteKit no longer re-exports vitePreprocess. You should import it directly from @sveltejs/vite-plugin-svelte.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)


#### Description

- What does this PR change? Give us a brief description.
When copy the whole code block, the project won't build.
vitePreprocess is no longer exported from @sveltejs/kit/vite
That's why @sveltejs/vite-plugin-svelte should be used.

