### PR TITLE
[i18nIgnore]docs: redirects broken links

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -3,3 +3,13 @@
 # Decommissioned locales
 /ko/*  /:splat  302
 /it/*  /:splat  302
+
+# Migrated pages
+/build/* /start/:splat 301
+
+/guides                     /start                               301
+/guides/prerequisites       /start/prerequisites                 301
+/guides/create              /start/create-project                301
+/guides/frontend            /start/frontend-configuration        301
+/guides/frontend/*          /start/frontend-configuration/:splat 301
+/guides/upgrade-migrate     /start/upgrade--migrate              301

--- a/public/_redirects
+++ b/public/_redirects
@@ -4,13 +4,27 @@
 /ko/*  /:splat  302
 /it/*  /:splat  302
 
-# Migrated pages
-/build/* /start/:splat 301
+# Docs rework
 
 /guides                     /start                               301
 /guides/prerequisites       /start/prerequisites                 301
 /guides/create              /start/create-project                301
+/guides/plugins             /develop/plugins/                    301
+
 /guides/frontend            /start/frontend-configuration        301
 /guides/frontend/*          /start/frontend-configuration/:splat 301
+
 /guides/upgrade-migrate     /start/upgrade--migrate              301
 /guides/upgrade-migrate/*   /start/upgrade--migrate/:splat       301
+
+/references/v2/cli          /references/cli                      301      
+/references/v2/acl          /references/acl                      301     
+/references/v2/config       /references/config                   301
+/references/v2/js           /references/javascript/api           301
+/references/v2/js/*         /references/javascript/api/:splat    301
+/references/v2/*            /references/:splat                   301
+
+
+/references/configuration-files /develop/configuration-files     301
+
+/features/commands           /develop/calling-rust               301

--- a/public/_redirects
+++ b/public/_redirects
@@ -24,6 +24,9 @@
 /references/v2/js/*         /references/javascript/api/:splat    301
 /references/v2/*            /references/:splat                   301
 
+/2/reference/js/core/namespacepath /references/javascript/api/namespacepath 301
+/2/reference/                /references/                  301
+
 
 /references/configuration-files /develop/configuration-files     301
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -24,7 +24,7 @@
 /references/v2/js/*         /references/javascript/api/:splat    301
 /references/v2/*            /references/:splat                   301
 
-/2/reference/js/core/namespacepath /references/javascript/api/namespacepath 301
+/2/reference/js/core/namespacepath          /references/javascript/api/namespacepath 301
 /2/reference/                /references/                  301
 
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -13,3 +13,4 @@
 /guides/frontend            /start/frontend-configuration        301
 /guides/frontend/*          /start/frontend-configuration/:splat 301
 /guides/upgrade-migrate     /start/upgrade--migrate              301
+/guides/upgrade-migrate/*   /start/upgrade--migrate/:splat       301

--- a/src/content/docs/_zh-cn/guides/upgrade-migrate/index.mdx
+++ b/src/content/docs/_zh-cn/guides/upgrade-migrate/index.mdx
@@ -9,14 +9,14 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
 	<LinkCard
 		title="从 Tauri 1.0 升级"
-		href="/zh-cn/guides/upgrade-migrate/from-tauri-1"
+		href="/zh-cn/guides/upgrade--migrate/from-tauri-1"
 	/>
 	<LinkCard
 		title="从 Electron 迁移"
-		href="/zh-cn/guides/upgrade-migrate/from-electron"
+		href="/zh-cn/guides/upgrade--migrate/from-electron"
 	/>
 	<LinkCard
 		title="从 Flutter 迁移"
-		href="/zh-cn/guides/upgrade-migrate/from-flutter"
+		href="/zh-cn/guides/upgrade--migrate/from-flutter"
 	/>
 </CardGrid>

--- a/src/content/docs/start/Upgrade & Migrate/index.mdx
+++ b/src/content/docs/start/Upgrade & Migrate/index.mdx
@@ -15,14 +15,14 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
 	<LinkCard
 		title="Upgrade from Tauri 1.0"
-		href="/start/upgrade-migrate/from-tauri-1"
+		href="/start/upgrade--migrate/from-tauri-1"
 	/>
 	<LinkCard
 		title="Migrate from Electron"
-		href="/start/upgrade-migrate/from-electron"
+		href="/start/upgrade--migrate/from-electron"
 	/>
 	<LinkCard
 		title="Migrate from Flutter"
-		href="/start/upgrade-migrate/from-flutter"
+		href="/start/upgrade--migrate/from-flutter"
 	/>
 </CardGrid>


### PR DESCRIPTION
There are probably more, I did a few that was easy to notice

`upgrade--migrate` because the directory is now named "Upgrade & Migrate", the & becomes a dash