### PR TITLE
Update calling rust from frontend

### DIFF
--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -47,6 +47,35 @@ const invoke = window.__TAURI__.invoke;
 invoke('my_custom_command');
 ```
 
+If you are using rust-based frontend and want to use `invoke()` without arguments,
+because rust doesn't support optional arguments,
+you will need to change code on your frontend from this:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+```
+
+to this
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    // invoke without arguments
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke_without_args(cmd: &str) -> JsValue;
+
+    // invoke with arguments (default)
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], js_name = invoke)]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+
+    // They need to have different names!
+}
+```
+
 ## Passing Arguments
 
 Your command handlers can take arguments:


### PR DESCRIPTION
Based on this [issue](https://github.com/tauri-apps/tauri/issues/10303). If you want `invoke()` in rust-based frontend without arguments and errors, you need to change frontend bindgen

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
