### PR TITLE
Corrected dietpi image link

### DIFF
--- a/docs/guides/building/linux.md
+++ b/docs/guides/building/linux.md
@@ -260,7 +260,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pguyot/arm-runner-action@v2.5.2
         with:
-          base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
+          base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.img.xz
           cpu: cortex-a53
           bind_mount_repository: true
           image_additional_mb: 10240


### PR DESCRIPTION
The current version points to an outdated link of the dietpi base image. This commit changes that to the currently working link.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
The docs point to an older broken link of the dietpi base image in the GitHub Actions workflow which throws the following error when run:

```
Run bash /home/runner/work/_actions/pguyot/arm-runner-action/v2.5.2/download_image.sh https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
Don't know how to uncompress image  *
Error: Process completed with exit code 1.
```

This PR changes it to a new link as per [#93](https://github.com/pguyot/arm-runner-action/issues/93) in [pguyot/arm-runner-action](https://github.com/pguyot/arm-runner-action). I hope this change will make it easier for anyone copying the workflow from the docs directly. 

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->