### PR TITLE
fix: blog override warning

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -76,8 +76,6 @@ export default defineConfig({
 			components: {
 				SiteTitle: 'src/components/overrides/SiteTitle.astro',
 				Footer: 'src/components/overrides/Footer.astro',
-				MarkdownContent: 'starlight-blog/overrides/MarkdownContent.astro',
-				Sidebar: 'starlight-blog/overrides/Sidebar.astro',
 				Header: 'src/components/overrides/Header.astro',
 				ThemeSelect: 'src/components/overrides/ThemeSelect.astro',
 			},


### PR DESCRIPTION
There still will be one warning about the Theme Select, but this is because we need it overridden.
![image](https://github.com/tauri-apps/tauri-docs/assets/61759797/d50ba9a5-1ef3-47d5-bf98-e3a5ae7d4f5c)
