### PR TITLE
feat: stubs for learn category

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -138,6 +138,11 @@ export default defineConfig({
 					autogenerate: { directory: 'distribute' },
 				},
 				{
+					label: 'Learn',
+					collapsed: true,
+					autogenerate: { directory: 'learn' },
+				},
+				{
 					label: 'Features & Recipes',
 					collapsed: true,
 					autogenerate: { directory: 'features' },
@@ -253,9 +258,9 @@ function i18nRedirect(from, to) {
 		locale === 'root'
 			? (routes[from] = to)
 			: (routes[`/${locale}/${from.replaceAll(/^\/*/g, '')}`] = `/${locale}/${to.replaceAll(
-					/^\/*/g,
-					''
-				)}`)
+				/^\/*/g,
+				''
+			)}`)
 	);
 	return routes;
 }

--- a/src/content/docs/learn/index.mdx
+++ b/src/content/docs/learn/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Learn
+sidebar:
+  order: 0
+  label: Overview
+  badge:
+    text: WIP
+    variant: caution
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/learn/sidecar-nodejs.mdx
+++ b/src/content/docs/learn/sidecar-nodejs.mdx
@@ -1,0 +1,11 @@
+---
+title: Node.js as a sidecar
+sidebar:
+  badge:
+    text: WIP
+    variant: caution
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/learn/sidecar-python.mdx
+++ b/src/content/docs/learn/sidecar-python.mdx
@@ -1,0 +1,11 @@
+---
+title: Python as a sidecar
+sidebar:
+  badge:
+    text: WIP
+    variant: caution
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/learn/splashscreen.mdx
+++ b/src/content/docs/learn/splashscreen.mdx
@@ -1,0 +1,11 @@
+---
+title: Splashscreen
+sidebar:
+  badge:
+    text: WIP
+    variant: caution
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />

--- a/src/content/docs/learn/tokio-runtime.mdx
+++ b/src/content/docs/learn/tokio-runtime.mdx
@@ -1,0 +1,11 @@
+---
+title: Custom Tokio runtime
+sidebar:
+  badge:
+    text: WIP
+    variant: caution
+---
+
+import Stub from '@components/Stub.astro';
+
+<Stub />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- New or updated content

#### Description
Adds a new "Learn" category with stubs for some intial labs we can create. The idea is for them to be inspired in structure with what I have on my site: <https://tauri.by.simon.hyll.nu/labs/chatgpt/1_application/>

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->