### PR TITLE
[i18nIgnore] Import Examples When `"withGlobalTauri": true`

### DIFF
--- a/src/content/docs/blog/tauri-2-0-0-alpha-4.mdx
+++ b/src/content/docs/blog/tauri-2-0-0-alpha-4.mdx
@@ -117,7 +117,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 
 **Frontend code to call the plugin command:**
 
-```js
+```javascript
 import { invoke } from '@tauri-apps/api/tauri';
 invoke('plugin:example|ping', { value: 'Tauri' }).then(({ value }) =>
   console.log('Response', value)

--- a/src/content/docs/concept/Inter-Process Communication/isolation.md
+++ b/src/content/docs/concept/Inter-Process Communication/isolation.md
@@ -78,7 +78,7 @@ For the purposes of this example, let's imagine we are in the same directory as 
 
 `../dist-isolation/index.js`:
 
-```js
+```javascript
 window.__TAURI_ISOLATION_HOOK__ = (payload) => {
   // let's not verify or modify anything, just print the content from the hook
   console.log('hook', payload);

--- a/src/content/docs/develop/Tests/WebDriver/Example/selenium.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/Example/selenium.mdx
@@ -81,7 +81,7 @@ testing file at `test/test.js` by default, so let's create that file now.
 
 `test/test.js`:
 
-```js
+```javascript
 const os = require('os');
 const path = require('path');
 const { expect } = require('chai');

--- a/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
@@ -82,7 +82,7 @@ config file which controls most aspects of our testing suite.
 
 `wdio.conf.js`:
 
-```js
+```javascript
 const os = require('os');
 const path = require('path');
 const { spawn, spawnSync } = require('child_process');
@@ -135,7 +135,7 @@ run them as it sees fit. Let's create our spec now in the directory we specified
 
 `test/specs/example.e2e.js`:
 
-```js
+```javascript
 // calculates the luma from a hex color `#abcdef`
 function luma(hex) {
   if (hex.startsWith('#')) {

--- a/src/content/docs/develop/Tests/mocking.md
+++ b/src/content/docs/develop/Tests/mocking.md
@@ -28,7 +28,7 @@ The following examples use [Vitest], but you can use any other frontend testing 
 
 :::
 
-```js
+```javascript
 import { beforeAll, expect, test } from "vitest";
 import { randomFillSync } from "crypto";
 
@@ -61,7 +61,7 @@ test("invoke simple", async () => {
 Sometimes you want to track more information about an IPC call; how many times was the command invoked? Was it invoked at all?
 You can use [`mockIPC()`] with other spying and mocking tools to test this:
 
-```js
+```javascript
 import { beforeAll, expect, test, vi } from "vitest";
 import { randomFillSync } from "crypto";
 
@@ -99,7 +99,7 @@ test("invoke", async () => {
 
 To mock IPC requests to a sidecar or shell command you need to grab the ID of the event handler when `spawn()` or `execute()` is called and use this ID to emit events the backend would send back:
 
-```js
+```javascript
 mockIPC(async (cmd, args) => {
   if (args.message.cmd === 'execute') {
     const eventCallbackId = `_${args.message.onEventFn}`;
@@ -134,7 +134,7 @@ You can use the [`mockWindows()`] method to create fake window labels. The first
 
 :::
 
-```js
+```javascript
 import { beforeAll, expect, test } from 'vitest';
 import { randomFillSync } from 'crypto';
 

--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -35,7 +35,7 @@ pub fn run() {
 
 Now, you can invoke the command from your JavaScript code:
 
-```js
+```javascript
 // When using the Tauri API npm package:
 import { invoke } from '@tauri-apps/api/core';
 
@@ -60,7 +60,7 @@ fn my_custom_command(invoke_message: String) {
 
 Arguments should be passed as a JSON object with camelCase keys:
 
-```js
+```javascript
 invoke('my_custom_command', { invokeMessage: 'Hello!' });
 ```
 
@@ -78,7 +78,7 @@ fn my_custom_command(invoke_message: String) {
 
 The corresponding JavaScript:
 
-```js
+```javascript
 invoke('my_custom_command', { invoke_message: 'Hello!' });
 ```
 
@@ -95,7 +95,7 @@ fn my_custom_command() -> String {
 
 The `invoke` function returns a promise that resolves with the returned value:
 
-```js
+```javascript
 invoke('my_custom_command').then((message) => console.log(message));
 ```
 
@@ -117,7 +117,7 @@ fn my_custom_command() -> Result<String, String> {
 
 If the command returns an error, the promise will reject, otherwise, it resolves:
 
-```js
+```javascript
 invoke('my_custom_command')
   .then((message) => console.log(message))
   .catch((error) => console.error(error));
@@ -229,7 +229,7 @@ async fn my_custom_command(value: &str) -> Result<String, ()> {
 
 Since invoking the command from JavaScript already returns a promise, it works just like any other command:
 
-```js
+```javascript
 invoke('my_custom_command', { value: 'Hello, Async!' }).then(() =>
   console.log('Completed!')
 );
@@ -374,7 +374,7 @@ pub fn run() {
 }
 ```
 
-```js
+```javascript
 import { invoke } from '@tauri-apps/api/core';
 
 // Invocation from JavaScript

--- a/src/content/docs/es/plugin/dialog.mdx
+++ b/src/content/docs/es/plugin/dialog.mdx
@@ -88,7 +88,7 @@ Consulta todas las [Opciones de diálogo](/reference/javascript/dialog/) en la r
 
 Muestra un diálogo de pregunta con botones `Yes` y `No`.
 
-```js
+```javascript
 import { ask } from '@tauri-apps/plugin-dialog';
 
 // Crea un diálogo de Sí/No
@@ -107,7 +107,7 @@ console.log(answer);
 
 Muestra un diálogo de pregunta con botones `Ok` y `Cancel`.
 
-```js
+```javascript
 import { confirm } from '@tauri-apps/plugin-dialog';
 
 // Crea un diálogo de confirmación Ok/Cancelar
@@ -126,7 +126,7 @@ console.log(confirmation);
 
 Muestra un diálogo de mensaje con un botón `Ok`. Ten en cuenta que si el usuario cierra el diálogo, devolverá `false`.
 
-```js
+```javascript
 import { message } from '@tauri-apps/plugin-dialog';
 
 // Muestra un mensaje
@@ -141,7 +141,7 @@ Abre un diálogo de selección de archivos/directorios.
 
 La opción `multiple` controla si el diálogo permite la selección múltiple o no, mientras que `directory`, si es una selección de directorio o no.
 
-```js
+```javascript
 import { open } from '@tauri-apps/plugin-dialog';
 
 // Abre un diálogo
@@ -159,7 +159,7 @@ console.log(file);
 
 Abre un diálogo de guardar archivo/directorio.
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 // Indica para guardar un 'My Filter' con extensión .png o .jpeg
 const path = await save({

--- a/src/content/docs/es/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/es/start/migrate/from-tauri-1.mdx
@@ -240,7 +240,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 const matches = await getMatches();
 ```
@@ -291,7 +291,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 await writeText('Tauri is awesome!');
 assert(await readText(), 'Tauri is awesome!');
@@ -349,7 +349,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 const filePath = await save({
   filters: [
@@ -415,7 +415,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
 await mkdir('db', { baseDir: BaseDirectory.AppLocalData });
 ```
@@ -473,7 +473,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');
@@ -538,7 +538,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { fetch } from '@tauri-apps/plugin-http';
 const response = await fetch(
   'https://raw.githubusercontent.com/tauri-apps/tauri/dev/package.json'
@@ -604,7 +604,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { sendNotification } from '@tauri-apps/plugin-notification';
 sendNotification('Tauri is awesome!');
 ```
@@ -782,7 +782,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { arch } from '@tauri-apps/plugin-os';
 const architecture = await arch();
 ```
@@ -837,7 +837,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 await exit(0);
 await relaunch();
@@ -896,7 +896,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { Command, open } from '@tauri-apps/plugin-shell';
 const output = await Command.create('echo', 'message').execute();
 
@@ -1079,7 +1079,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 

--- a/src/content/docs/fr/plugin/notification.mdx
+++ b/src/content/docs/fr/plugin/notification.mdx
@@ -86,7 +86,7 @@ Suivez ces étapes pour envoyer une notification:
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import {
   isPermissionGranted,
   requestPermission,

--- a/src/content/docs/fr/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/fr/start/migrate/from-tauri-1.mdx
@@ -136,7 +136,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { show, hide } from '@tauri-apps/plugin-app';
 await hide();
 await show();
@@ -196,7 +196,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 const matches = await getMatches();
 ```
@@ -247,7 +247,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 await writeText('Tauri is awesome!');
 assert(await readText(), 'Tauri is awesome!');
@@ -305,7 +305,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 const filePath = await save({
   filters: [
@@ -371,7 +371,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { createDir, BaseDirectory } from '@tauri-apps/plugin-fs';
 await createDir('db', { dir: BaseDirectory.AppLocalData });
 ```
@@ -417,7 +417,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');
@@ -474,7 +474,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { fetch } from '@tauri-apps/plugin-http';
 const response = await fetch(
   'https://raw.githubusercontent.com/tauri-apps/tauri/dev/package.json'
@@ -540,7 +540,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { sendNotification } from '@tauri-apps/plugin-notification';
 sendNotification('Tauri is awesome!');
 ```
@@ -720,7 +720,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { arch } from '@tauri-apps/plugin-os';
 const architecture = await arch();
 ```
@@ -775,7 +775,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 await exit(0);
 await relaunch();
@@ -834,7 +834,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { Command, open } from '@tauri-apps/plugin-shell';
 const output = await Command.create('echo', 'message').execute();
 
@@ -1020,7 +1020,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 
@@ -1107,7 +1107,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { appWindow } from '@tauri-apps/plugin-window';
 await appWindow.setTitle('Tauri');
 ```

--- a/src/content/docs/learn/Security/capabilities-for-windows-and-platforms.mdx
+++ b/src/content/docs/learn/Security/capabilities-for-windows-and-platforms.mdx
@@ -33,7 +33,7 @@ This exercise is meant to be read after completing [`Using Plugin Permissions`](
    In the Tauri configuration file, usually named `tauri.conf.json`:
 
     <ShowSolution>
-    ```js
+    ```javascript
       "productName": "multiwindow",
       ...
       "app": {

--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -83,6 +83,8 @@ The autostart plugin is available in both JavaScript and Rust.
 
 ```js
 import { enable, isEnabled, disable } from '@tauri-apps/plugin-autostart';
+// when using `"withGlobalTauri": true`, you may use
+// const { enable, isEnabled, disable } = window.__TAURI_PLUGIN_AUTOSTART__;
 
 // Enable autostart
 await enable();

--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -81,7 +81,7 @@ The autostart plugin is available in both JavaScript and Rust.
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { enable, isEnabled, disable } from '@tauri-apps/plugin-autostart';
 // when using `"withGlobalTauri": true`, you may use
 // const { enable, isEnabled, disable } = window.__TAURI_PLUGIN_AUTOSTART__;

--- a/src/content/docs/plugin/barcode-scanner.mdx
+++ b/src/content/docs/plugin/barcode-scanner.mdx
@@ -77,7 +77,7 @@ Install the barcode-scanner plugin to get started.
 
 The barcode scanner plugin is available in JavaScript.
 
-```js
+```javascript
 import { scan, Format } from '@tauri-apps/plugin-barcode-scanner';
 // when using `"withGlobalTauri": true`, you may use
 // const { scan, Format } = window.__TAURI_PLUGIN_BARCODE_SCANNER__;

--- a/src/content/docs/plugin/barcode-scanner.mdx
+++ b/src/content/docs/plugin/barcode-scanner.mdx
@@ -79,6 +79,8 @@ The barcode scanner plugin is available in JavaScript.
 
 ```js
 import { scan, Format } from '@tauri-apps/plugin-barcode-scanner';
+// when using `"withGlobalTauri": true`, you may use
+// const { scan, Format } = window.__TAURI_PLUGIN_BARCODE_SCANNER__;
 
 // `windowed: true` actually sets the webview to transparent
 // instead of opening a separate view for the camera

--- a/src/content/docs/plugin/cli.mdx
+++ b/src/content/docs/plugin/cli.mdx
@@ -221,6 +221,8 @@ The CLI plugin is available in both JavaScript and Rust.
 
 ```js
 import { getMatches } from '@tauri-apps/plugin-cli';
+// when using `"withGlobalTauri": true`, you may use
+// const { getMatches } = window.__TAURI_PLUGIN_CLI_;
 
 const matches = await getMatches();
 if (matches.subcommand?.name === 'run') {

--- a/src/content/docs/plugin/cli.mdx
+++ b/src/content/docs/plugin/cli.mdx
@@ -219,7 +219,7 @@ The CLI plugin is available in both JavaScript and Rust.
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 // when using `"withGlobalTauri": true`, you may use
 // const { getMatches } = window.__TAURI_PLUGIN_CLI_;

--- a/src/content/docs/plugin/clipboard.mdx
+++ b/src/content/docs/plugin/clipboard.mdx
@@ -76,6 +76,8 @@ The clipboard plugin is available in both JavaScript and Rust.
 
 ```js
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
+// when using `"withGlobalTauri": true`, you may use
+// const { writeText, readText } = window.__TAURI_PLUGIN_CLIPBOARD_MANAGER__;
 
 // Write content to clipboard
 await writeText('Tauri is awesome!');

--- a/src/content/docs/plugin/clipboard.mdx
+++ b/src/content/docs/plugin/clipboard.mdx
@@ -74,7 +74,7 @@ The clipboard plugin is available in both JavaScript and Rust.
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 // when using `"withGlobalTauri": true`, you may use
 // const { writeText, readText } = window.__TAURI_PLUGIN_CLIPBOARD_MANAGER__;

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -168,6 +168,8 @@ The deep-link plugin is available in both JavaScript and Rust.
 
 ```js
 import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
+// when using `"withGlobalTauri": true`, you may use
+// const { onOpenUrl } = window.__TAURI_PLUGIN_DEEP_LINK__;
 
 await onOpenUrl((urls) => {
   console.log('deep link:', urls);

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -166,7 +166,7 @@ The deep-link plugin is available in both JavaScript and Rust.
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
 // when using `"withGlobalTauri": true`, you may use
 // const { onOpenUrl } = window.__TAURI_PLUGIN_DEEP_LINK__;

--- a/src/content/docs/plugin/dialog.mdx
+++ b/src/content/docs/plugin/dialog.mdx
@@ -93,7 +93,7 @@ See all [Dialog Options](/reference/javascript/dialog/) at the JavaScript API re
 
 Shows a question dialog with `Yes` and `No` buttons.
 
-```js
+```javascript
 import { ask } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
 // const { ask } = window.__TAURI_PLUGIN_DIALOG__;
@@ -114,7 +114,7 @@ console.log(answer);
 
 Shows a question dialog with `Ok` and `Cancel` buttons.
 
-```js
+```javascript
 import { confirm } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
 // const { confirm } = window.__TAURI_PLUGIN_DIALOG__;
@@ -135,7 +135,7 @@ console.log(confirmation);
 
 Shows a message dialog with an `Ok` button. Keep in mind that if the user closes the dialog it will return `false`.
 
-```js
+```javascript
 import { message } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
 // const { message } = window.__TAURI_PLUGIN_DIALOG__;
@@ -152,7 +152,7 @@ Open a file/directory selection dialog.
 
 The `multiple` option controls whether the dialog allows multiple selection or not, while the `directory`, whether is a directory selection or not.
 
-```js
+```javascript
 import { open } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
 // const { open } = window.__TAURI_PLUGIN_DIALOG__;
@@ -172,7 +172,7 @@ console.log(file);
 
 Open a file/directory save dialog.
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
 // const { save } = window.__TAURI_PLUGIN_DIALOG__;

--- a/src/content/docs/plugin/dialog.mdx
+++ b/src/content/docs/plugin/dialog.mdx
@@ -95,6 +95,8 @@ Shows a question dialog with `Yes` and `No` buttons.
 
 ```js
 import { ask } from '@tauri-apps/plugin-dialog';
+// when using `"withGlobalTauri": true`, you may use
+// const { ask } = window.__TAURI_PLUGIN_DIALOG__;
 
 // Create a Yes/No dialog
 const answer = await ask('This action cannot be reverted. Are you sure?', {
@@ -114,6 +116,8 @@ Shows a question dialog with `Ok` and `Cancel` buttons.
 
 ```js
 import { confirm } from '@tauri-apps/plugin-dialog';
+// when using `"withGlobalTauri": true`, you may use
+// const { confirm } = window.__TAURI_PLUGIN_DIALOG__;
 
 // Creates a confirmation Ok/Cancel dialog
 const confirmation = await confirm(
@@ -133,6 +137,8 @@ Shows a message dialog with an `Ok` button. Keep in mind that if the user closes
 
 ```js
 import { message } from '@tauri-apps/plugin-dialog';
+// when using `"withGlobalTauri": true`, you may use
+// const { message } = window.__TAURI_PLUGIN_DIALOG__;
 
 // Shows message
 await message('File not found', { title: 'Tauri', kind: 'error' });
@@ -148,6 +154,8 @@ The `multiple` option controls whether the dialog allows multiple selection or n
 
 ```js
 import { open } from '@tauri-apps/plugin-dialog';
+// when using `"withGlobalTauri": true`, you may use
+// const { open } = window.__TAURI_PLUGIN_DIALOG__;
 
 // Open a dialog
 const file = await open({
@@ -166,6 +174,9 @@ Open a file/directory save dialog.
 
 ```js
 import { save } from '@tauri-apps/plugin-dialog';
+// when using `"withGlobalTauri": true`, you may use
+// const { save } = window.__TAURI_PLUGIN_DIALOG__;
+
 // Prompt to save a 'My Filter' with extension .png or .jpeg
 const path = await save({
   filters: [

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -88,7 +88,7 @@ The fs plugin is available in both JavaScript and Rust.
 <Tabs>
   <TabItem label="JavaScript" >
 
-```js
+```javascript
 import { exists, BaseDirectory } from '@tauri-apps/plugin-fs';
 // when using `"withGlobalTauri": true`, you may use
 // const { exists, BaseDirectory } = window.__TAURI_PLUGIN_FS__;

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -90,6 +90,8 @@ The fs plugin is available in both JavaScript and Rust.
 
 ```js
 import { exists, BaseDirectory } from '@tauri-apps/plugin-fs';
+// when using `"withGlobalTauri": true`, you may use
+// const { exists, BaseDirectory } = window.__TAURI_PLUGIN_FS__;
 
 // Check if the `$APPDATA/avatar.png` file exists
 await exists('avatar.png', { baseDir: BaseDirectory.AppData });

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -88,7 +88,7 @@ The global-shortcut plugin is available in both JavaScript and Rust.
 <Tabs>
   <TabItem label="JavaScript" >
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 // when using `"withGlobalTauri": true`, you may use
 // const { register } = window.__TAURI_PLUGIN_GLOBAL_SHORTCUT__;

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -90,6 +90,8 @@ The global-shortcut plugin is available in both JavaScript and Rust.
 
 ```js
 import { register } from '@tauri-apps/plugin-global-shortcut';
+// when using `"withGlobalTauri": true`, you may use
+// const { register } = window.__TAURI_PLUGIN_GLOBAL_SHORTCUT__;
 
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');

--- a/src/content/docs/plugin/http-client.mdx
+++ b/src/content/docs/plugin/http-client.mdx
@@ -91,7 +91,7 @@ The http plugin is available in both as an JavaScript API and in Rust as a [reqw
 
 2.  Send a request
 
-    ```js
+    ```javascript
     import { fetch } from '@tauri-apps/plugin-http';
 
     // Send a GET request

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -112,6 +112,8 @@ Install the log plugin to get started.
 
         ```js
         import { trace, info, error, attachConsole } from '@tauri-apps/plugin-log';
+        // when using `"withGlobalTauri": true`, you may use
+        // const { trace, info, error, attachConsole } = window.__TAURI_PLUGIN_LOG__;
 
         // with TargetKind::Webview enabled, this function will print logs to the browser console
         const detach = await attachConsole();

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -110,7 +110,7 @@ Install the log plugin to get started.
 
 2.  Afterwards, all the plugin's APIs are available through the JavaScript guest bindings:
 
-        ```js
+        ```javascript
         import { trace, info, error, attachConsole } from '@tauri-apps/plugin-log';
         // when using `"withGlobalTauri": true`, you may use
         // const { trace, info, error, attachConsole } = window.__TAURI_PLUGIN_LOG__;

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -98,6 +98,8 @@ import {
   requestPermission,
   sendNotification,
 } from '@tauri-apps/plugin-notification';
+// when using `"withGlobalTauri": true`, you may use
+// const { isPermissionGranted, requestPermission, sendNotification, } = window.__TAURI_PLUGIN_NOTIFICATION__;
 
 // Do you have permission to send a notification?
 let permissionGranted = await isPermissionGranted();

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -92,7 +92,7 @@ Follow these steps to send a notification:
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import {
   isPermissionGranted,
   requestPermission,

--- a/src/content/docs/plugin/os-info.mdx
+++ b/src/content/docs/plugin/os-info.mdx
@@ -79,6 +79,8 @@ With this plugin you can query multiple information from current operational sys
 
 ```js
 import { platform } from '@tauri-apps/plugin-os';
+// when using `"withGlobalTauri": true`, you may use
+// const { platform } = window.__TAURI_PLUGIN_OS__;
 
 const currentPlatform = await platform();
 console.log(currentPlatform);

--- a/src/content/docs/plugin/os-info.mdx
+++ b/src/content/docs/plugin/os-info.mdx
@@ -77,7 +77,7 @@ With this plugin you can query multiple information from current operational sys
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { platform } from '@tauri-apps/plugin-os';
 // when using `"withGlobalTauri": true`, you may use
 // const { platform } = window.__TAURI_PLUGIN_OS__;

--- a/src/content/docs/plugin/positioner.mdx
+++ b/src/content/docs/plugin/positioner.mdx
@@ -119,6 +119,8 @@ The plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
 import { moveWindow, Position } from '@tauri-apps/plugin-positioner';
+// when using `"withGlobalTauri": true`, you may use
+// const { moveWindow, Position } = window.__TAURI_PLUGIN_POSITIONER__;
 
 moveWindow(Position.TopRight);
 ```

--- a/src/content/docs/plugin/process.mdx
+++ b/src/content/docs/plugin/process.mdx
@@ -71,7 +71,7 @@ The process plugin is available in both JavaScript and Rust.
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 // when using `"withGlobalTauri": true`, you may use
 // const { exit, relaunch } = window.__TAURI_PLUGIN_PROCESS__;

--- a/src/content/docs/plugin/process.mdx
+++ b/src/content/docs/plugin/process.mdx
@@ -73,6 +73,8 @@ The process plugin is available in both JavaScript and Rust.
 
 ```js
 import { exit, relaunch } from '@tauri-apps/plugin-process';
+// when using `"withGlobalTauri": true`, you may use
+// const { exit, relaunch } = window.__TAURI_PLUGIN_PROCESS__;
 
 // exits the app with the given status code
 await exit(0);

--- a/src/content/docs/plugin/shell.mdx
+++ b/src/content/docs/plugin/shell.mdx
@@ -85,6 +85,8 @@ The shell plugin is available in both JavaScript and Rust.
 
 ```js
 import { Command } from '@tauri-apps/plugin-shell';
+// when using `"withGlobalTauri": true`, you may use
+// const { Command } = window.__TAURI_PLUGIN_SHELL__;
 
 let result = await Command.create('exec-sh', [
   '-c',

--- a/src/content/docs/plugin/shell.mdx
+++ b/src/content/docs/plugin/shell.mdx
@@ -83,7 +83,7 @@ The shell plugin is available in both JavaScript and Rust.
 <Tabs>
 	<TabItem label="JavaScript" >
 
-```js
+```javascript
 import { Command } from '@tauri-apps/plugin-shell';
 // when using `"withGlobalTauri": true`, you may use
 // const { Command } = window.__TAURI_PLUGIN_SHELL__;

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -84,6 +84,9 @@ The path is relative to [`tauri::api::path::BaseDirectory::AppConfig`](https://d
 
 ```javascript
 import Database from '@tauri-apps/plugin-sql';
+// when using `"withGlobalTauri": true`, you may use
+// const V = window.__TAURI_PLUGIN_SQL_;
+
 const db = await Database.load('sqlite:test.db');
 await db.execute('INSERT INTO ...');
 ```
@@ -93,6 +96,9 @@ await db.execute('INSERT INTO ...');
 ```javascript
 
 import Database from '@tauri-apps/plugin-sql';
+// when using `"withGlobalTauri": true`, you may use
+// const Database = window.__TAURI_PLUGIN_SQL__;
+
 const db = await Database.load('mysql://user:pass@host/database');
 await db.execute('INSERT INTO ...');
 

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -85,7 +85,7 @@ The path is relative to [`tauri::api::path::BaseDirectory::AppConfig`](https://d
 ```javascript
 import Database from '@tauri-apps/plugin-sql';
 // when using `"withGlobalTauri": true`, you may use
-// const V = window.__TAURI_PLUGIN_SQL_;
+// const V = window.__TAURI_PLUGIN_SQL__;
 
 const db = await Database.load('sqlite:test.db');
 await db.execute('INSERT INTO ...');

--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -80,7 +80,7 @@ Install the store plugin to get started.
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { Store } from '@tauri-apps/plugin-store';
 
 // Store will be loaded automatically when used in JavaScript binding.

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -138,7 +138,7 @@ pub fn run() {
 
 The stronghold plugin is available in JavaScript.
 
-```js
+```javascript
 import { Client, Stronghold } from '@tauri-apps/plugin-stronghold';
 // when using `"withGlobalTauri": true`, you may use
 // const { Client, Stronghold } = window.__TAURI_PLUGIN_STRONGHOLD__;

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -140,7 +140,11 @@ The stronghold plugin is available in JavaScript.
 
 ```js
 import { Client, Stronghold } from '@tauri-apps/plugin-stronghold';
+// when using `"withGlobalTauri": true`, you may use
+// const { Client, Stronghold } = window.__TAURI_PLUGIN_STRONGHOLD__;
 import { appDataDir } from '@tauri-apps/api/path';
+// when using `"withGlobalTauri": true`, you may use
+// const { appDataDir } = window.__TAURI__.path;
 
 const initStronghold = async () => {
 	const vaultPath = `${await appDataDir()}/vault.hold`;

--- a/src/content/docs/plugin/upload.mdx
+++ b/src/content/docs/plugin/upload.mdx
@@ -72,7 +72,7 @@ Once you've completed the registration and setup process for the plugin, you can
 
 Here's an example of how you can use the plugin to upload and download files:
 
-```js
+```javascript
 import { upload } from '@tauri-apps/plugin-upload';
 // when using `"withGlobalTauri": true`, you may use
 // const { upload } = window.__TAURI_PLUGIN_UPLOAD__;
@@ -85,7 +85,7 @@ upload(
 );
 ```
 
-```js
+```javascript
 import { download } from '@tauri-apps/plugin-upload';
 // when using `"withGlobalTauri": true`, you may use
 // const { download } = window.__TAURI_PLUGIN_UPLOAD__;

--- a/src/content/docs/plugin/upload.mdx
+++ b/src/content/docs/plugin/upload.mdx
@@ -74,6 +74,8 @@ Here's an example of how you can use the plugin to upload and download files:
 
 ```js
 import { upload } from '@tauri-apps/plugin-upload';
+// when using `"withGlobalTauri": true`, you may use
+// const { upload } = window.__TAURI_PLUGIN_UPLOAD__;
 
 upload(
   'https://example.com/file-upload',
@@ -85,6 +87,8 @@ upload(
 
 ```js
 import { download } from '@tauri-apps/plugin-upload';
+// when using `"withGlobalTauri": true`, you may use
+// const { download } = window.__TAURI_PLUGIN_UPLOAD__;
 
 download(
   'https://example.com/file-download-link',

--- a/src/content/docs/plugin/websocket.mdx
+++ b/src/content/docs/plugin/websocket.mdx
@@ -85,6 +85,8 @@ The websocket plugin is available in JavaScript.
 
 ```js
 import WebSocket from '@tauri-apps/plugin-websocket';
+// when using `"withGlobalTauri": true`, you may use
+// const WebSocket = window.__TAURI_PLUGIN_WEBSOCKET__;
 
 const ws = await WebSocket.connect('ws://127.0.0.1:8080');
 

--- a/src/content/docs/plugin/websocket.mdx
+++ b/src/content/docs/plugin/websocket.mdx
@@ -83,7 +83,7 @@ Install the websocket plugin to get started.
 
 The websocket plugin is available in JavaScript.
 
-```js
+```javascript
 import WebSocket from '@tauri-apps/plugin-websocket';
 // when using `"withGlobalTauri": true`, you may use
 // const WebSocket = window.__TAURI_PLUGIN_WEBSOCKET__;

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -137,7 +137,7 @@ Note that you may need to move the rest of your content down so that the titleba
 
 Use this code snippet to make the buttons work:
 
-```js
+```javascript
 import { Window } from '@tauri-apps/api/window';
 // when using `"withGlobalTauri": true`, you may use
 // const { Window } = window.__TAURI__.window;

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -139,6 +139,8 @@ Use this code snippet to make the buttons work:
 
 ```js
 import { Window } from '@tauri-apps/api/window';
+// when using `"withGlobalTauri": true`, you may use
+// const { Window } = window.__TAURI__.window;
 
 const appWindow = new Window('main');
 

--- a/src/content/docs/plugin/window-state.mdx
+++ b/src/content/docs/plugin/window-state.mdx
@@ -92,6 +92,8 @@ You can use `saveWindowState` to manually save the window state:
 
 ```javascript
 import { saveWindowState, StateFlags } from '@tauri-apps/plugin-window-state';
+// when using `"withGlobalTauri": true`, you may use
+// const { Store } = window.__TAURI_PLUGIN_STORE__;
 
 saveWindowState(StateFlags.ALL);
 ```
@@ -103,6 +105,8 @@ import {
   restoreStateCurrent,
   StateFlags,
 } from '@tauri-apps/plugin-window-state';
+// when using `"withGlobalTauri": true`, you may use
+// const { restoreStateCurrent, StateFlags } = window.__TAURI_PLUGIN_WINDOW_STATE__;
 
 restoreStateCurrent(StateFlags.ALL);
 ```

--- a/src/content/docs/plugin/window-state.mdx
+++ b/src/content/docs/plugin/window-state.mdx
@@ -93,7 +93,7 @@ You can use `saveWindowState` to manually save the window state:
 ```javascript
 import { saveWindowState, StateFlags } from '@tauri-apps/plugin-window-state';
 // when using `"withGlobalTauri": true`, you may use
-// const { Store } = window.__TAURI_PLUGIN_STORE__;
+// const { saveWindowState, StateFlags } = window.__TAURI_PLUGIN_WINDOW_STATE__;
 
 saveWindowState(StateFlags.ALL);
 ```

--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -240,7 +240,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 const matches = await getMatches();
 ```
@@ -291,7 +291,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 await writeText('Tauri is awesome!');
 assert(await readText(), 'Tauri is awesome!');
@@ -349,7 +349,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 const filePath = await save({
   filters: [
@@ -415,7 +415,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
 await mkdir('db', { baseDir: BaseDirectory.AppLocalData });
 ```
@@ -473,7 +473,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');
@@ -538,7 +538,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { fetch } from '@tauri-apps/plugin-http';
 const response = await fetch(
   'https://raw.githubusercontent.com/tauri-apps/tauri/dev/package.json'
@@ -604,7 +604,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { sendNotification } from '@tauri-apps/plugin-notification';
 sendNotification('Tauri is awesome!');
 ```
@@ -782,7 +782,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { arch } from '@tauri-apps/plugin-os';
 const architecture = await arch();
 ```
@@ -837,7 +837,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 await exit(0);
 await relaunch();
@@ -896,7 +896,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { Command, open } from '@tauri-apps/plugin-shell';
 const output = await Command.create('echo', 'message').execute();
 
@@ -1084,7 +1084,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 

--- a/src/content/docs/zh-cn/develop/Plugins/index.mdx
+++ b/src/content/docs/zh-cn/develop/Plugins/index.mdx
@@ -289,7 +289,7 @@ Builder::new("<plugin-name>")
 
 在 `webview-src/index.ts` 中定义一个绑定函数，然后插件用户就可以轻松地在 JavaScript 中调用这个命令：
 
-```js
+```javascript
 // webview-src/index.ts
 import { invoke, Channel } from '@tauri-apps/api/tauri'
 

--- a/src/content/docs/zh-cn/develop/Tests/WebDriver/Example/selenium.mdx
+++ b/src/content/docs/zh-cn/develop/Tests/WebDriver/Example/selenium.mdx
@@ -66,7 +66,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 
 `test/test.js`:
 
-```js
+```javascript
 const os = require('os');
 const path = require('path');
 const { expect } = require('chai');

--- a/src/content/docs/zh-cn/develop/Tests/mocking.md
+++ b/src/content/docs/zh-cn/develop/Tests/mocking.md
@@ -27,7 +27,7 @@ Tauri 提供 mockIPC 函数来拦截 IPC 请求。 您可以 [在此处][<code>m
 
 :::
 
-```js
+```javascript
 import { beforeAll, expect, test } from "vitest";
 import { randomFillSync } from "crypto";
 
@@ -59,7 +59,7 @@ test("invoke simple", async () => {
 
 有时您想跟踪有关 IPC 呼叫的更多信息; 调用了多少次命令？ 它被调用了吗？ 您可以将 [`mockIPC()`][] 与其他侦测和 mocking 工具来测试这一点：
 
-```js
+```javascript
 import { beforeAll, expect, test, vi } from "vitest";
 import { randomFillSync } from "crypto";
 
@@ -97,7 +97,7 @@ test("invoke", async () => {
 
 要模拟对 sidecar 或 shell 命令的 IPC 请求，当事件 `spawn()` 或 `execute()` 被调用时获取处理程序的 ID，并使用此 ID 返回给后端：
 
-```js
+```javascript
 mockIPC(async (cmd, args) => {
   if (args.message.cmd === 'execute') {
     const eventCallbackId = `_${args.message.onEventFn}`;
@@ -131,7 +131,7 @@ mockIPC(async (cmd, args) => {
 
 :::
 
-```js
+```javascript
 import { beforeAll, expect, test } from 'vitest';
 import { randomFillSync } from 'crypto';
 

--- a/src/content/docs/zh-cn/plugin/autostart.mdx
+++ b/src/content/docs/zh-cn/plugin/autostart.mdx
@@ -73,7 +73,7 @@ autostart 插件有 JavaScript 和 Rust 两种版本。
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { enable, isEnabled, disable } from '@tauri-apps/plugin-autostart';
 
 // 启用 autostart

--- a/src/content/docs/zh-cn/plugin/barcode-scanner.mdx
+++ b/src/content/docs/zh-cn/plugin/barcode-scanner.mdx
@@ -73,7 +73,7 @@ fn run() {
 
 条形码扫描器插件在 JavaScript 中可用。
 
-```js
+```javascript
 import { scan, Format } from '@tauri-apps/plugin-barcode-scanner';
 
 // `windowed: true` 实际上将 webview 设置为透明的

--- a/src/content/docs/zh-cn/plugin/cli.mdx
+++ b/src/content/docs/zh-cn/plugin/cli.mdx
@@ -211,7 +211,7 @@ CLI 有 JavaScript 和 Rust 两种版本。
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 
 const matches = await getMatches();

--- a/src/content/docs/zh-cn/plugin/clipboard.mdx
+++ b/src/content/docs/zh-cn/plugin/clipboard.mdx
@@ -68,7 +68,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 
 // 将内容写到剪贴板

--- a/src/content/docs/zh-cn/plugin/commands.mdx
+++ b/src/content/docs/zh-cn/plugin/commands.mdx
@@ -30,7 +30,7 @@ pub fn run() {
 
 现在，你可以从 JavaScript 代码中调用该命令。
 
-```js
+```javascript
 // 当使用 Tauri API 的 npm 包时
 import { invoke } from '@tauri-apps/api/core';
 
@@ -55,7 +55,7 @@ fn my_custom_command(invoke_message: String) {
 
 参数应该作为一个带有 camelCase 键的 JSON 对象传递。
 
-```js
+```javascript
 invoke('my_custom_command', { invokeMessage: 'Hello!' });
 ```
 
@@ -73,7 +73,7 @@ fn my_custom_command(invoke_message: String) {
 
 对应的 JavaScript 代码。
 
-```js
+```javascript
 invoke('my_custom_command', { invoke_message: 'Hello!' });
 ```
 
@@ -90,7 +90,7 @@ fn my_custom_command() -> String {
 
 `invoke` 函数返回一个 promise，其 resolve 接收一个返回值。
 
-```js
+```javascript
 invoke('my_custom_command').then((message) => console.log(message));
 ```
 
@@ -112,7 +112,7 @@ fn my_custom_command() -> Result<String, String> {
 
 如果命令返回错误，promise 将 reject，否则 resolve。
 
-```js
+```javascript
 invoke('my_custom_command')
   .then((message) => console.log(message))
   .catch((error) => console.error(error));
@@ -226,7 +226,7 @@ async fn my_custom_command(value: &str) -> Result<String, ()> {
 
 因为在 JavaScript 中调用这个命令会返回一个 promise，所以它的工作方式和其他命令一样。
 
-```js
+```javascript
 invoke('my_custom_command', { value: 'Hello, Async!' }).then(() =>
   console.log('Completed!')
 );
@@ -370,7 +370,7 @@ pub fn run() {
 }
 ```
 
-```js
+```javascript
 import { invoke } from '@tauri-apps/api/core';
 
 // 从 JavaScript 调用

--- a/src/content/docs/zh-cn/plugin/deep-linking.mdx
+++ b/src/content/docs/zh-cn/plugin/deep-linking.mdx
@@ -162,7 +162,7 @@ deep-link 有 JavaScript 和 Rust 两种版本。
 <Tabs>
   <TabItem label="JavaScript">
 
-```js
+```javascript
 import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 await onOpenUrl((urls) => {

--- a/src/content/docs/zh-cn/plugin/dialog.mdx
+++ b/src/content/docs/zh-cn/plugin/dialog.mdx
@@ -90,7 +90,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 
 显示一个带有 "Yes" 和 "No" 按钮的提问对话框。
 
-```js
+```javascript
 import { ask } from '@tauri-apps/plugin-dialog';
 
 // 创建 Yes/No 对话框
@@ -109,7 +109,7 @@ console.log(answer);
 
 显示一个带有 "Ok" 和 "Cancel" 按钮的提问对话框。
 
-```js
+```javascript
 import { confirm } from '@tauri-apps/plugin-dialog';
 
 // Creates a confirmation Ok/Cancel dialog
@@ -128,7 +128,7 @@ console.log(confirmation);
 
 一个带有 "Ok" 按钮的消息对话框。请注意，如果用户关闭对话框，它将返回 `false`。
 
-```js
+```javascript
 import { message } from '@tauri-apps/plugin-dialog';
 
 // Shows message
@@ -143,7 +143,7 @@ await message('File not found', { title: 'Tauri', type: 'error' });
 
 `multiple` 选项控制对话框是否允许多重选择，而 `directory` 则控制对话框是否允许目录选择。
 
-```js
+```javascript
 import { open } from '@tauri-apps/plugin-dialog';
 
 // Open a dialog
@@ -161,7 +161,7 @@ console.log(file);
 
 打开一个文件/目录保存对话框。
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 // Prompt to save a 'My Filter' with extension .png or .jpeg
 const path = await save({

--- a/src/content/docs/zh-cn/plugin/file-system.mdx
+++ b/src/content/docs/zh-cn/plugin/file-system.mdx
@@ -80,7 +80,7 @@ fs 插件有 JavaScript 和 Rust 两种版本。
 <Tabs>
   <TabItem label="JavaScript" >
 
-```js
+```javascript
 import { exists, BaseDirectory } from '@tauri-apps/plugin-fs';
 
 // 检查 `$APPDATA/avatar.png` 文件是否存在

--- a/src/content/docs/zh-cn/plugin/global-shortcut.mdx
+++ b/src/content/docs/zh-cn/plugin/global-shortcut.mdx
@@ -80,7 +80,7 @@ fn run() {
 <Tabs>
   <TabItem label="JavaScript" >
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 
 await register('CommandOrControl+Shift+C', () => {

--- a/src/content/docs/zh-cn/plugin/http-client.mdx
+++ b/src/content/docs/zh-cn/plugin/http-client.mdx
@@ -85,7 +85,7 @@ http 插件既有 JavaScript API 版本，也有 Rust [reqwest](https://docs.rs/
 
 2. 发送请求
 
-   ```js
+   ```javascript
    import { fetch } from '@tauri-apps/plugin-http';
 
    // Send a GET request

--- a/src/content/docs/zh-cn/plugin/logging.mdx
+++ b/src/content/docs/zh-cn/plugin/logging.mdx
@@ -100,7 +100,7 @@ pub fn run() {
 
 2. 然后，插件的所有 api 都可以通过 JavaScript 的 guest 绑定使用：
 
-```js
+```javascript
 import { trace, info, error, attachConsole } from '@tauri-apps/plugin-log';
 
 // 启用 TargetKind::Webview 后，这个函数将把日志打印到浏览器控制台

--- a/src/content/docs/zh-cn/plugin/notification.mdx
+++ b/src/content/docs/zh-cn/plugin/notification.mdx
@@ -86,7 +86,7 @@ import Stub from '@components/Stub.astro';
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import {
   isPermissionGranted,
   requestPermission,

--- a/src/content/docs/zh-cn/plugin/os-info.mdx
+++ b/src/content/docs/zh-cn/plugin/os-info.mdx
@@ -71,7 +71,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { platform } from '@tauri-apps/plugin-os';
 
 const currentPlatform = await platform();

--- a/src/content/docs/zh-cn/plugin/process.mdx
+++ b/src/content/docs/zh-cn/plugin/process.mdx
@@ -64,7 +64,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 
 // exits the app with the given status code

--- a/src/content/docs/zh-cn/plugin/shell.mdx
+++ b/src/content/docs/zh-cn/plugin/shell.mdx
@@ -79,7 +79,7 @@ Shell 插件有 JavaScript 和 Rust 两种版本。
 <Tabs>
 	<TabItem label="JavaScript" >
 
-```js
+```javascript
 import { Command } from '@tauri-apps/plugin-shell';
 
 let result = await Command.create('exec-sh', [

--- a/src/content/docs/zh-cn/plugin/store.mdx
+++ b/src/content/docs/zh-cn/plugin/store.mdx
@@ -76,7 +76,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 <Tabs>
 <TabItem label="JavaScript">
 
-```js
+```javascript
 import { Store } from '@tauri-apps/plugin-store';
 
 // Store 会在 JavaScript 绑定时自动加载。

--- a/src/content/docs/zh-cn/plugin/stronghold.mdx
+++ b/src/content/docs/zh-cn/plugin/stronghold.mdx
@@ -134,7 +134,7 @@ pub fn run() {
 
 Stronghold 插件可以在 JavaScript 中使用。
 
-```js
+```javascript
 import { Client, Stronghold } from '@tauri-apps/plugin-stronghold';
 import { appDataDir } from '@tauri-apps/api/path';
 

--- a/src/content/docs/zh-cn/plugin/upload.mdx
+++ b/src/content/docs/zh-cn/plugin/upload.mdx
@@ -68,7 +68,7 @@ _这个插件要求 Rust 版本至少是 **1.75**_
 
 下面是一个使用插件上传和下载文件的例子：
 
-```js
+```javascript
 import { upload } from '@tauri-apps/plugin-upload';
 
 upload(
@@ -79,7 +79,7 @@ upload(
 );
 ```
 
-```js
+```javascript
 import { download } from '@tauri-apps/plugin-upload';
 
 download(

--- a/src/content/docs/zh-cn/plugin/websocket.mdx
+++ b/src/content/docs/zh-cn/plugin/websocket.mdx
@@ -79,7 +79,7 @@ _这个插件要求 Rust 版本至少是 **1.75**_
 
 WebSocket 插件可以在 JavaScript 中使用。
 
-```js
+```javascript
 import WebSocket from '@tauri-apps/plugin-websocket';
 
 const ws = await WebSocket.connect('ws://127.0.0.1:8080');

--- a/src/content/docs/zh-cn/plugin/window-customization.mdx
+++ b/src/content/docs/zh-cn/plugin/window-customization.mdx
@@ -134,7 +134,7 @@ Tauri 提供了许多自定义应用程序窗口外观的选项。您可以创�
 
 使用下面的代码片段来实现按钮。
 
-```js
+```javascript
 import { Window } from '@tauri-apps/api/window';
 
 const appWindow = new Window('main');

--- a/src/content/docs/zh-cn/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/zh-cn/start/migrate/from-tauri-1.mdx
@@ -239,7 +239,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 const matches = await getMatches();
 ```
@@ -290,7 +290,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 await writeText('Tauri is awesome!');
 assert(await readText(), 'Tauri is awesome!');
@@ -348,7 +348,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 const filePath = await save({
   filters: [
@@ -414,7 +414,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
 await mkdir('db', { baseDir: BaseDirectory.AppLocalData });
 ```
@@ -472,7 +472,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');
@@ -537,7 +537,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { fetch } from '@tauri-apps/plugin-http';
 const response = await fetch(
   'https://raw.githubusercontent.com/tauri-apps/tauri/dev/package.json'
@@ -603,7 +603,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { sendNotification } from '@tauri-apps/plugin-notification';
 sendNotification('Tauri is awesome!');
 ```
@@ -787,7 +787,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { arch } from '@tauri-apps/plugin-os';
 const architecture = await arch();
 ```
@@ -842,7 +842,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 await exit(0);
 await relaunch();
@@ -901,7 +901,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { Command, open } from '@tauri-apps/plugin-shell';
 const output = await Command.create('echo', 'message').execute();
 
@@ -1090,7 +1090,7 @@ fn main() {
 }
 ```
 
-```js
+```javascript
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

To better support those venturing into Tauri with vanillajs, we include (commented out) import statements for each plugin. The imports are used from the `window` object instead of from the package, so this will improve visibility and discoverability.

Additionally, normalized on code blocks noting code type using `javascript` instead of `js` which improves searching for the code blocks while writing docs.
