### PR TITLE
fix: workaround for getting rid of double blog entry

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
 			components: {
 				SiteTitle: 'src/components/overrides/SiteTitle.astro',
 				Footer: 'src/components/overrides/Footer.astro',
+				ThemeSelect: 'src/components/overrides/ThemeSelect.astro',
 			},
 			head: [
 				{
@@ -298,9 +299,9 @@ function i18nRedirect(from, to) {
 		locale === 'root'
 			? (routes[from] = to)
 			: (routes[`/${locale}/${from.replaceAll(/^\/*/g, '')}`] = `/${locale}/${to.replaceAll(
-					/^\/*/g,
-					''
-				)}`)
+				/^\/*/g,
+				''
+			)}`)
 	);
 	return routes;
 }

--- a/src/components/overrides/ThemeSelect.astro
+++ b/src/components/overrides/ThemeSelect.astro
@@ -1,0 +1,6 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/ThemeSelect.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description
<!-- Delete any that don’t apply -->
- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:
1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!
2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->