### PR TITLE
fixed typo in migrate

### DIFF
--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -1062,7 +1062,7 @@ The Rust `tauri::updater` and JavaScript `@tauri-apps/api-updater` APIs have bee
 tauri-plugin-updater = "2"
 ```
 
-2. Use in JavaScript of Rust project:
+2. Use in JavaScript or Rust project:
 
 <Tabs>
 <TabItem label="JavaScript">


### PR DESCRIPTION
#### Description
- fixing a small typo in migration guide
