### PR TITLE
[i18n-ignore] Add trailing slash to state management url

### DIFF
--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -10,7 +10,7 @@ import PluginPermissions from '@components/PluginPermissions.astro';
 
 <PluginLinks plugin="store" />
 
-This plugin provides a persistent key-value store. This is one of many options to handle state in your application. See the [state management overview](/develop/state-management) for more information on additional options.
+This plugin provides a persistent key-value store. This is one of many options to handle state in your application. See the [state management overview](/develop/state-management/) for more information on additional options.
 
 This store will allow you to persist state to a file which can be saved and loaded on demand including between app restarts. Note that this process is asynchronous which will require handling it within your code. It can be used both in the webview or within Rust.
 

--- a/src/content/docs/zh-cn/develop/Plugins/index.mdx
+++ b/src/content/docs/zh-cn/develop/Plugins/index.mdx
@@ -466,4 +466,4 @@ fn main() {
 
 ## 管理状态
 
-插件可以像 Tauri 应用程序一样管理状态。阅读[状态管理指南](/develop/state-management)以获取更多信息。
+插件可以像 Tauri 应用程序一样管理状态。阅读[状态管理指南](/develop/state-management/)以获取更多信息。

--- a/src/content/docs/zh-cn/develop/Plugins/index.mdx
+++ b/src/content/docs/zh-cn/develop/Plugins/index.mdx
@@ -466,4 +466,4 @@ fn main() {
 
 ## 管理状态
 
-插件可以像 Tauri 应用程序一样管理状态。阅读[状态管理指南](/develop/state-management/)以获取更多信息。
+插件可以像 Tauri 应用程序一样管理状态。阅读[状态管理指南](/develop/state-management)以获取更多信息。


### PR DESCRIPTION
#### Description
Thanks for making Tauri!

Adds a trailing slash to state-management link so clicking on the url works.
- Closes #2570

#### Test results
**Before changes (on production):**
<details><summary>GIF</summary>

![CleanShot 2024-08-23 at 08 59 57](https://github.com/user-attachments/assets/6b0028ad-e14b-4c85-a8ec-0e5347425051)
</details>


**After changes (on localhost):**

<details><summary>GIF</summary>

![CleanShot 2024-08-23 at 08 54 13](https://github.com/user-attachments/assets/1506f8fa-02c7-4cf6-9c30-eb62645c0c02)
</details>

