### PR TITLE
fix(prerequisites): remove duplicated env path of `NDK_HOME`

### DIFF
--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -290,7 +290,7 @@ export NDK_HOME="$ANDROID_HOME/ndk/$(ls -1 $ANDROID_HOME/ndk)"
 ```ps
 [System.Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:LocalAppData\Android\Sdk", "User")
 $VERSION = Get-ChildItem -Path "$env:LocalAppData\Android\Sdk\ndk"
-[System.Environment]::SetEnvironmentVariable("NDK_HOME", "$env:LocalAppData\Android\Sdk\ndk\$VERSION", "User")
+[System.Environment]::SetEnvironmentVariable("NDK_HOME", "$VERSION", "User")
 ```
 
 </TabItem>

--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -289,8 +289,9 @@ export NDK_HOME="$ANDROID_HOME/ndk/$(ls -1 $ANDROID_HOME/ndk)"
 
 ```ps
 [System.Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:LocalAppData\Android\Sdk", "User")
-$VERSION = Get-ChildItem -Path "$env:LocalAppData\Android\Sdk\ndk"
-[System.Environment]::SetEnvironmentVariable("NDK_HOME", "$VERSION", "User")
+$VERSION = Get-ChildItem -Path "$env:LocalAppData\Android\Sdk\ndk" -Name
+[System.Environment]::SetEnvironmentVariable("NDK_HOME", "$env:LocalAppData\Android\Sdk\ndk\$VERSION", "User")
+
 ```
 
 </TabItem>

--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -289,9 +289,8 @@ export NDK_HOME="$ANDROID_HOME/ndk/$(ls -1 $ANDROID_HOME/ndk)"
 
 ```ps
 [System.Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:LocalAppData\Android\Sdk", "User")
-$VERSION = Get-ChildItem -Path "$env:LocalAppData\Android\Sdk\ndk" -Name
+$VERSION = Get-ChildItem -Name "$env:LocalAppData\Android\Sdk\ndk"
 [System.Environment]::SetEnvironmentVariable("NDK_HOME", "$env:LocalAppData\Android\Sdk\ndk\$VERSION", "User")
-
 ```
 
 </TabItem>


### PR DESCRIPTION
#### What kind of changes does this PR include?

remove duplicated env path of `NDK_HOME`


#### Description

When setting the Android environment of  `NDK_HOME` on Windows, the variable `$VERSION` returns the full path already, so there is no need to add the duplicated path before  `$VERSION`.

Before:
![image](https://github.com/tauri-apps/tauri-docs/assets/147602513/fe89bf29-a468-4b90-9714-5bab2e8cc7b7)

After:
![image](https://github.com/tauri-apps/tauri-docs/assets/147602513/3167401f-46db-4103-9f0f-8d0912736bd8)

