### PR TITLE
Specify that invoke is in window.__TAURI__.core

### DIFF
--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -70,7 +70,7 @@ import { invoke } from '@tauri-apps/api/core';
 
 // When using the Tauri global script (if not using the npm package)
 // Be sure to set `app.withGlobalTauri` in `tauri.conf.json` to true
-const invoke = window.__TAURI__.invoke;
+const invoke = window.__TAURI__.core.invoke;
 
 // Invoke the command
 invoke('my_custom_command');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->

Getting started with 2.0, I ran into an issue that `window.__TAURI__.invoke` did not exist. Examining the object, it is under `window.__TAURI__.core.invoke`. If this is new to 2.0, this change sets the documentation straight. If it is Windows specific or a personal problem of sorts, feel free to close this PR.

Thank you!

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
