### PR TITLE
docs(features): add permissions to sql page

### DIFF
--- a/src/content/docs/features/sql.mdx
+++ b/src/content/docs/features/sql.mdx
@@ -220,3 +220,34 @@ Migrations are applied automatically when the plugin is initialized. The plugin 
 - **Version Control**: Each migration must have a unique version number. This is crucial for ensuring the migrations are applied in the correct order.
 - **Idempotency**: Write migrations in a way that they can be safely re-run without causing errors or unintended consequences.
 - **Testing**: Thoroughly test migrations to ensure they work as expected and do not compromise the integrity of your database.
+
+## Permissions
+
+By default all plugin commands are blocked and cannot be accessed.
+You must define a list of permissions in your `capabilities` configuration.
+
+See [Access Control List](/references/acl) for more information.
+
+```json title="src-tauri/capabilities/main.json" ins={7-8}
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "sql:allow-load",
+    "sql:allow-execute",
+  ]
+}
+```
+
+| Permission | Description |
+|------|-----|
+|`sql:allow-close`|Enables the close command without any pre-configured scope.|
+|`sql:deny-close`|Denies the close command without any pre-configured scope.|
+|`sql:allow-execute`|Enables the execute command without any pre-configured scope.|
+|`sql:deny-execute`|Denies the execute command without any pre-configured scope.|
+|`sql:allow-load`|Enables the load command without any pre-configured scope.|
+|`sql:deny-load`|Denies the load command without any pre-configured scope.|
+|`sql:allow-select`|Enables the select command without any pre-configured scope.|
+|`sql:deny-select`|Denies the select command without any pre-configured scope.|


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->

- New or updated content

#### Description
- The `feature/sql.mdx` was missing the `Permissions` part, that I now added.
- I know that #1985 plans to auto-generate the reference pages. But for now I added the permissions manually.