### PR TITLE
fix: broken link

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
@@ -184,6 +184,6 @@ const output = await command.execute()
 L'exemple Tauri [sidecar][] montre comment utiliser l'API sidecar pour exécuter une application Node.js sur Tauri. Il compile le code Node.js en utilisant [pkg][] et utilise les scripts ci-dessus pour l'exécuter.
 
 [tauri.bundle]: ../../api/config.md#tauri.bundle
-[sidecar]: https://github.com/tauri-apps/tauri/tree/dev/examples/sidecar
+[sidecar]: https://github.com/tauri-apps/tauri/tree/1.x/examples/sidecar
 [Restreindre l'accès aux API de commande]: ../../api/js/shell.md#restricting-access-to-the-command-apis
 [pkg]: https://github.com/vercel/pkg

--- a/i18n/it/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
@@ -187,6 +187,6 @@ const output = await command.execute()
 The Tauri [sidecar example][] demonstrates how to use the sidecar API to run a Node.js application on Tauri. It compiles the Node.js code using [pkg][] and uses the scripts above to run it.
 
 [tauri.bundle]: ../../api/config.md#tauri.bundle
-[sidecar example]: https://github.com/tauri-apps/tauri/tree/dev/examples/sidecar
+[sidecar example]: https://github.com/tauri-apps/tauri/tree/1.x/examples/sidecar
 [Restricting access to the Command APIs]: ../../api/js/shell.md#restricting-access-to-the-command-apis
 [pkg]: https://github.com/vercel/pkg

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
@@ -187,6 +187,6 @@ const output = await command.execute()
 Tauri [sidecar 예제][]는 sidecar API를 사용하여 Tauri에서 Node.js 애플리케이션을 실행하는 방법을 보여줍니다. [pkg][]를 사용하여 node.js 코드를 컴파일하고 위의 스크립트를 사용하여 실행합니다.
 
 [tauri.bundle]: ../../api/config.md#tauri.bundle
-[sidecar 예제]: https://github.com/tauri-apps/tauri/tree/dev/examples/sidecar
+[sidecar 예제]: https://github.com/tauri-apps/tauri/tree/1.x/examples/sidecar
 [Command API에 대한 액세스 제한]: ../../api/js/shell.md#restricting-access-to- the-command-apis
 [pkg]: https://github.com/vercel/pkg

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/building/sidecar.md
@@ -187,6 +187,6 @@ const output = await command.execute()
 The Tauri [sidecar example][] demonstrates how to use the sidecar API to run a Node.js application on Tauri. It compiles the Node.js code using [pkg][] and uses the scripts above to run it.
 
 [tauri.bundle]: ../../api/config.md#tauri.bundle
-[sidecar example]: https://github.com/tauri-apps/tauri/tree/dev/examples/sidecar
+[sidecar example]: https://github.com/tauri-apps/tauri/tree/1.x/examples/sidecar
 [Restricting access to the Command APIs]: ../../api/js/shell.md#restricting-access-to-the-command-apis
 [pkg]: https://github.com/vercel/pkg


### PR DESCRIPTION
Fix broken links in non-English documentation

#### Description
The project documentation has links that point to 404 pages, except for the English documentation. I've updated the links in the non-English documentation to match the correct English links, resolving the broken link issue.