### PR TITLE
fix: border-radius on asides and code blocks

### DIFF
--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -1,4 +1,5 @@
 @import url('./theme.scss');
+@import url('./overrides.scss');
 
 .content details {
 	padding: 0 1rem;

--- a/src/styles/overrides.scss
+++ b/src/styles/overrides.scss
@@ -1,0 +1,6 @@
+.expressive-code > figure > pre {
+	border-radius: 0.5rem;
+}
+.starlight-aside {
+	border-radius: 0.5rem;
+}


### PR DESCRIPTION
Turns this:
![image](https://github.com/tauri-apps/tauri-docs/assets/79983560/29b9fed8-eaab-4c8a-b070-75314e9f2caa)

Into this:
![image](https://github.com/tauri-apps/tauri-docs/assets/79983560/6abc5725-808e-445e-9266-54cf15adc47f)
