### PR TITLE
Fix: error[E0308]: mismatched types during cargo-xwin installation

### DIFF
--- a/docs/guides/building/cross-platform.md
+++ b/docs/guides/building/cross-platform.md
@@ -223,7 +223,7 @@ rustup target add x86_64-pc-windows-msvc
 Instead of setting the Windows SDKs up manually we will use [`cargo-xwin`] as Tauri's "runner":
 
 ```sh
-cargo install cargo-xwin
+cargo install --locked cargo-xwin
 ```
 
 By default `cargo-xwin` will download the Windows SDKs into a project-local folder. If you have multiple projects and want to share those files you can set the `XWIN_CACHE_DIR` environment variable with a path to the preferred location.


### PR DESCRIPTION
Updated to include the correct command for installing cargo-xwin

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
  This PR corrects the cargo-xwin installation command. With the previously written command, I was receiving the following error:
```
error[E0308]: mismatched types
   --> /home/sahil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-xwin-0.17.2/src/common.rs:642:40
    |
642 |         Ok(builder.tls_config(Arc::new(client_config)).build())
    |                               -------- ^^^^^^^^^^^^^ expected `ClientConfig`, found a different `ClientConfig`
    |                               |
    |                               arguments to this function are incorrect
    |
    = note: `ClientConfig` and `ClientConfig` have similar names, but are actually distinct types
note: `ClientConfig` is defined in crate `rustls`
   --> /home/sahil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.22.4/src/client/client_conn.rs:150:1
    |
150 | pub struct ClientConfig {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `ClientConfig` is defined in crate `rustls`
   --> /home/sahil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.11/src/client/client_conn.rs:157:1
    |
157 | pub struct ClientConfig {
    | ^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `rustls` are being used?
note: associated function defined here
   --> /home/sahil/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:392:12
    |
392 |     pub fn new(data: T) -> Arc<T> {
    |            ^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `cargo-xwin` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-xwin v0.17.2`, intermediate artifacts can be found at `/tmp/cargo-installXcKzK1`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
``` 
But then I checked the [documentation](https://github.com/rust-cross/cargo-xwin?tab=readme-ov-file#installation) of cargo-xwin crate and found that installation command uses a `--locked` flag which fixed this issue for me and I was successfully able to build the app.

Here's the documentation for reference: [Documentation](https://github.com/rust-cross/cargo-xwin?tab=readme-ov-file) - check the first command in Installation
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->
None
<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
