### PR TITLE
Add redirect for Tauri v2 upgrade guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -238,6 +238,9 @@ export default defineConfig({
 		...i18nRedirect('/v1/references/configuration-files', '/references/configuration-files'),
 		...i18nRedirect('/v1/references/webview-versions', '/references/webview-versions'),
 
+		// Indexed by google as top entry when searching "tauri v1 to v2"
+		'/guides/upgrade-migrate/from-tauri-1': "/start/upgrade--migrate/from-tauri-1/",
+
 		// Decommissioned locales -> refer to /public/_redirects file
 		// '/ko/[...slug]': '/[...slug]',
 		// '/it/[...slug]': '/[...slug]',


### PR DESCRIPTION
Add a redirect from `/guides/upgrade-migrate/from-tauri-1` to `/start/upgrade--migrate/from-tauri-1/`.

If you google "tauri v1 to v2" or similar you'll end up with this as the top entry but it points to a 404 page.

![Screenshot 2024-04-30 at 1 03 35 PM](https://github.com/tauri-apps/tauri-docs/assets/21004798/c7eebd19-6a3b-46b3-99b3-bf5c669d1bf7)
