### PR TITLE
Clarify the new default permissions and how to use plugin permissions

### DIFF
--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -129,10 +129,9 @@ fn run() {
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json"
 {

--- a/src/content/docs/plugin/barcode-scanner.mdx
+++ b/src/content/docs/plugin/barcode-scanner.mdx
@@ -90,10 +90,9 @@ scan({ windowed: true, formats: [Format.QRCode] });
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/mobile.json"
 {

--- a/src/content/docs/plugin/cli.mdx
+++ b/src/content/docs/plugin/cli.mdx
@@ -269,10 +269,9 @@ fn run() {
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={6}
 {

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -208,10 +208,9 @@ fn run() {
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={9}
 {

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -131,9 +131,11 @@ See [@tauri-apps/plugin-fs - Security](/reference/javascript/fs/#security) for m
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
+
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={7-11}
 {

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -134,9 +134,11 @@ fn run() {
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
+
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={7-9}
 {

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -132,7 +132,7 @@ Install the log plugin to get started.
 
 By default, all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={6}
 {

--- a/src/content/docs/plugin/os-info.mdx
+++ b/src/content/docs/plugin/os-info.mdx
@@ -101,10 +101,9 @@ println!("Platform: {}", platform);
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={4-6}
 {

--- a/src/content/docs/plugin/positioner.mdx
+++ b/src/content/docs/plugin/positioner.mdx
@@ -136,10 +136,9 @@ let _ = win.as_ref().window().move_window(Position::TopRight);
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={4}
 {

--- a/src/content/docs/plugin/shell.mdx
+++ b/src/content/docs/plugin/shell.mdx
@@ -123,9 +123,11 @@ if output.status.success() {
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
+
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={6-23}
 {

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -250,10 +250,9 @@ Ensure that the migrations are defined in the correct order and are safe to run 
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={7-8}
 {

--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -144,7 +144,7 @@ pub fn run() {
 
 By default, all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={6-11}
 {

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -198,9 +198,11 @@ await store.remove(key);
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
+
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={8-14}
 {

--- a/src/content/docs/plugin/websocket.mdx
+++ b/src/content/docs/plugin/websocket.mdx
@@ -101,9 +101,11 @@ await ws.disconnect();
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
+
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={6}
 {

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -56,7 +56,7 @@ Add window permissions in capability file.
 
 By default, all plugin commands are blocked and cannot be accessed. You must define a list of permissions in your `capabilities` configuration.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information.
 
 ```json title="src-tauri/capabilities/main.json" ins={7-8}
 {

--- a/src/content/docs/plugin/window-state.mdx
+++ b/src/content/docs/plugin/window-state.mdx
@@ -133,10 +133,9 @@ window.restore_state(StateFlags::all()); // will restore the window's state from
 
 ## Permissions
 
-By default all plugin commands are blocked and cannot be accessed.
-You must define a list of permissions in your `capabilities` configuration.
+By default all potentially dangerous plugin commands and scopes are blocked and cannot be accessed. You must modify the permissions in your `capabilities` configuration to enable these.
 
-See [Permissions Overview](/security/permissions/) for more information.
+See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
 ```json title="src-tauri/capabilities/main.json" ins={4-5}
 {


### PR DESCRIPTION
Changes the the claim that all permissions are disabled by default to only non-destructive permissions are enabled by default.

Also links to capabilities section instead of permissions and adds a reference to the step by step guide to using plugin permissions.