### PR TITLE
Fixing executable package name (create-next-app) in next-js.mdx

### DIFF
--- a/docs/guides/getting-started/setup/next-js.mdx
+++ b/docs/guides/getting-started/setup/next-js.mdx
@@ -43,21 +43,21 @@ npx create-next-app@latest --use-npm
   <TabItem value="Yarn">
 
 ```shell
-yarn create next-app --use-yarn
+yarn create-next-app --use-yarn
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm create next-app --use-pnpm
+pnpm create-next-app --use-pnpm
 ```
 
   </TabItem>
   <TabItem value="Bun">
 
 ```shell
-bunx create next-app --use-bun
+bunx create-next-app --use-bun
 ```
 
   </TabItem>


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
Fixing executable package name of next-js.mdx 
`yarn create next-app --use-yarn` => `yarn create-next-app --use-yarn`