### PR TITLE
docs: fix some fn run miss pub

### DIFF
--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -55,7 +55,7 @@ Install the autostart plugin to get started.
 
             ```rust title="src-tauri/src/lib.rs" ins={5-6}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .setup(|app| {
                         #[cfg(desktop)]
@@ -109,7 +109,7 @@ use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_autostart::ManagerExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-fn run() {
+pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,

--- a/src/content/docs/plugin/barcode-scanner.mdx
+++ b/src/content/docs/plugin/barcode-scanner.mdx
@@ -56,7 +56,7 @@ Install the barcode-scanner plugin to get started.
 
           ```rust title="src-tauri/src/lib.rs" ins={5-6}
           #[cfg_attr(mobile, tauri::mobile_entry_point)]
-          fn run() {
+          pub fn run() {
               tauri::Builder::default()
                   .setup(|app| {
                       #[cfg(mobile)]

--- a/src/content/docs/plugin/biometric.mdx
+++ b/src/content/docs/plugin/biometric.mdx
@@ -45,7 +45,7 @@ Install the biometric plugin to get started.
 
             ```rust title="src-tauri/src/lib.rs" ins={5-6}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .setup(|app| {
                         #[cfg(mobile)]

--- a/src/content/docs/plugin/cli.mdx
+++ b/src/content/docs/plugin/cli.mdx
@@ -55,7 +55,7 @@ Install the CLI plugin to get started.
 
             ```rust title="src-tauri/src/lib.rs" ins={5-6}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .setup(|app| {
                         #[cfg(desktop)]
@@ -243,7 +243,7 @@ if (matches.subcommand?.name === 'run') {
 use tauri_plugin_cli::CliExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-fn run() {
+pub fn run() {
    tauri::Builder::default()
        .plugin(tauri_plugin_cli::init())
        .setup(|app| {

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -59,7 +59,7 @@ Install the deep-link plugin to get started.
 
           ```rust title="src-tauri/src/lib.rs" ins={4}
           #[cfg_attr(mobile, tauri::mobile_entry_point)]
-          fn run() {
+          pub fn run() {
               tauri::Builder::default()
                   .plugin(tauri_plugin_deep_link::init())
                   .run(tauri::generate_context!())
@@ -194,7 +194,7 @@ await onOpenUrl((urls) => {
 use tauri_plugin_deep_link::DeepLinkExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-fn run() {
+pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .setup(|app| {

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -55,7 +55,7 @@ Install the fs plugin to get started.
 
             ```rust title="src-tauri/src/lib.rs" ins={4}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
               tauri::Builder::default()
                 .plugin(tauri_plugin_fs::init())
                 .run(tauri::generate_context!())
@@ -100,7 +100,7 @@ await exists('avatar.png', { baseDir: BaseDirectory.AppData });
 use tauri_plugin_fs::FsExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-fn run() {
+pub fn run() {
   tauri::Builder::default()
       .plugin(tauri_plugin_fs::init())
       .setup(|app| {

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -56,7 +56,7 @@ Install the global-shortcut plugin to get started.
     2.  Modify `lib.rs` to initialize the plugin:
 
         ```rust title="src-tauri/src/lib.rs" ins={4-5}
-        fn run() {
+        pub fn run() {
             tauri::Builder::default()
                 .setup(|app| {
                     #[cfg(desktop)]
@@ -103,7 +103,7 @@ await register('CommandOrControl+Shift+C', () => {
   <TabItem label = "Rust" >
 
 ```rust title="src-tauri/src/lib.rs"
-fn run() {
+pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
             #[cfg(desktop)]

--- a/src/content/docs/plugin/localhost.mdx
+++ b/src/content/docs/plugin/localhost.mdx
@@ -77,7 +77,7 @@ The localhost plugin is available in Rust.
 ```rust title="src-tauri/src/lib.rs" {4} {7-14}
 use tauri::{webview::WebviewWindowBuilder, WebviewUrl};
 
-fn run() {
+pub fn run() {
   let port: u16 = 9527;
 
   tauri::Builder::default()

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -55,7 +55,7 @@ Install the log plugin to get started.
 
         ```rust title="src-tauri/src/lib.rs" ins={4}
         #[cfg_attr(mobile, tauri::mobile_entry_point)]
-        fn run() {
+        pub fn run() {
             tauri::Builder::default()
                 .plugin(tauri_plugin_log::Builder::new().build())
                 .run(tauri::generate_context!())

--- a/src/content/docs/plugin/nfc.mdx
+++ b/src/content/docs/plugin/nfc.mdx
@@ -57,7 +57,7 @@ Install the nfc plugin to get started.
 
           ```rust title="src-tauri/src/lib.rs" ins={5-6}
           #[cfg_attr(mobile, tauri::mobile_entry_point)]
-          fn run() {
+          pub fn run() {
               tauri::Builder::default()
                   .setup(|app| {
                       #[cfg(mobile)]

--- a/src/content/docs/plugin/persisted-scope.mdx
+++ b/src/content/docs/plugin/persisted-scope.mdx
@@ -58,7 +58,7 @@ Install the persisted-scope plugin to get started.
 
         ```rust title="src-tauri/src/lib.rs" ins={4}
         #[cfg_attr(mobile, tauri::mobile_entry_point)]
-        fn run() {
+        pub fn run() {
             tauri::Builder::default()
                 .plugin(tauri_plugin_persisted_scope::init())
                 .run(tauri::generate_context!())

--- a/src/content/docs/plugin/positioner.mdx
+++ b/src/content/docs/plugin/positioner.mdx
@@ -94,7 +94,7 @@ Additional setup is required to get tray-relative positions to work.
 
     2. Setup `on_tray_event` for positioner plugin:
     	```rust title="src-tauri/src/lib.rs" ins={4-12}
-    	fn run() {
+    	pub fn run() {
     		tauri::Builder::default()
     			.plugin(tauri_plugin_positioner::init())
     			// This is required to get tray-relative positions to work

--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -48,7 +48,7 @@ Install the Single Instance plugin to get started.
 
             ```rust title="lib.rs" ins={5-6}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .setup(|app| {
                         #[cfg(desktop)]

--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -50,7 +50,7 @@ Install the store plugin to get started.
 
             ```rust title="src-tauri/src/lib.rs" ins={4}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .plugin(tauri_plugin_store::Builder::new().build())
                     .run(tauri::generate_context!())

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -56,7 +56,7 @@ Install the stronghold plugin to get started.
 
     				```rust title="src-tauri/src/lib.rs" ins={4}
     				#[cfg_attr(mobile, tauri::mobile_entry_point)]
-    				fn run() {
+    				pub fn run() {
     						tauri::Builder::default()
     								.plugin(tauri_plugin_stronghold::Builder::new(|password| {}).build())
     								.run(tauri::generate_context!())

--- a/src/content/docs/plugin/updater.mdx
+++ b/src/content/docs/plugin/updater.mdx
@@ -49,7 +49,7 @@ Install the Tauri updater plugin to get started.
 
             ```rust title="lib.rs" ins={5-6}
             #[cfg_attr(mobile, tauri::mobile_entry_point)]
-            fn run() {
+            pub fn run() {
                 tauri::Builder::default()
                     .setup(|app| {
                         #[cfg(desktop)]
@@ -382,7 +382,7 @@ For more information see the [JavaScript API documentation].
 ```rust title="src-tauri/src/lib.rs"
 use tauri_plugin_updater::UpdaterExt;
 
-fn run() {
+pub fn run() {
   tauri::Builder::default()
     .setup(|app| {
       let handle = app.handle().clone();

--- a/src/content/docs/plugin/upload.mdx
+++ b/src/content/docs/plugin/upload.mdx
@@ -48,7 +48,7 @@ _This plugin requires a Rust version of at least **1.75**_
 
               ```rust title="src-tauri/src/lib.rs" ins={4}
               #[cfg_attr(mobile, tauri::mobile_entry_point)]
-              pb fn run() {
+              pub fn run() {
                 tauri::Builder::default()
                   .plugin(tauri_plugin_upload::init())
                     .run(tauri::generate_context!())

--- a/src/content/docs/plugin/window-customization.mdx
+++ b/src/content/docs/plugin/window-customization.mdx
@@ -188,7 +188,7 @@ Create the main window and change its background color:
     ```rust title="src-tauri/src/lib.rs"
     use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
-    fn run() {
+    pub run() {
     	tauri::Builder::default()
     		.setup(|app| {
     			let win_builder =


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

`lib.rb` should be `pub fn run()`. In the setup of plugin, many documents miss `pub`

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
