### PR TITLE
Update automatic plugin setup instructions

### DIFF
--- a/src/content/docs/features/clipboard.mdx
+++ b/src/content/docs/features/clipboard.mdx
@@ -19,29 +19,12 @@ Install the clipboard plugin to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add clipboard-manager"
     yarn="yarn run tauri add clipboard-manager"
     pnpm="pnpm tauri add clipboard-manager"
     cargo="cargo tauri add clipboard-manager" />
-
-    2. Modify `lib.rs` to initialize the plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_clipboard_manager::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
-
-
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/features/dialog.mdx
+++ b/src/content/docs/features/dialog.mdx
@@ -21,25 +21,13 @@ Install the dialog plugin to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add dialog"
     yarn="yarn run tauri add dialog"
     pnpm="pnpm tauri add dialog"
     cargo="cargo tauri add dialog" />
 
-    2. Modify `lib.rs` to initialize the plugin:
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_dialog::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
     </TabItem>
     <TabItem label="Manual">
 

--- a/src/content/docs/features/http-client.mdx
+++ b/src/content/docs/features/http-client.mdx
@@ -18,28 +18,12 @@ Install the http plugin to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add http"
     yarn="yarn run tauri add http"
     pnpm="pnpm tauri add http"
     cargo="cargo tauri add http" />
-
-    2. Modify `lib.rs` to initialize the plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust ins={6}
-    // lib.rs
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_http::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/features/notification.mdx
+++ b/src/content/docs/features/notification.mdx
@@ -20,27 +20,12 @@ Install the notifications plugin to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add notification"
     yarn="yarn run tauri add notification"
     pnpm="pnpm tauri add notification"
     cargo="cargo tauri add notification" />
-
-    2. Modify `lib.rs` to initialize the plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_notification::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/features/os-info.mdx
+++ b/src/content/docs/features/os-info.mdx
@@ -18,27 +18,12 @@ Install the OS Information plugin to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add os"
     yarn="yarn run tauri add os"
     pnpm="pnpm tauri add os"
     cargo="cargo tauri add os" />
-
-    2. Modify `lib.rs` to initialize the plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_os::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/features/process.mdx
+++ b/src/content/docs/features/process.mdx
@@ -18,28 +18,12 @@ Install the plugin-process to get started.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Use your project's package manager to add the dependency:
+    Use your project's package manager to add the dependency:
 
     <CommandTabs npm="npm run tauri add process"
     yarn="yarn run tauri add process"
     pnpm="pnpm tauri add process"
     cargo="cargo tauri add process" />
-
-    2. Modify `lib.rs` to initialize the plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust ins={6}
-    // lib.rs
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialize the plugin
-            .plugin(tauri_plugin_process::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/fr/features/notification.mdx
+++ b/src/content/docs/fr/features/notification.mdx
@@ -20,27 +20,12 @@ Pour commencer, installez le plugin de notifications.
 <Tabs>
     <TabItem label="Automatic">
 
-    1. Utilisez le gestionnaire de package (package manager) de votre projet pour ajouter la dépendance:
+    Utilisez le gestionnaire de package (package manager) de votre projet pour ajouter la dépendance:
 
     <CommandTabs npm="npm run tauri add notification"
     yarn="yarn run tauri add notification"
     pnpm="pnpm tauri add notification"
     cargo="cargo tauri add notification" />
-
-    2. Modifiez `lib.rs` pour initialiser le plugin:
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // Initialisation du plugin
-            .plugin(tauri_plugin_notification::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="Manual">

--- a/src/content/docs/zh-cn/features/notification.mdx
+++ b/src/content/docs/zh-cn/features/notification.mdx
@@ -20,27 +20,12 @@ import Stub from '@components/Stub.astro';
 <Tabs>
     <TabItem label="自动">
 
-    1. 使用你的项目的包管理器以添加依赖：
+    使用你的项目的包管理器以添加依赖：
 
     <CommandTabs npm="npm run tauri plugin add notification"
     yarn="yarn run tauri plugin add notification"
     pnpm="pnpm tauri plugin add notification"
     cargo="cargo tauri plugin add notification" />
-
-    2. 修改 `lib.rs` 以初始化插件：
-
-    {/* TODO: Revise once https://github.com/tauri-apps/tauri/issues/7696 is in */}
-
-    ```rust
-    #[cfg_attr(mobile, tauri::mobile_entry_point)]
-    pub fn run() {
-        tauri::Builder::default()
-            // 初始化插件
-            .plugin(tauri_plugin_notification::init())
-            .run(tauri::generate_context!())
-            .expect("error while running tauri application");
-    }
-    ```
 
     </TabItem>
     <TabItem label="手动">


### PR DESCRIPTION
- Updated content: Removed step to initialize the plugin in `lib.rs` in the automatic setup instructions

Considering that [#7696 ](https://github.com/tauri-apps/tauri/issues/7696) is in and the add command automagically configures the plugin, there's no need for step 2

Current:
<img src="https://github.com/tauri-apps/tauri-docs/assets/61759797/7f7d1067-f467-4505-8b77-00181140bca9" width="60%"/>


PR:
<img src="https://github.com/tauri-apps/tauri-docs/assets/61759797/db76f251-216d-486c-b948-2f712cbdd6f6" width="60%"/>



I didn't modified the wording "Use your project's package manager to add the dependency:" because it would be needed to update the translations accordingly. Ideally, if this is to be changed, then it's better to make another PR so that the translation tracker shows up correctly.

