### PR TITLE
Add SolidStart to list of Frontend guides

### DIFF
--- a/src/content/docs/start/frontend/solidstart.mdx
+++ b/src/content/docs/start/frontend/solidstart.mdx
@@ -6,5 +6,8 @@ tableOfContents:
   maxHeadingLevel: 5
 ---
 
-An integration guide for [SolidStart](https://start.solidjs.com/) with Tauri 2 can be found in this [repository](https://github.com/atilafassina/quantum/tree/main).
+The official meta-framework for SolidJS is called [SolidStart](https://start.solidjs.com/).
+
+### Community resources
+- Batteries included SolidStart app using Tauri 2 can be found in this [repository](https://github.com/atilafassina/quantum/tree/main).
 

--- a/src/content/docs/start/frontend/solidstart.mdx
+++ b/src/content/docs/start/frontend/solidstart.mdx
@@ -1,0 +1,10 @@
+---
+title: SolidStart
+i18nReady: true
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 5
+---
+
+An integration guide for [SolidStart](https://start.solidjs.com/) with Tauri 2 can be found in this [repository](https://github.com/atilafassina/quantum/tree/main).
+


### PR DESCRIPTION
This PR adds SolidStart to the list of framework guides.

<img width="1059" alt="Screenshot 2024-08-12 at 16 00 04" src="https://github.com/user-attachments/assets/83fd65a3-6de9-44b8-9aa0-9e8ed5c47c01">

