### PR TITLE
Update HTTP Client Recipe for 2.0

### DIFF
--- a/src/content/docs/features/http-client.mdx
+++ b/src/content/docs/features/http-client.mdx
@@ -80,6 +80,7 @@ The http plugin is available in both as an JavaScript API and in Rust as a [reqw
       ]
     }
     ```
+For more information, please see the documentation for [Access Control Lists](/references/v2/acl/)
 
 2.  Send a request
 

--- a/src/content/docs/features/http-client.mdx
+++ b/src/content/docs/features/http-client.mdx
@@ -80,7 +80,7 @@ The http plugin is available in both as an JavaScript API and in Rust as a [reqw
       ]
     }
     ```
-For more information, please see the documentation for [Access Control Lists](/references/v2/acl/)
+    For more information, please see the documentation for [Access Control Lists](/references/v2/acl/)
 
 2.  Send a request
 

--- a/src/content/docs/features/http-client.mdx
+++ b/src/content/docs/features/http-client.mdx
@@ -66,16 +66,18 @@ The http plugin is available in both as an JavaScript API and in Rust as a [reqw
 
 <Steps>
 
-1.  To keep your app safe, configure allowed scope. Read more on [JavaScript API reference](/references/v2/js/http/#security).
+1.  Configure the allowed URLs
 
     ```json
-    //tauri.conf.json
+    //src-tauri/capabilities/base.json
     {
-    	"plugins": {
-    		"http": {
-    			"scope": ["http://my.api.host/*"]
-    		}
-    	}
+      "permissions": [
+        {
+          "identifier": "http:default",
+          "allow": [{ "url": "https://*.tauri.app" }],
+          "deny": [{ "url": "https://private.tauri.app" }]
+        }
+      ]
     }
     ```
 
@@ -85,7 +87,7 @@ The http plugin is available in both as an JavaScript API and in Rust as a [reqw
     import { fetch } from '@tauri-apps/plugin-http';
 
     // Send a GET request
-    const response = await fetch('http://my.api.host/data.json', {
+    const response = await fetch('http://test.tauri.app/data.json', {
     	method: 'GET',
     });
     console.log(response.status); // e.g. 200


### PR DESCRIPTION
Updates docs for http client recipe to show the 2.0 configuration (scopes are part of permissions)

- Minor content fixes (broken links, typos, etc.)

#### Description
Updates docs for http client recipe to show the 2.0 configuration (scopes are part of permissions), adds link to ACL page.