### PR TITLE
docs: fix log target configuration examples

### DIFF
--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -195,7 +195,9 @@ To forward all your logs to the terminal, enable the `Stdout` or `Stderr` target
 
 ```rust
 tauri_plugin_log::Builder::new()
-  .target(tauri_plugin_log::TargetKind::Stdout)
+  .target(tauri_plugin_log::Target::new(
+    tauri_plugin_log::TargetKind::Stdout,
+  ))
   .build()
 ```
 
@@ -207,7 +209,9 @@ To view all your Rust logs in the webview console, enable the `Webview` target a
 
 ```rust
 tauri_plugin_log::Builder::new()
-  .target(tauri_plugin_log::TargetKind::Webview)
+  .target(tauri_plugin_log::Target::new(
+    tauri_plugin_log::TargetKind::Webview,
+  ))
   .build()
 ```
 
@@ -225,9 +229,11 @@ To write all logs to a file, you can use either the `LogDir` or the `Folder` tar
 
 ```rust
 tauri_plugin_log::Builder::new()
-  .target(tauri_plugin_log::TargetKind::LogDir {
-    file_name: Some("logs".to_string())
-  })
+  .target(tauri_plugin_log::Target::new(
+    tauri_plugin_log::TargetKind::LogDir {
+      file_name: Some("logs".to_string()),
+    },
+  ))
   .build()
 ```
 
@@ -246,10 +252,12 @@ The Folder target lets you write logs to a custom location in the filesystem.
 
 ```rust
 tauri_plugin_log::Builder::new()
-  .target(tauri_plugin_log::TargetKind::Folder {
-    path: std::path::PathBuf::from("/path/to/logs"),
-    file_name: None,
-  })
+  .target(tauri_plugin_log::Target::new(
+    tauri_plugin_log::TargetKind::Folder {
+      path: std::path::PathBuf::from("/path/to/logs"),
+      file_name: None,
+    },
+  ))
   .build()
 ```
 


### PR DESCRIPTION
#### Description
Fixes the examples of configuring a log target - the target function accepts a Target struct not the TargetKind enum.
This closes https://github.com/tauri-apps/tauri-docs/issues/2558