### PR TITLE
fix: hide toc on main releases page as it serves no purpose

### DIFF
--- a/packages/releases-generator/build.ts
+++ b/packages/releases-generator/build.ts
@@ -151,6 +151,7 @@ async function generator() {
 		extraNote,
 		`title: 'Tauri Core Ecosystem Releases'`,
 		`editUrl: 'https://github.com/tauri-apps/tauri-docs/packages/releases-generator/build.ts'`,
+		'tableOfContents: false',
 		'---',
 	].join('\n');
 


### PR DESCRIPTION
Does what it says, no more no less. The TOC on the right side serves no purpose on the releases page and is distruptive to the layout when navigating.

![image](https://github.com/tauri-apps/tauri-docs/assets/79983560/5cad42bc-9303-49af-b352-d28ff73fdfb6)
