### PR TITLE
fix: added `run` to npm scripts

### DIFF
--- a/src/content/docs/references/v1/cli.mdx
+++ b/src/content/docs/references/v1/cli.mdx
@@ -8,7 +8,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 ## `info`
 
 <CommandTabs
-	npm="npm tauri info"
+	npm="npm run tauri info"
 	yarn="yarn tauri info"
 	pnpm="pnpm tauri info"
 	cargo="cargo tauri info"
@@ -35,7 +35,7 @@ This command is pretty helpful when you need to have a quick overview of your ap
 ## `init`
 
 <CommandTabs
-	npm="npm tauri init"
+	npm="npm run tauri init"
 	yarn="yarn tauri init"
 	pnpm="pnpm tauri init"
 	cargo="cargo tauri init"
@@ -78,7 +78,7 @@ Options:
 ## `plugin init`
 
 <CommandTabs
-	npm="npm tauri plugin init"
+	npm="npm run tauri plugin init"
 	yarn="yarn tauri plugin init"
 	pnpm="pnpm tauri plugin init"
 	cargo="cargo tauri plugin init"
@@ -101,7 +101,7 @@ Options:
 ## `dev`
 
 <CommandTabs
-	npm="npm tauri dev"
+	npm="npm run tauri dev"
 	yarn="yarn tauri dev"
 	pnpm="pnpm tauri dev"
 	cargo="cargo tauri dev"
@@ -143,7 +143,7 @@ If you're not using `build.beforeDevCommand`, make sure your `build.devPath` is 
 ## `build`
 
 <CommandTabs
-	npm="npm tauri build"
+	npm="npm run tauri build"
 	yarn="yarn tauri build"
 	pnpm="pnpm tauri build"
 	cargo="cargo tauri build"
@@ -205,7 +205,7 @@ If you have entered a command to the `build.beforeBuildCommand` property, this o
 ## `icon`
 
 <CommandTabs
-	npm="npm tauri icon"
+	npm="npm run tauri icon"
 	yarn="yarn tauri icon"
 	pnpm="pnpm tauri icon"
 	cargo="cargo tauri icon"
@@ -230,7 +230,7 @@ For more information, check out the complete [Tauri Icon Guide](../guides/featur
 ## `completions`
 
 <CommandTabs
-	npm="npm tauri completions"
+	npm="npm run tauri completions"
 	yarn="yarn tauri completions"
 	pnpm="pnpm tauri completions"
 	cargo="cargo tauri completions"
@@ -384,7 +384,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ## `version`
 
 <CommandTabs
-	npm="npm tauri --version"
+	npm="npm run tauri --version"
 	yarn="yarn tauri --version"
 	pnpm="pnpm tauri --version"
 	cargo="cargo tauri --version"

--- a/src/content/docs/references/v2/cli.mdx
+++ b/src/content/docs/references/v2/cli.mdx
@@ -43,7 +43,7 @@ For CLI commands related to developing plugins visit the [Develop a Tauri Plugin
 ## `build`
 
 <CommandTabs
-	npm="npm tauri build"
+	npm="npm run tauri build"
 	yarn="yarn tauri build"
 	pnpm="pnpm tauri build"
 	cargo="cargo tauri build"
@@ -88,7 +88,7 @@ Options:
 ## `dev`
 
 <CommandTabs
-	npm="npm tauri dev"
+	npm="npm run tauri dev"
 	yarn="yarn tauri dev"
 	pnpm="pnpm tauri dev"
 	cargo="cargo tauri dev"
@@ -125,7 +125,7 @@ If you have entered a command to the `build.beforeDevCommand` property, this one
 ## `icon`
 
 <CommandTabs
-	npm="npm tauri icon"
+	npm="npm run tauri icon"
 	yarn="yarn tauri icon"
 	pnpm="pnpm tauri icon"
 	cargo="cargo tauri icon"
@@ -151,7 +151,7 @@ Options:
 ## `info`
 
 <CommandTabs
-	npm="npm tauri info"
+	npm="npm run tauri info"
 	yarn="yarn tauri info"
 	pnpm="pnpm tauri info"
 	cargo="cargo tauri info"
@@ -174,7 +174,7 @@ Options:
 ## `init`
 
 <CommandTabs
-	npm="npm tauri init"
+	npm="npm run tauri init"
 	yarn="yarn tauri init"
 	pnpm="pnpm tauri init"
 	cargo="cargo tauri init"
@@ -219,7 +219,7 @@ Options:
 ## `add`
 
 <CommandTabs
-	npm="npm tauri add"
+	npm="npm run tauri add"
 	yarn="yarn tauri add"
 	pnpm="pnpm tauri add"
 	cargo="cargo tauri add"
@@ -245,7 +245,7 @@ Options:
 ## `signer`
 
 <CommandTabs
-	npm="npm tauri signer"
+	npm="npm run tauri signer"
 	yarn="yarn tauri signer"
 	pnpm="pnpm tauri signer"
 	cargo="cargo tauri signer"
@@ -270,7 +270,7 @@ Options:
 ## `completions`
 
 <CommandTabs
-	npm="npm tauri completions"
+	npm="npm run tauri completions"
 	yarn="yarn tauri completions"
 	pnpm="pnpm tauri completions"
 	cargo="cargo tauri completions"
@@ -426,7 +426,7 @@ Add-Content -Path $profile -Value '& "$PSScriptRoot\_tauri.ps1"'
 ## `android`
 
 <CommandTabs
-	npm="npm tauri android"
+	npm="npm run tauri android"
 	yarn="yarn tauri android"
 	pnpm="pnpm tauri android"
 	cargo="cargo tauri android"
@@ -453,7 +453,7 @@ Options:
 ## `ios`
 
 <CommandTabs
-	npm="npm tauri ios"
+	npm="npm run tauri ios"
 	yarn="yarn tauri ios"
 	pnpm="pnpm tauri ios"
 	cargo="cargo tauri ios"
@@ -480,7 +480,7 @@ Options:
 ## `migrate`
 
 <CommandTabs
-	npm="npm tauri migrate"
+	npm="npm run tauri migrate"
 	yarn="yarn tauri migrate"
 	pnpm="pnpm tauri migrate"
 	cargo="cargo tauri migrate"
@@ -500,7 +500,7 @@ Options:
 ## `help`
 
 <CommandTabs
-	npm="npm tauri help"
+	npm="npm run tauri help"
 	yarn="yarn tauri help"
 	pnpm="pnpm tauri help"
 	cargo="cargo tauri help"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
The command snippets were missing the mandatory `run` command for `npm` to run `tauri` as a script.

before:
```sh
npm tauri [tauri-command]
```
after:
```sh
npm run tauri [tauri-command]
```

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->