### PR TITLE
fix: sorting of release versions

### DIFF
--- a/src/components/list/ReleaseSidebar.astro
+++ b/src/components/list/ReleaseSidebar.astro
@@ -62,7 +62,7 @@ function sortVersions(a: Route, b: Route): number {
 	const [package1, version1] = t1.split('@').filter((w) => w.length > 0);
 	const [package2, version2] = t2.split('@').filter((w) => w.length > 0);
 	if (package1 === package2) {
-		return semver.lt(version1, version2);
+		return semver.lt(version1, version2) ? -1 : semver.gt(version1, version2) ? 1 : 0;
 	} else {
 		return package1.localeCompare(package2);
 	}


### PR DESCRIPTION
Fixes the broken sorting of versions, it was returning a boolean instead of -1, 0 or 1.

![image](https://github.com/tauri-apps/tauri-docs/assets/79983560/b209f1d3-7873-4958-9ab5-00d57ec39622)
