### PR TITLE
webdriver: WebKitWebDriver: set correct browsername to avoid `Failed to match capabilities`

### DIFF
--- a/docs/guides/testing/webdriver/example/selenium.md
+++ b/docs/guides/testing/webdriver/example/selenium.md
@@ -165,7 +165,7 @@ before(async function () {
 
   const capabilities = new Capabilities()
   capabilities.set('tauri:options', { application })
-  capabilities.setBrowserName('wry')
+  capabilities.setBrowserName('')
 
   // start the webdriver client
   driver = await new Builder()

--- a/i18n/fr/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
@@ -139,7 +139,7 @@ before(async function () {
 
   const capabilities = new Capabilities()
   capabilities.set('tauri:options', { application })
-  capabilities.setBrowserName('wry')
+  capabilities.setBrowserName('')
 
   // start the webdriver client
   driver = await new Builder()

--- a/i18n/it/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
@@ -139,7 +139,7 @@ before(async function () {
 
   const capabilities = new Capabilities()
   capabilities.set('tauri:options', { application })
-  capabilities.setBrowserName('wry')
+  capabilities.setBrowserName('')
 
   // start the webdriver client
   driver = await new Builder()

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
@@ -139,7 +139,7 @@ before(async function () {
 
   const capabilities = new Capabilities()
   capabilities.set('tauri:options', { application })
-  capabilities.setBrowserName('wry')
+  capabilities.setBrowserName('')
 
   // start the webdriver client
   driver = await new Builder()

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/testing/webdriver/example/selenium.md
@@ -139,7 +139,7 @@ before(async function () {
 
   const capabilities = new Capabilities()
   capabilities.set('tauri:options', { application })
-  capabilities.setBrowserName('wry')
+  capabilities.setBrowserName('')
 
   // start the webdriver client
   driver = await new Builder()


### PR DESCRIPTION
fixes https://github.com/tauri-apps/tauri/issues/8828

This is really annoying, with previous `wry` example:

1. `Edgedriver` doesn't care.
2. `WebKitWebDriver` fails with `Failed to match capabilities`.
3. `Selenium` won't allow `undefined`.


P.S `WebKitWebDriver` can run with bundled `MiniBrowser` if you set `browserName` to `MiniBrowser`