### PR TITLE
fix: added append slash to next steps links on Create a Project page

### DIFF
--- a/src/content/docs/start/create-project.mdx
+++ b/src/content/docs/start/create-project.mdx
@@ -135,6 +135,6 @@ The following example assumes you are creating a new project. If you've already 
 ## Next Steps
 
 - [Add and Configure a Frontend Framework](/start/frontend/)
-- [Tauri Command Line Interface (CLI) Reference](/reference/cli)
-- [Learn how to build your Tauri app](/develop)
-- [Discover additional features to extend Tauri](/plugin)
+- [Tauri Command Line Interface (CLI) Reference](/reference/cli/)
+- [Learn how to build your Tauri app](/develop/)
+- [Discover additional features to extend Tauri](/plugin/)


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
<!-- Delete any that don’t apply -->
- Closes #2181 (please read for more context)

In the end (no pun intended) the **links only are broken when we don't have an append slash at the link URL**.

> For development, this does not seem to be an issue so I'm guessing this is related to the docs deployment config (NGINX, DNS config, or something like that.)

For now, I **just added the append slashes in the links to prevent the redirect to the broken page**, but for the main problem I suspect it's going on I think it's outside of what I could help

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way: 
   https://discord.com/invite/tauri
-->