### PR TITLE
fix: NixOS setup -- shell.nix must also depend on librsvg

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -263,6 +263,7 @@ let
     glib
     dbus
     openssl_3
+    librsvg
   ];
 
   packages = with pkgs; [
@@ -274,6 +275,7 @@ let
     libsoup
     webkitgtk
     appimagekit
+    librsvg
   ];
 in
 pkgs.mkShell {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
The flakes.nix variant includes the dependency of librsvg, but the shell.nix variant does not. Following the shell.nix approach leads to 
```
Your system is missing dependencies (or they do not exist in $PATH):
│ rsvg2 │ Visit https://tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux │
```
Thus, we have to add librsvg as dependency for shell.nix as well, which fixes the issue above.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->