### PR TITLE
fix(ci): update tauri dependencies in ci

### DIFF
--- a/src/content/docs/develop/Tests/WebDriver/ci.md
+++ b/src/content/docs/develop/Tests/WebDriver/ci.md
@@ -51,9 +51,11 @@ jobs:
           sudo apt-get install -y
           libgtk-3-dev
           libayatana-appindicator3-dev
-          libwebkit2gtk-4.0-dev
+          libwebkit2gtk-4.1-dev
           webkit2gtk-driver
           xvfb
+          libjavascriptcoregtk-4.1-dev
+          libsoup-3.0-dev
 
       # install the latest Rust stable
       - name: Rust stable

--- a/src/content/docs/develop/Tests/WebDriver/ci.md
+++ b/src/content/docs/develop/Tests/WebDriver/ci.md
@@ -54,8 +54,6 @@ jobs:
           libwebkit2gtk-4.1-dev
           webkit2gtk-driver
           xvfb
-          libjavascriptcoregtk-4.1-dev
-          libsoup-3.0-dev
 
       # install the latest Rust stable
       - name: Rust stable


### PR DESCRIPTION
#### Description

Hi! I was running a workflow in my repo to build tauri 2 project, and the workflow failed as some libraries not installed in `ubuntu-latest` when using example in [guide](https://v2.tauri.app/develop/tests/webdriver/ci/). After several tests, the workflow worked soon.

Look at: https://github.com/noctisynth/Grassator/pull/5 and my workflow file is in https://github.com/noctisynth/Grassator/blob/main/.github/workflows/build.yml.

Of course, I was not involved in the development of Tauri 2, and if this issue is due to some carelessness on my part, please forgive my recklessness to submit a pull request.

Thank you for your awesome work!