### PR TITLE
prerequisites.md: Update to new nixos wiki

### DIFF
--- a/docs/guides/getting-started/prerequisites.md
+++ b/docs/guides/getting-started/prerequisites.md
@@ -416,10 +416,10 @@ While npm is the default package manager for Node.js, you can also use others li
 [github discussions]: https://github.com/tauri-apps/tauri/discussions
 [download webview2]: https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section
 [rustup.sh]: https://sh.rustup.rs
-[nix flakes]: https://nixos.wiki/wiki/Flakes
-[direnv's flakes integration]: https://nixos.wiki/wiki/Flakes#Direnv_integration
-[nix shell]: https://nixos.wiki/wiki/Development_environment_with_nix-shell
-[direnv's shell integration]: https://nixos.wiki/wiki/Development_environment_with_nix-shell#direnv
+[nix flakes]: https://wiki.nixos.org/wiki/Flakes
+[direnv's flakes integration]: https://wiki.nixos.org/wiki/Flakes#Direnv_integration
+[nix shell]: https://wiki.nixos.org/wiki/Development_environment_with_nix-shell
+[direnv's shell integration]: https://wiki.nixos.org/wiki/Development_environment_with_nix-shell#direnv
 [direnv's Guix shell support]: https://github.com/direnv/direnv/pull/1045/files
 [Guix shell]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-shell.html
 [`trunk`]: https://trunkrs.dev


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description
<!-- Delete any that don’t apply -->
- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->