### PR TITLE
Update calling rust from frontend guide

### DIFF
--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -47,21 +47,10 @@ const invoke = window.__TAURI__.invoke;
 invoke('my_custom_command');
 ```
 
-If you are using rust-based frontend and want to use `invoke()` without arguments,
-because rust doesn't support optional arguments,
-you will need to change code on your frontend from this:
+When using a Rust frontend to call `invoke()` without arguments, you will need to change adapt your frontend code as below.
+The reason is that Rust doesn't support optional arguments.
 
-```rust
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
-    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
-}
-```
-
-to this
-
-```rust
+```rust ins={4-5}
 #[wasm_bindgen]
 extern "C" {
     // invoke without arguments

--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -47,7 +47,7 @@ const invoke = window.__TAURI__.invoke;
 invoke('my_custom_command');
 ```
 
-When using a Rust frontend to call `invoke()` without arguments, you will need to change adapt your frontend code as below.
+When using a Rust frontend to call `invoke()` without arguments, you will need to adapt your frontend code as below.
 The reason is that Rust doesn't support optional arguments.
 
 ```rust ins={4-5}

--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -47,6 +47,35 @@ const invoke = window.__TAURI__.invoke;
 invoke('my_custom_command');
 ```
 
+If you are using rust-based frontend and want to use `invoke()` without arguments,
+because rust doesn't support optional arguments,
+you will need to change code on your frontend from this:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+```
+
+to this
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    // invoke without arguments
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], js_name = invoke)]
+    async fn invoke_without_args(cmd: &str) -> JsValue;
+
+    // invoke with arguments (default)
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+
+    // They need to have different names!
+}
+```
+
 ## Passing Arguments
 
 Your command handlers can take arguments:


### PR DESCRIPTION
Based on this [issue](https://github.com/tauri-apps/tauri/issues/10303). If you want to `invoke()` in rust-based frontend without arguments and errors, you need to change frontend bindgen. I think it's good to mention this detail in docs.

