### PR TITLE
Update window customization guide

### DIFF
--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -143,7 +143,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 // when using `"withGlobalTauri": true`, you may use
 // const { getCurrentWindow } = window.__TAURI__.window;
 
-const appWindow = getCurrentWindow()
+const appWindow = getCurrentWindow();
 
 document
   .getElementById('titlebar-minimize')

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -138,11 +138,12 @@ Note that you may need to move the rest of your content down so that the titleba
 Use this code snippet to make the buttons work:
 
 ```javascript
-import { Window } from '@tauri-apps/api/window';
-// when using `"withGlobalTauri": true`, you may use
-// const { Window } = window.__TAURI__.window;
+import { getCurrentWindow } from '@tauri-apps/api/window';
 
-const appWindow = new Window('main');
+// when using `"withGlobalTauri": true`, you may use
+// const { getCurrentWindow } = window.__TAURI__.window;
+
+const appWindow = getCurrentWindow()
 
 document
   .getElementById('titlebar-minimize')
@@ -154,6 +155,8 @@ document
   .getElementById('titlebar-close')
   ?.addEventListener('click', () => appWindow.close());
 ```
+
+Note that if you are using rust for frontend, you can copy code above into `<script>` tag into your `index.html`.
 
 ### (macOS) Transparent Titlebar with Custom Window Background Color
 

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -156,7 +156,7 @@ document
   ?.addEventListener('click', () => appWindow.close());
 ```
 
-Note that if you are using rust for frontend, you can copy code above into `<script>` tag into your `index.html`.
+Note that if you are using a Rust-based frontend, you can copy the code above into a `<script>` element in your `index.html` file.
 
 ### (macOS) Transparent Titlebar with Custom Window Background Color
 


### PR DESCRIPTION
Guide had a mistake. To get appWindow you need to use `getCurrentWindow()` and not `new Window('main')`. I tested code with leptos and svelte frameworks. Both `import { getCurrentWindow } from '@tauri-apps/api/window';` and `const { Window } = window.__TAURI__.window;` worked with both frameworks. I want to note also that previous way of getting appWindow was working only with javascript frontend.
