### PR TITLE
Fix: Remove `libvips` from dependency #1663

### DIFF
--- a/src/content/docs/es/guides/prerequisites/index.mdx
+++ b/src/content/docs/es/guides/prerequisites/index.mdx
@@ -55,8 +55,7 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg \
-  libvips
+  librsvg
 ```
 
   </TabItem>

--- a/src/content/docs/fr/guides/prerequisites/index.mdx
+++ b/src/content/docs/fr/guides/prerequisites/index.mdx
@@ -57,8 +57,7 @@ sudo pacman -S --needed \
   appmenu-gtk-module \
   gtk3 \
   libappindicator-gtk3 \
-  librsvg \
-  libvips
+  librsvg
 ```
 
   </TabItem>

--- a/src/content/docs/guides/prerequisites/index.mdx
+++ b/src/content/docs/guides/prerequisites/index.mdx
@@ -55,8 +55,7 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg \
-  libvips
+  librsvg
 ```
 
   </TabItem>

--- a/src/content/docs/zh-cn/guides/prerequisites/index.mdx
+++ b/src/content/docs/zh-cn/guides/prerequisites/index.mdx
@@ -57,8 +57,7 @@ sudo pacman -S --needed \
   appmenu-gtk-module \
   gtk3 \
   libappindicator-gtk3 \
-  librsvg \
-  libvips
+  librsvg
 ```
 
   </TabItem>


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
- Closes https://github.com/tauri-apps/tauri-docs/issues/1663
- Remove `libvips` as prerequisite of Arch Linux