### PR TITLE
Improvements in nextConfig's type

### DIFF
--- a/src/content/docs/start/frontend/nextjs.mdx
+++ b/src/content/docs/start/frontend/nextjs.mdx
@@ -78,11 +78,11 @@ Next.js is a meta framework for React. Learn more about Next.js at https://nextj
 
     ```ts
     // next.conf.mjs
-    /** @type {import('next').NextConfig} */
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';
 
+    /** @type {import('next').NextConfig} */
     const nextConfig = {
       // Ensure Next.js uses SSG instead of SSR
       // https://nextjs.org/docs/pages/building-your-application/deploying/static-exports

--- a/src/content/docs/zh-cn/start/frontend/nextjs.mdx
+++ b/src/content/docs/zh-cn/start/frontend/nextjs.mdx
@@ -78,11 +78,11 @@ Next.js 是一个基于 React 的元框架。要了解更多关于 Next.js 的�
 
     ```ts
     // next.conf.mjs
-    /** @type {import('next').NextConfig} */
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';
 
+    /** @type {import('next').NextConfig} */
     const nextConfig = {
       // 确保 Next.js 使用 SSG 而不是 SSR
       // https://nextjs.org/docs/pages/building-your-application/deploying/static-exports


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- This PR improves the type of `nextConfig` export value in `src/content/docs/start/frontend/nextjs.mdx` and `src/content/docs/zh-cn/start/frontend/nextjs.mdx` files. Previously the type was given to `isProd` constant.

    - In simple terms previously it was same as this -> `const isProd: NextConfig` which is wrong.
    - Now it is same as this -> `const nextConfig: NextConfig` which is necessary as developers should get type suggestions on the right constant when they want to change Next.js configuration.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
