### PR TITLE
fix: flatpak runtimes names

### DIFF
--- a/src/content/docs/distribute/flatpak.mdx
+++ b/src/content/docs/distribute/flatpak.mdx
@@ -54,7 +54,7 @@ dev-util/flatpak-builder
 **2. Install the Flatpak Runtime**
 
 ```shell
-flatpak install flathub org.Gnome.Platform//46 org.Gnome.Sdk//46
+flatpak install flathub org.gnome.Platform//46 org.gnome.Sdk//46
 ```
 
 **3. [Build the .deb of your tauri-app](https://deploy-preview-2279--tauri-v2.netlify.app/reference/config/#bundleconfig)**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Fix the flatpak runtimes names. They should be lower case or flatpak will not find the corresponding packages.