### PR TITLE
Flatten nested JS plugin reference pages

### DIFF
--- a/packages/js-api-generator/build.ts
+++ b/packages/js-api-generator/build.ts
@@ -95,8 +95,10 @@ async function generator() {
 				entryPoints: [`../plugins-workspace/plugins/${plugin}/guest-js/index.ts`],
 				tsconfig: `../plugins-workspace/plugins/${plugin}/tsconfig.json`,
 				gitRevision: 'v2',
-				baseUrl: `/references/javascript/${plugin}`,
+				baseUrl: `/references/javascript/`,
 				...typeDocConfigBaseOptions,
+				// Must go after to override base
+				entryFileName: `${plugin}.md`,
 			};
 
 			await generateDocs(pluginJsOptions);
@@ -135,10 +137,8 @@ function pageEventEnd(event: PageEvent<DeclarationReflection>) {
 	}
 	const frontmatter = [
 		'---',
-		`title: "${event.model.name}"`,
+		`title: "${event.model.name.replace("@tauri-apps/plugin-", "")}"`,
 		'editUrl: false',
-		'prev: false',
-		'next: false',
 		'---',
 		'',
 		event.contents,


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description
- What does this PR change? Give us a brief description.
Remove sub-categories for JS plugin reference pages, remove `@tauri-apps/plugin-` prefix from JS plugin page titles, restore pagination navigation for JS API pages.

#### Additional context:
Tried making the names "Title Case" but it didn't look right for short names like `Fs` and `Os` nor for hyphenated names like `Window-State` without replacing the hyphen with a space: `Window State`. The process itself is fairly simple: `.toLowerCase().replace(/\b\S/g, (char) => char.toUpperCase())`