### PR TITLE
fix: hide releases from search

### DIFF
--- a/packages/releases-generator/build.ts
+++ b/packages/releases-generator/build.ts
@@ -119,6 +119,7 @@ async function generator() {
 				`slug: 'releases/${pkg.name}/v${thisVersion}'`,
 				`tableOfContents: false`,
 				`editUrl: 'https://github.com/tauri-apps/tauri-docs/packages/releases-generator/build.ts'`,
+				'pagefind: false',
 			];
 
 			const frontmatter = ['---', ...pageFrontmatter, ...navFrontmatter, '---'].join('\n');


### PR DESCRIPTION
i kept it enabled for the topmost index file so that you can still search for the releases overview page at least 🤷 

fixes #2028