### PR TITLE
Fix application.mdx

### DIFF
--- a/src/content/docs/guides/debug/application.mdx
+++ b/src/content/docs/guides/debug/application.mdx
@@ -63,7 +63,7 @@ tauri::Builder::default()
   .setup(|app| {
     #[cfg(debug_assertions)] // only include this code on debug builds
     {
-      let window = app.get_window("main").unwrap();
+      let window = app.get_webview_window("main").unwrap();
       window.open_devtools();
       window.close_devtools();
     }


### PR DESCRIPTION
fix a bug in this article:
the `get_window` now is 
`get_webview_window`

