### PR TITLE
[i18n-ignore] increase js-api  toc depth to 5

### DIFF
--- a/packages/js-api-generator/build.ts
+++ b/packages/js-api-generator/build.ts
@@ -158,6 +158,8 @@ function pageEventEnd(event: PageEvent<DeclarationReflection>) {
     'editUrl: false',
     'sidebar:',
     `  label: "${event.model.name.replace('@tauri-apps/plugin-', '')}"`,
+    'tableOfContents:',
+    '  maxHeadingLevel: 5',
     '---',
     '',
     event.contents,


### PR DESCRIPTION
increase toc for all generated js-api references to 5
closes  #2444

for store page:

with 6:
![image](https://github.com/user-attachments/assets/4dcca27c-a07f-451a-b2c0-6cad96e2e900)

with 5:
![image](https://github.com/user-attachments/assets/0b13bca8-841d-4f54-9782-9108c241a677)

with 4:
![image](https://github.com/user-attachments/assets/353c2bc4-7c86-4f65-876b-31c2398ce6ea)


note that other pages behaves differently, so they may be longer or shorter depending on its contents. I think that to avoid it would need a per page toc or something 