### PR TITLE
Blog Post Sidebar Sorts By Date

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -312,7 +312,7 @@ export default defineConfig({
             {
               label: 'Recent posts',
               collapsed: false,
-              autogenerate: { directory: 'blog' }, // TODO: Manually construct `items` to sort by dates
+              autogenerate: { directory: 'blog', sort: 'date', order: 'descending' },
             },
           ],
         },

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
   "packageManager": "pnpm@9.4.0",
   "engines": {
     "pnpm": "^9.0.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@astrojs/starlight@0.24.5": "patches/@astrojs__starlight@0.24.5.patch"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^7.6.0",
     "sharp": "^0.33.2",
     "shiki": "^1.1.7",
-    "starlight-blog": "^0.9.0",
+    "starlight-blog": "^0.9.1",
     "starlight-links-validator": "^0.9.0"
   },
   "packageManager": "pnpm@9.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^7.6.0",
     "sharp": "^0.33.2",
     "shiki": "^1.1.7",
-    "starlight-blog": "^0.9.1",
+    "starlight-blog": "^0.9.0",
     "starlight-links-validator": "^0.9.0"
   },
   "packageManager": "pnpm@9.4.0",

--- a/patches/@astrojs__starlight@0.24.5.patch
+++ b/patches/@astrojs__starlight@0.24.5.patch
@@ -1,3 +1,16 @@
+diff --git a/schemas/sidebar.ts b/schemas/sidebar.ts
+index 86eb7f87e48d2f1b2cb096efa7a5bfaae63939bf..d1cf4ca8f280082ebf1c41c8c849e838d2250f3d 100644
+--- a/schemas/sidebar.ts
++++ b/schemas/sidebar.ts
+@@ -49,6 +49,8 @@ const AutoSidebarGroupSchema = SidebarGroupSchema.extend({
+ 		// TODO: not supported by Docusaurus but would be good to have
+ 		/** How many directories deep to include from this directory in the sidebar. Default: `Infinity`. */
+ 		// depth: z.number().optional(),
++		sort: z.enum(['date']).optional(),
++		order: z.enum(['ascending','descending']).optional()
+ 	}),
+ });
+ export type AutoSidebarGroup = z.infer<typeof AutoSidebarGroupSchema>;
 diff --git a/utils/navigation.ts b/utils/navigation.ts
 index aa4ab1f4db2f4fcb6adb8122cadb89e3e05791b9..e4a85077b588de3e33cf64e7eb4fb91501fc1c13 100644
 --- a/utils/navigation.ts

--- a/patches/@astrojs__starlight@0.24.5.patch
+++ b/patches/@astrojs__starlight@0.24.5.patch
@@ -1,0 +1,39 @@
+diff --git a/utils/navigation.ts b/utils/navigation.ts
+index aa4ab1f4db2f4fcb6adb8122cadb89e3e05791b9..e4a85077b588de3e33cf64e7eb4fb91501fc1c13 100644
+--- a/utils/navigation.ts
++++ b/utils/navigation.ts
+@@ -91,7 +91,7 @@ function groupFromAutogenerateConfig(
+ 	routes: Route[],
+ 	currentPathname: string
+ ): Group {
+-	const { collapsed: subgroupCollapsed, directory } = item.autogenerate;
++	const { collapsed: subgroupCollapsed, directory, sort, order } = item.autogenerate;
+ 	const localeDir = locale ? locale + '/' + directory : directory;
+ 	const dirDocs = routes.filter(
+ 		(doc) =>
+@@ -99,8 +99,9 @@ function groupFromAutogenerateConfig(
+ 			stripExtension(doc.id) === localeDir ||
+ 			// Match against `foo/anything/else.md`.
+ 			doc.id.startsWith(localeDir + '/')
+-	);
+-	const tree = treeify(dirDocs, localeDir);
++	)
++	const sorted = !sort ? dirDocs : dirDocs.sort(sortHandler(sort, order)).map((doc, i) => {doc.entry.data.sidebar.order = i; return doc});
++	const tree = treeify(sorted, localeDir);
+ 	return {
+ 		type: 'group',
+ 		label: pickLang(item.translations, localeToLang(locale)) || item.label,
+@@ -110,6 +111,13 @@ function groupFromAutogenerateConfig(
+ 	};
+ }
+ 
++const sortHandler = (kind: 'date', order: 'ascending' | 'descending') => {
++	if (kind === 'date') {
++		if (order === 'ascending') return (docA: Route, docB: Route) => docA.entry.data.date! > docB.entry.data.date! ? 1 : -1
++		return (docA: Route, docB: Route) => docA.entry.data.date! < docB.entry.data.date! ? 1 : -1
++	}
++}
++
+ /** Check if a string starts with one of `http://` or `https://`. */
+ const isAbsolute = (link: string) => /^https?:\/\//.test(link);
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@astrojs/starlight@0.24.5':
+    hash: nnqwl3vppw6bpddjyrfm5v3svi
+    path: patches/@astrojs__starlight@0.24.5.patch
+
 importers:
 
   .:
@@ -16,10 +21,10 @@ importers:
         version: 4.0.7
       '@astrojs/starlight':
         specifier: ^0.24.0
-        version: 0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@lorenzo_lewis/starlight-utils':
         specifier: ^0.1.0
-        version: 0.1.1(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.1.1(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -61,10 +66,10 @@ importers:
         version: 1.10.0
       starlight-blog:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       starlight-links-validator:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
 
   packages/config-generator:
     dependencies:
@@ -3892,7 +3897,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
+  '@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
     dependencies:
       '@astrojs/mdx': 3.1.2(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@astrojs/sitemap': 3.1.6
@@ -4886,9 +4891,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lorenzo_lewis/starlight-utils@0.1.1(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
+  '@lorenzo_lewis/starlight-utils@0.1.1(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
     dependencies:
-      '@astrojs/starlight': 0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       astro-integration-kit: 0.13.3(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
     transitivePeerDependencies:
@@ -7681,10 +7686,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
       '@astrojs/rss': 4.0.5
-      '@astrojs/starlight': 0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       astro-remote: 0.3.2
       github-slugger: 2.0.0
@@ -7692,9 +7697,9 @@ snapshots:
       marked-plaintify: 1.0.1(marked@12.0.2)
       ultrahtml: 1.5.3
 
-  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
-      '@astrojs/starlight': 0.24.5(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@astrojs/starlight@0.24.5':
-    hash: nnqwl3vppw6bpddjyrfm5v3svi
+    hash: kv7yo3q5mkk7b2of2xzi4btao4
     path: patches/@astrojs__starlight@0.24.5.patch
 
 importers:
@@ -21,10 +21,10 @@ importers:
         version: 4.0.7
       '@astrojs/starlight':
         specifier: ^0.24.0
-        version: 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@lorenzo_lewis/starlight-utils':
         specifier: ^0.1.0
-        version: 0.1.1(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.1.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -66,10 +66,10 @@ importers:
         version: 1.10.0
       starlight-blog:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       starlight-links-validator:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
 
   packages/config-generator:
     dependencies:
@@ -3897,7 +3897,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
+  '@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
     dependencies:
       '@astrojs/mdx': 3.1.2(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       '@astrojs/sitemap': 3.1.6
@@ -4891,9 +4891,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lorenzo_lewis/starlight-utils@0.1.1(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
+  '@lorenzo_lewis/starlight-utils@0.1.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))':
     dependencies:
-      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       astro-integration-kit: 0.13.3(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
     transitivePeerDependencies:
@@ -7686,10 +7686,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
       '@astrojs/rss': 4.0.5
-      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       astro-remote: 0.3.2
       github-slugger: 2.0.0
@@ -7697,9 +7697,9 @@ snapshots:
       marked-plaintify: 1.0.1(marked@12.0.2)
       ultrahtml: 1.5.3
 
-  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
-      '@astrojs/starlight': 0.24.5(patch_hash=nnqwl3vppw6bpddjyrfm5v3svi)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+      '@astrojs/starlight': 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       astro: 4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^1.1.7
         version: 1.10.0
       starlight-blog:
-        specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        specifier: ^0.9.1
+        version: 0.9.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       starlight-links-validator:
         specifier: ^0.9.0
         version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
@@ -3292,8 +3292,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  starlight-blog@0.9.0:
-    resolution: {integrity: sha512-SpQulRfi8/lQ1XYz+YZ26/4o/gCeCqQ/IsMNRYD8erpxcBNq0/iGax32E3TsJVO2E9iM32LHvMrp0pF+vwk7fg==}
+  starlight-blog@0.9.1:
+    resolution: {integrity: sha512-N41QM0URHiepC3dc6dgdyGOQ/FtidslWfYQ/JwXQCuYxbO7c6vjl4ciwevHBB0CJfVyz4hIJD5jPabIO8waSjA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.24.0'
@@ -7686,7 +7686,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-blog@0.9.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
       '@astrojs/rss': 4.0.5
       '@astrojs/starlight': 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^1.1.7
         version: 1.10.0
       starlight-blog:
-        specifier: ^0.9.1
-        version: 0.9.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
+        specifier: ^0.9.0
+        version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
       starlight-links-validator:
         specifier: ^0.9.0
         version: 0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))
@@ -3292,8 +3292,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  starlight-blog@0.9.1:
-    resolution: {integrity: sha512-N41QM0URHiepC3dc6dgdyGOQ/FtidslWfYQ/JwXQCuYxbO7c6vjl4ciwevHBB0CJfVyz4hIJD5jPabIO8waSjA==}
+  starlight-blog@0.9.0:
+    resolution: {integrity: sha512-SpQulRfi8/lQ1XYz+YZ26/4o/gCeCqQ/IsMNRYD8erpxcBNq0/iGax32E3TsJVO2E9iM32LHvMrp0pF+vwk7fg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.24.0'
@@ -7686,7 +7686,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  starlight-blog@0.9.1(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
+  starlight-blog@0.9.0(@astrojs/starlight@0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)))(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2)):
     dependencies:
       '@astrojs/rss': 4.0.5
       '@astrojs/starlight': 0.24.5(patch_hash=kv7yo3q5mkk7b2of2xzi4btao4)(astro@4.11.3(@types/node@20.14.9)(sass@1.77.6)(terser@5.31.0)(typescript@5.5.2))


### PR DESCRIPTION
## Description

Blog posts were sorting alphabetically in the sidebar partly due to a combination of plugins. This adjusts the config to use a sort and order in the `autogenerated` sidebar config.

_Note: It is currently using a patch to accomplish this. We may want to consider whether this is acceptable upstream, and push it up if so._
