### PR TITLE
feat: add docs for partnership with CrabNebula

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -23,8 +23,6 @@ To setup code signing for both Windows and macOS on your workflow, follow the sp
 - [Windows Code Signing with GitHub Actions]
 - [macOS Code Signing with GitHub Actions]
 
-:::
-
 ### Getting Started
 
 To set up Tauri Action you must first set up a GitHub repository. You can use this action on a repo that doesn't have Tauri configured since it automatically initializes Tauri before building and configuring it to use your artifacts.

--- a/docs/guides/debugging/application.md
+++ b/docs/guides/debugging/application.md
@@ -32,7 +32,6 @@ $env:RUST_BACKTRACE=1
 tauri dev
 ```
 
-
 This command gives you a granular stack trace. Generally speaking, the Rust compiler helps you by
 giving you detailed information about the issue, such as:
 
@@ -47,6 +46,8 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 ```
+
+Additionally, you can instrument and view your app logs with the [CrabNebula DevTools].
 
 ## WebView Console
 
@@ -108,5 +109,6 @@ tauri = { version = "...", features = ["...", "devtools"] }
 The Core process is powered by Rust so you can use GDB or LLDB to debug it. You can follow the [Debugging in VS Code] guide to learn how to use the LLDB VS Code Extension to debug the Core Process of Tauri applications.
 
 [debugging in vs code]: ./vs-code.md
+[crabnebula devtools]: ./crabnebula-devtools
 [`window::open_devtools`]: https://docs.rs/tauri/1/tauri/window/struct.Window.html#method.open_devtools
 [`window::close_devtools`]: https://docs.rs/tauri/1/tauri/window/struct.Window.html#method.close_devtools

--- a/docs/guides/debugging/crabnebula-devtools.md
+++ b/docs/guides/debugging/crabnebula-devtools.md
@@ -34,4 +34,4 @@ In this case we only initialize the devtools plugin for debug applications, whic
 
 For more information, see the [CrabNebula DevTools] documentation.
 
-[crabnebula devtools]: https://docs.crabnebula.dev/devtools/get-started/
+[CrabNebula DevTools]: https://docs.crabnebula.dev/devtools/get-started/

--- a/docs/guides/debugging/crabnebula-devtools.md
+++ b/docs/guides/debugging/crabnebula-devtools.md
@@ -1,9 +1,9 @@
 # Debugging in CrabNebula DevTools
 
-CrabNebula provides a free DevTools application for Tauri as part of its partnership with the Tauri project.
+[CrabNebula](https://crabnebula.dev) provides a free [DevTools](https://crabnebula.dev/devtools/) application for Tauri as part of its partnership with the Tauri project.
 This application allows you to instrument your Tauri app by capturing its embedded assets, Tauri configuration file, logs and spans and providing a web frontend to seamlessly visualize data in real time.
 
-With the CrabNebula DevTools you can inspect your app's log events (including logs from dependencies), track down the performance of your command calls and overall Tauri API usage, with special interface for Tauri events and commands, including payload, responses and inner logs and execution spans.
+With the CrabNebula DevTools you can inspect your app's log events (including logs from dependencies), track down the performance of your command calls and overall Tauri API usage, with a special interface for Tauri events and commands, including payload, responses and inner logs and execution spans.
 
 To enable the CrabNebula DevTools, install the `devtools` crate:
 

--- a/docs/guides/debugging/crabnebula-devtools.md
+++ b/docs/guides/debugging/crabnebula-devtools.md
@@ -1,4 +1,3 @@
-@ -0,0 +1,37 @@
 # Debugging in CrabNebula DevTools
 
 CrabNebula provides a free DevTools application for Tauri as part of its partnership with the Tauri project.

--- a/docs/guides/debugging/crabnebula-devtools.md
+++ b/docs/guides/debugging/crabnebula-devtools.md
@@ -1,0 +1,38 @@
+@ -0,0 +1,37 @@
+# Debugging in CrabNebula DevTools
+
+CrabNebula provides a free DevTools application for Tauri as part of its partnership with the Tauri project.
+This application allows you to instrument your Tauri app by capturing its embedded assets, Tauri configuration file, logs and spans and providing a web frontend to seamlessly visualize data in real time.
+
+With the CrabNebula DevTools you can inspect your app's log events (including logs from dependencies), track down the performance of your command calls and overall Tauri API usage, with special interface for Tauri events and commands, including payload, responses and inner logs and execution spans.
+
+To enable the CrabNebula DevTools, install the `devtools` crate:
+
+```shell
+cargo add devtools
+```
+
+And initialize the plugin as soon as possible in your main function:
+
+```rust
+fn main() {
+    #[cfg(debug_assertions)]
+    let devtools = devtools::init(); // initialize the plugin as early as possible
+
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(debug_assertions)]
+    builder = builder.plugin(devtools); // then register it with Tauri
+
+    builder.run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+:::note
+In this case we only initialize the devtools plugin for debug applications, which is recommended.
+:::
+
+For more information, see the [CrabNebula DevTools] documentation.
+
+[crabnebula devtools]: https://docs.crabnebula.dev/devtools/get-started/

--- a/docs/guides/distribution/distributing-with-crabnebula-cloud.md
+++ b/docs/guides/distribution/distributing-with-crabnebula-cloud.md
@@ -1,7 +1,7 @@
 # Distributing with CrabNebula Cloud
 
-CrabNebula is an official Tauri partner providing services and tooling for Tauri applications.
-The CrabNebula Cloud is a platform for application distribution that seamlessly integrates with the Tauri updater.
+[CrabNebula](https://crabnebula.dev) is an official Tauri partner providing services and tooling for Tauri applications.
+The [CrabNebula Cloud](https://crabnebula.dev/cloud/) is a platform for application distribution that seamlessly integrates with the Tauri updater.
 
 The Cloud offers a Content Delivery Network (CDN) that is capable of shipping your application installers and updates globally while being cost effective and exposing download metrics.
 

--- a/docs/guides/distribution/distributing-with-crabnebula-cloud.md
+++ b/docs/guides/distribution/distributing-with-crabnebula-cloud.md
@@ -1,0 +1,16 @@
+# Distributing with CrabNebula Cloud
+
+CrabNebula is an official Tauri partner providing services and tooling for Tauri applications.
+The CrabNebula Cloud is a platform for application distribution that seamlessly integrates with the Tauri updater.
+
+The Cloud offers a Content Delivery Network (CDN) that is capable of shipping your application installers and updates globally while being cost effective and exposing download metrics.
+
+With the CrabNebula Cloud service it is simple to implement multiple release channels, download buttons for your application website and more.
+
+Setting up your Tauri app to use the Cloud is easy: all you need to do is to sign in to the [Cloud website] using your GitHub account, create your organization and application and install its CLI to create a release and upload the Tauri bundles. Additionally, a [GitHub Action] is provided to simplify the process of using the CLI on GitHub workflows.
+
+For more information, see the [CrabNebula Cloud documentation].
+
+[GitHub Action]: https://github.com/crabnebula-dev/cloud-release/
+[Cloud website]: https://web.crabnebula.cloud/
+[CrabNebula Cloud documentation]: https://docs.crabnebula.dev/cloud/

--- a/docs/guides/distribution/updater.md
+++ b/docs/guides/distribution/updater.md
@@ -188,6 +188,10 @@ The required keys are `"version"`, `"platforms.[target].url"` and `"platforms.[t
 
 Note that Tauri will validate the _whole_ file before checking the version field, so make sure all existing platform configurations are valid and complete.
 
+:::tip
+[Tauri Action] generates a static JSON file for you to use on CDNs such as GitHub Releases.
+:::
+
 ### Dynamic Update Server
 
 With this approach, Tauri will follow the update server's instructions. To disable the internal version check you can [overwrite Tauri's version comparison] to always install the version sent by the server. This could be useful if you need to roll back your app version quickly.
@@ -215,6 +219,10 @@ The required keys are "url", "version" and "signature"; the others are optional.
 - `"signature"` must be the **content** of the generated `.sig` file. The signature may change each time you run `tauri build` so make sure to always update it.
 - `"notes"`: Here you can add notes about the update, like release notes. Tauri's default dialog will present this to the user when it asks if it's allowed to update.
 - `"pub_date"` must be formatted according to [RFC 3339] if present.
+
+:::tip
+CrabNebula, an official Tauri partner, offers a dynamic update server. For more information, see the [Distributing with CrabNebula Cloud] documentation.
+:::
 
 ## Checking for Updates
 
@@ -286,3 +294,5 @@ unlisten()
 [`204 no content`]: http://tools.ietf.org/html/rfc2616#section-10.2.5
 [rfc 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.8
 [docs.rs]: https://docs.rs/tauri/latest/tauri/updater/index.html
+[Tauri Action]: /v1/guides/building/cross-platform#tauri-github-action
+[Distributing with CrabNebula Cloud]: ./distributing-with-crabnebula-cloud


### PR DESCRIPTION
We've been discussing about including more information about Tauri partners in the Tauri documentation, including their offerings for the community. This PR includes basic information about CrabNebula free DevTools website for instrumenting apps and the CrabNebula Cloud platform for distributing Tauri apps.

This PR targets the v1 documentation. A separate PR for v2 will be opened shortly after this gets merged, including any proposed changes.