### PR TITLE
Add Explanation on Dev Server Security

### DIFF
--- a/src/content/docs/develop/index.mdx
+++ b/src/content/docs/develop/index.mdx
@@ -18,11 +18,22 @@ import CommandTabs from '@components/CommandTabs.astro';
 
 ### 1. Start Your Dev server
 
-Now that you have [everything set up](../start/), you should start your application development server provided by your UI framework or bundler (assuming you're using one, of course). If you followed our guides you will have `beforeDevCommand` configured to do this for you in step 2.
+Now that you have [everything set up](../start/), you should start your application development server
+provided by your UI framework or bundler (assuming you're using one, of course).
+If you followed our guides you will have `beforeDevCommand` configured to do this for you in step 2.
 
 :::note
 
 Every framework has its own development tooling. It is outside of the scope of this document to cover them all or stay up to date.
+
+:::
+
+:::caution[Plain/Vanilla Dev Server Security]
+
+The built-in Tauri development server does not support mutual authentication
+or encryption. You should never use it for development on untrusted networks.
+See the [development server security considerations](/security/lifecycle#development-server)
+for a more detailed explanation.
 
 :::
 
@@ -41,7 +52,7 @@ Once Rust has finished building, the webview opens, displaying your web app. You
 
 Note that Tauri's APIs only work in your app windows, so once you start using them you won't be able to open your frontend in your system's browser anymore.
 
-:::caution[About Cargo.toml and Source Control]
+:::note[About Cargo.toml and Source Control]
 
 In your project repository, you **SHOULD** commit the `src-tauri/Cargo.lock` along with the `src-tauri/Cargo.toml` to git because Cargo uses the lockfile to provide deterministic builds. As a result, it is recommended that all applications check in their `Cargo.lock`. You **SHOULD NOT** commit the `src-tauri/target` folder or any of its contents.
 

--- a/src/content/docs/security/lifecycle.mdx
+++ b/src/content/docs/security/lifecycle.mdx
@@ -76,7 +76,7 @@ and you would be well off to address this head-on.
 Tauri application frontends can be developed using a number of web frameworks.
 Each of these frameworks usually ship their own development server, which is exposing
 the frontend assets via an open port to the local system or network.
-This allows the frontend to be hot-reloaded and debugged in the WebView or Browser. 
+This allows the frontend to be hot-reloaded and debugged in the WebView or Browser.
 
 In practice this connection is often neither encrypted nor authenticated by default.
 This is also the case for the built-in Tauri development server and exposes your
@@ -88,7 +88,7 @@ in the worst case.
 You should only develop on trusted networks where you can safely expose your
 development device. If this is not possible you MUST ensure that your development
 server uses **mutual** authentication and encryption (e.g. mTLS) for connections
-with your development devices. 
+with your development devices.
 
 :::note
 The built-in Tauri development server does not support

--- a/src/content/docs/security/lifecycle.mdx
+++ b/src/content/docs/security/lifecycle.mdx
@@ -71,6 +71,30 @@ which are usually considered to be attacks on direct dependencies of your projec
 However, a growing class of attacks in the wild directly target development machines,
 and you would be well off to address this head-on.
 
+### Development Server
+
+Tauri application frontends can be developed using a number of web frameworks.
+Each of these frameworks usually ship their own development server, which is exposing
+the frontend assets via an open port to the local system or network.
+This allows the frontend to be hot-reloaded and debugged in the WebView or Browser. 
+
+In practice this connection is often neither encrypted nor authenticated by default.
+This is also the case for the built-in Tauri development server and exposes your
+frontend and assets to the local network. Additionally, this allows attackers
+to push their own frontend code to development devices in the same network as the attacker.
+Depending on what kind of functionality is exposed this could lead to device compromise
+in the worst case.
+
+You should only develop on trusted networks where you can safely expose your
+development device. If this is not possible you MUST ensure that your development
+server uses **mutual** authentication and encryption (e.g. mTLS) for connections
+with your development devices. 
+
+:::note
+The built-in Tauri development server does not support
+mutual authentication and transport encryption at the moment and should not be used on untrusted networks.
+:::
+
 ### Harden Development machines
 
 Hardening your development systems depends on various factors and on your personal


### PR DESCRIPTION
This adds a section to the lifecycle security explaining how development servers for the frontend can be insecure and that the default vanilla dev server has no authentication or encryption.

It is also mentioned in the develop section.