### PR TITLE
Use correct method in file selector dialog example

### DIFF
--- a/src/content/docs/features/dialog.mdx
+++ b/src/content/docs/features/dialog.mdx
@@ -255,7 +255,7 @@ let file_path = app.dialog().file().blocking_pick_file();
 // return a file_path `Option`, or `None` if the user closes the dialog
 ```
 
-If you need a non blocking operation you can use `show()` instead:
+If you need a non blocking operation you can use `pick_file()` instead:
 
 ```rust
 use tauri_plugin_dialog::DialogExt;


### PR DESCRIPTION
Corrects inconsistency in docs: Instead of suggesting to use `show()`, it should suggest `pick_file()`, which is actually used in the Rust example.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
Change `show()` to `pick_file()` when recommending the user which method to use.
The example actually uses `pick_file()`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->