### PR TITLE
docs:fix the caution  in distribute/signing/linux 

### DIFF
--- a/src/content/docs/distribute/Signing/linux.mdx
+++ b/src/content/docs/distribute/Signing/linux.mdx
@@ -42,7 +42,9 @@ You can display the signature embedded in the AppImage by running the following 
 
 Note that you need to change the $APPNAME and $VERSION values with the correct ones based on your configuration.
 
-:::caution The signature is not verified
+:::caution 
+
+**The signature is not verified**
 
 AppImage does not validate the signature, so you can't rely on it to check whether the file has been tampered with or not.
 To validate the signature, you must provide an external tool for your users.


### PR DESCRIPTION
#### Description
The caution bubble was not showing correctly  in `distribute/signing/linux/ `
 because of the The signature is not verified! after `:::caution`
