### PR TITLE
Explain wen "typo"

### DIFF
--- a/src/content/docs/blog/tauri-2-0-0-release-candidate.mdx
+++ b/src/content/docs/blog/tauri-2-0-0-release-candidate.mdx
@@ -19,7 +19,7 @@ A simplified [TL;DR](#too-long-didnt-read) can be found at the end of this post.
 
 With this release candidate we want to communicate our expectations and timeline for the stable release.
 
-We have been asked countless times "_Wen Tauri 2.0?_" and always gave broad answers. Especially in open source projects overpromising can be a quick way to burn out developers and maintainers or lead to angry comments from disappointed adopters.
+We have been asked countless times "_[Wen](https://englishinprogress.net/blog/wen-instead-of-when/) Tauri 2.0?_" and always gave broad answers. Especially in open source projects overpromising can be a quick way to burn out developers and maintainers or lead to angry comments from disappointed adopters.
 
 This is one of the reasons for the long alpha and beta stage and why we waited with the release candidate, as we strive to get things right and simple to use.
 


### PR DESCRIPTION
Adding a link to explain why "wen" is also okay and not a typo due to language changes.
Supersedes [PR #2495](https://github.com/tauri-apps/tauri-docs/pull/2495).