### PR TITLE
sql: add `preload` config example for migrations

### DIFF
--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -221,7 +221,26 @@ fn main() {
 
 ### Applying Migrations
 
-Migrations are applied automatically when the plugin is initialized. The plugin runs these migrations against the database specified by the connection string. Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
+To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
+
+```json title="src-tauri/tauri.conf.json" {3-5}
+{
+  "plugins": {
+    "sql": {
+      "preload": ["sqlite:mydatabase.db"]
+    }
+  }
+}
+```
+
+Alternatively, the client side `load()` also runs the migrations for a given connection string:
+
+```ts
+import Database from "@tauri-apps/plugin-sql";
+const db = await Database.load("sqlite:mydatabase.db");
+```
+
+Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
 
 ### Migration Management
 

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -240,7 +240,7 @@ import Database from "@tauri-apps/plugin-sql";
 const db = await Database.load("sqlite:mydatabase.db");
 ```
 
-Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
+Ensure that the migrations are defined in the correct order and are safe to run multiple times.
 
 ### Migration Management
 


### PR DESCRIPTION
#### Description

- Updates the `tauri-plugin-sql` docs, adding a missing mention to the `preload` configuration option.

Relates to:
- https://github.com/tauri-apps/plugins-workspace/pull/1557
- https://github.com/tauri-apps/plugins-workspace/issues/509
- https://github.com/tauri-apps/plugins-workspace/issues/1555