### PR TITLE
chore(docs): update CTA --beta flag

### DIFF
--- a/src/content/docs/_fragments/cta.mdx
+++ b/src/content/docs/_fragments/cta.mdx
@@ -3,33 +3,33 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
 <TabItem label="Bash">
 ```sh
-sh <(curl https://create.tauri.app/sh) --alpha
+sh <(curl https://create.tauri.app/sh) --beta
 ```
 </TabItem>
 <TabItem label="PowerShell">
 ```ps
-$env:CTA_ARGS="--alpha"; irm https://create.tauri.app/ps | iex
+$env:CTA_ARGS="--beta"; irm https://create.tauri.app/ps | iex
 ```
 </TabItem>
 <TabItem label="npm">
 ```sh
-npm create tauri-app@latest -- --alpha
+npm create tauri-app@latest -- --beta
 ```
 </TabItem>
 <TabItem label="Yarn">
 ```sh
-yarn create tauri-app --alpha
+yarn create tauri-app --beta
 ```
 </TabItem>
 <TabItem label="pnpm">
 ```sh
-pnpm create tauri-app --alpha
+pnpm create tauri-app --beta
 ```
 </TabItem>
 <TabItem label="Cargo">
 ```sh
 cargo install create-tauri-app
-cargo create-tauri-app --alpha
+cargo create-tauri-app --beta
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION

#### Description

Now that tauri v2 is in beta, invoking CTA with `--alpha` flag yields the following warning:

```
warning: The `--alpha` option is now an alias for `--beta` and may be removed in the future.
```