### PR TITLE
Add set RUST_BACKTRACE=1 when using powershell on windows

### DIFF
--- a/docs/guides/debugging/application.md
+++ b/docs/guides/debugging/application.md
@@ -18,12 +18,20 @@ Sometimes you may have an error in your Rust code, and the Rust compiler can giv
 RUST_BACKTRACE=1 tauri dev
 ```
 
-or like this on Windows:
+or like this on Windows if you're on cmd:
 
 ```shell
 set RUST_BACKTRACE=1
 tauri dev
 ```
+
+or like this on Windows if you're using PowerShell:
+
+```shell
+$env:RUST_BACKTRACE=1
+tauri dev
+```
+
 
 This command gives you a granular stack trace. Generally speaking, the Rust compiler helps you by
 giving you detailed information about the issue, such as:

--- a/docs/guides/debugging/application.md
+++ b/docs/guides/debugging/application.md
@@ -19,7 +19,6 @@ RUST_BACKTRACE=1 tauri dev
 ```
 
 or like this on Windows if you're using cmd.exe:
-``` adding the .exe makes it a bit clearer. 
 
 ```shell
 set RUST_BACKTRACE=1
@@ -28,7 +27,7 @@ tauri dev
 
 or like this on Windows if you're using PowerShell:
 
-```shell
+```powershell
 $env:RUST_BACKTRACE=1
 tauri dev
 ```

--- a/docs/guides/debugging/application.md
+++ b/docs/guides/debugging/application.md
@@ -18,7 +18,8 @@ Sometimes you may have an error in your Rust code, and the Rust compiler can giv
 RUST_BACKTRACE=1 tauri dev
 ```
 
-or like this on Windows if you're on cmd:
+or like this on Windows if you're using cmd.exe:
+``` adding the .exe makes it a bit clearer. 
 
 ```shell
 set RUST_BACKTRACE=1


### PR DESCRIPTION
#### What kind of changes does this PR include?
- New or updated content

#### Description
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
The provided command for setting RUST_BACKTRACE=1 on Windows was valid only if using cmd; while, if using PowerShell, that  command wouldn't work.

Added the powershell version too