### PR TITLE
[i18n-ignore] fix: missing slashes in href elements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -92,7 +92,7 @@ export default defineConfig({
         discord: 'https://discord.com/invite/tauri',
         twitter: 'https://twitter.com/TauriApps',
         mastodon: 'https://fosstodon.org/@TauriApps',
-        rss: `${site}/rss`,
+        rss: `${site}/rss/`,
       },
       components: {
         Header: './src/components/overrides/Header.astro',

--- a/src/content/docs/about/index.mdx
+++ b/src/content/docs/about/index.mdx
@@ -13,17 +13,17 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard
     title="Tauri Philosophy"
-    href="/about/philosophy"
+    href="/about/philosophy/"
     description="Learn more about the approach behind Tauri"
   />
   <LinkCard
     title="Governance"
-    href="/about/governance"
+    href="/about/governance/"
     description="Understand how the Tauri governance structure is setup"
   />
   <LinkCard
     title="Trademark"
-    href="/about/trademark"
+    href="/about/trademark/"
     description="Guidelines for using the Tauri trademark"
   />
 </CardGrid>

--- a/src/content/docs/concept/index.mdx
+++ b/src/content/docs/concept/index.mdx
@@ -22,7 +22,7 @@ Tauri has a variety of topics that are considered to be core concepts, things an
   />
   <LinkCard
     title="Security"
-    href="/security"
+    href="/security/"
     description="How Tauri enforces security practices."
   />
   <LinkCard

--- a/src/content/docs/distribute/index.mdx
+++ b/src/content/docs/distribute/index.mdx
@@ -20,27 +20,27 @@ Signing is required on most platforms. See the documentation for each platform f
 <CardGrid>
   <LinkCard
     title="macOS"
-    href="/distribute/signing/ios"
+    href="/distribute/signing/ios/"
     description="Code signing and notarization for macOS apps"
   />
   <LinkCard
     title="Windows"
-    href="/distribute/signing/ios"
+    href="/distribute/signing/ios/"
     description="Code signing Windows installers"
   />
   <LinkCard
     title="Linux"
-    href="/distribute/signing/ios"
+    href="/distribute/signing/ios/"
     description="Code signing Linux packages"
   />
   <LinkCard
     title="Android"
-    href="/distribute/signing/android"
+    href="/distribute/signing/android/"
     description="Code signing for Android"
   />
   <LinkCard
     title="iOS"
-    href="/distribute/signing/ios"
+    href="/distribute/signing/ios/"
     description="Code signing for iOS"
   />
 </CardGrid>
@@ -50,7 +50,7 @@ Signing is required on most platforms. See the documentation for each platform f
 <CardGrid>
   <LinkCard
     title="App Store"
-    href="/distribute/app-store"
+    href="/distribute/app-store/"
     description="Distribute iOS and macOS apps to the App Store"
   />
   <LinkCard
@@ -60,12 +60,12 @@ Signing is required on most platforms. See the documentation for each platform f
   />
   <LinkCard
     title="AUR"
-    href="/distribute/aur"
+    href="/distribute/aur/"
     description="Distribute using the Arch User Repository"
   />
   <LinkCard
     title="CrabNebula Cloud"
-    href="/distribute/crabnebula-cloud"
+    href="/distribute/crabnebula-cloud/"
     description="Distribute your app using CrabNebula"
   />
   <LinkCard
@@ -85,12 +85,12 @@ Signing is required on most platforms. See the documentation for each platform f
   />
   <LinkCard
     title="Microsoft Store"
-    href="/distribute/microsoft-store"
+    href="/distribute/microsoft-store/"
     description="Distribute Windows apps to the Microsoft Store"
   />
   <LinkCard
     title="RPM"
-    href="/distribute/rpm"
+    href="/distribute/rpm/"
     description="Distribute as an RPM package"
   />
   <LinkCard
@@ -100,7 +100,7 @@ Signing is required on most platforms. See the documentation for each platform f
   />
   <LinkCard
     title="Windows Installer"
-    href="/distribute/windows-installer"
+    href="/distribute/windows-installer/"
     description="Distribute installers for Windows"
   />
 </CardGrid>

--- a/src/content/docs/es/start/frontend/index.mdx
+++ b/src/content/docs/es/start/frontend/index.mdx
@@ -18,21 +18,21 @@ Si un framework no aparece en esta lista puede que funcione con Tauri sin necesi
 ## JavaScript
 
 <CardGrid>
-  <LinkCard title="Next.js" href="/start/frontend/nextjs" />
-  <LinkCard title="Nuxt" href="/start/frontend/nuxt" />
-  <LinkCard title="Qwik" href="/start/frontend/qwik" />
-  <LinkCard title="Svelte" href="/start/frontend/svelte" />
-  <LinkCard title="Vite" href="/start/frontend/vite" />
-  <LinkCard title="Webpack" href="/start/frontend/webpack" />
+  <LinkCard title="Next.js" href="/start/frontend/nextjs/" />
+  <LinkCard title="Nuxt" href="/start/frontend/nuxt/" />
+  <LinkCard title="Qwik" href="/start/frontend/qwik/" />
+  <LinkCard title="Svelte" href="/start/frontend/svelte/" />
+  <LinkCard title="Vite" href="/start/frontend/vite/" />
+  <LinkCard title="Webpack" href="/start/frontend/webpack/" />
 </CardGrid>
 
 ## Rust
 
 <CardGrid>
-  <LinkCard title="Leptos" href="/start/frontend/leptos" />
-  <LinkCard title="Sycamore" href="/start/frontend/sycamore" />
-  <LinkCard title="Trunk" href="/start/frontend/trunk" />
-  <LinkCard title="Yew" href="/start/frontend/yew" />
+  <LinkCard title="Leptos" href="/start/frontend/leptos/" />
+  <LinkCard title="Sycamore" href="/start/frontend/sycamore/" />
+  <LinkCard title="Trunk" href="/start/frontend/trunk/" />
+  <LinkCard title="Yew" href="/start/frontend/yew/" />
 </CardGrid>
 
 ## Checklist de Configuración

--- a/src/content/docs/fr/develop/Debug/index.mdx
+++ b/src/content/docs/fr/develop/Debug/index.mdx
@@ -8,11 +8,11 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard
     title="Débogage de l'application"
-    href="/fr/develop/Debug/application//"
+    href="/fr/develop/Debug/application/"
   />
-  <LinkCard title="Débogage dans VS Code" href="/fr/develop/Debug/vscode" />
+  <LinkCard title="Débogage dans VS Code" href="/fr/develop/Debug/vscode/" />
   <LinkCard
     title="Débogage dans RustRover"
-    href="/fr/develop/Debug/rustrover"
+    href="/fr/develop/Debug/rustrover/"
   />
 </CardGrid>

--- a/src/content/docs/fr/develop/index.mdx
+++ b/src/content/docs/fr/develop/index.mdx
@@ -12,6 +12,6 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
   />
   <LinkCard
     title="Mise à jour des dépendances"
-    href="/fr/guides/develop/updating-dependencies"
+    href="/fr/guides/develop/updating-dependencies/"
   />
 </CardGrid>

--- a/src/content/docs/fr/start/frontend/index.mdx
+++ b/src/content/docs/fr/start/frontend/index.mdx
@@ -19,21 +19,21 @@ Un framework manque à la liste ? Il peut fonctionner avec Tauri sans configurat
 ## JavaScript
 
 <CardGrid>
-  <LinkCard title="Next.js" href="/fr/start/frontend/nextjs" />
-  <LinkCard title="Nuxt" href="/fr/start/frontend/nuxt" />
-  <LinkCard title="Qwik" href="/fr/start/frontend/qwik" />
-  <LinkCard title="Svelte" href="/fr/start/frontend/svelte" />
-  <LinkCard title="Vite" href="/fr/start/frontend/vite" />
-  <LinkCard title="Webpack" href="/fr/start/frontend/webpack" />
+  <LinkCard title="Next.js" href="/fr/start/frontend/nextjs/" />
+  <LinkCard title="Nuxt" href="/fr/start/frontend/nuxt/" />
+  <LinkCard title="Qwik" href="/fr/start/frontend/qwik/" />
+  <LinkCard title="Svelte" href="/fr/start/frontend/svelte/" />
+  <LinkCard title="Vite" href="/fr/start/frontend/vite/" />
+  <LinkCard title="Webpack" href="/fr/start/frontend/webpack/" />
 </CardGrid>
 
 ## Rust
 
 <CardGrid>
-  <LinkCard title="Leptos" href="/fr/start/frontend/leptos" />
-  <LinkCard title="Sycamore" href="/fr/start/frontend/sycamore" />
-  <LinkCard title="Trunk" href="/fr/start/frontend/trunk" />
-  <LinkCard title="Yew" href="/fr/start/frontend/yew" />
+  <LinkCard title="Leptos" href="/fr/start/frontend/leptos/" />
+  <LinkCard title="Sycamore" href="/fr/start/frontend/sycamore/" />
+  <LinkCard title="Trunk" href="/fr/start/frontend/trunk/" />
+  <LinkCard title="Yew" href="/fr/start/frontend/yew/" />
 </CardGrid>
 
 ## Instructions de Configuration

--- a/src/content/docs/zh-cn/develop/Debug/index.mdx
+++ b/src/content/docs/zh-cn/develop/Debug/index.mdx
@@ -8,5 +8,8 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard title="应用调试" href="/zh-cn/develop/Debug/application/" />
   <LinkCard title="在 VS Code 中调试" href="/zh-cn/develop/debug/vscode/" />
-  <LinkCard title="在 RustRover 中调试" href="/zh-cn/develop/debug/rustrover/" />
+  <LinkCard
+    title="在 RustRover 中调试"
+    href="/zh-cn/develop/debug/rustrover/"
+  />
 </CardGrid>

--- a/src/content/docs/zh-cn/develop/Debug/index.mdx
+++ b/src/content/docs/zh-cn/develop/Debug/index.mdx
@@ -6,7 +6,7 @@ description: 调试工作流程的技巧和窍门
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
-  <LinkCard title="应用调试" href="/zh-cn/develop/Debug/application//" />
-  <LinkCard title="在 VS Code 中调试" href="/zh-cn/develop/debug/vscode" />
-  <LinkCard title="在 RustRover 中调试" href="/zh-cn/develop/debug/rustrover" />
+  <LinkCard title="应用调试" href="/zh-cn/develop/Debug/application/" />
+  <LinkCard title="在 VS Code 中调试" href="/zh-cn/develop/debug/vscode/" />
+  <LinkCard title="在 RustRover 中调试" href="/zh-cn/develop/debug/rustrover/" />
 </CardGrid>

--- a/src/content/docs/zh-cn/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/zh-cn/develop/Tests/WebDriver/index.mdx
@@ -41,10 +41,10 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard title="Setup" href="/zh-cn/tests/webdriver/example/" />
-  <LinkCard title="Selenium" href="/zh-cn/tests/webdriver/example/selenium" />
+  <LinkCard title="Selenium" href="/zh-cn/tests/webdriver/example/selenium/" />
   <LinkCard
     title="WebdriverIO"
-    href="/zh-cn/tests/webdriver/example/webdriverio"
+    href="/zh-cn/tests/webdriver/example/webdriverio/"
   />
 </CardGrid>
 
@@ -52,7 +52,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 The above examples also comes with a CI script to test with GitHub actions, but you may still be interested in the below WebDriver CI guide as it explains the concept a bit more.
 
-<LinkCard title="持续集成 (CI)" href="/start/test/webdriver/ci" />
+<LinkCard title="持续集成 (CI)" href="/start/test/webdriver/ci/" />
 
 [webdriver]: https://www.w3.org/TR/webdriver/
 [`tauri-driver`]: https://crates.io/crates/tauri-driver

--- a/src/content/docs/zh-cn/develop/Tests/index.mdx
+++ b/src/content/docs/zh-cn/develop/Tests/index.mdx
@@ -9,5 +9,5 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard title="Mocking" href="/zh-cn/guides/test/mocking/" />
-  <LinkCard title="WebDriver" href="/zh-cn/test/webdriver" />
+  <LinkCard title="WebDriver" href="/zh-cn/test/webdriver/" />
 </CardGrid>

--- a/src/content/docs/zh-cn/start/frontend/index.mdx
+++ b/src/content/docs/zh-cn/start/frontend/index.mdx
@@ -18,21 +18,21 @@ Tauri 与前端无关，支持大多数开箱即用的前端框架。但是，�
 ## JavaScript
 
 <CardGrid>
-  <LinkCard title="Next.js" href="/zh-cn/start/frontend/nextjs" />
-  <LinkCard title="Nuxt" href="/zh-cn/start/frontend/nuxt" />
-  <LinkCard title="Qwik" href="/zh-cn/start/frontend/qwik" />
-  <LinkCard title="Svelte" href="/zh-cn/start/frontend/svelte" />
-  <LinkCard title="Vite" href="/zh-cn/start/frontend/vite" />
-  <LinkCard title="Webpack" href="/zh-cn/start/frontend/webpack" />
+  <LinkCard title="Next.js" href="/zh-cn/start/frontend/nextjs/" />
+  <LinkCard title="Nuxt" href="/zh-cn/start/frontend/nuxt/" />
+  <LinkCard title="Qwik" href="/zh-cn/start/frontend/qwik/" />
+  <LinkCard title="Svelte" href="/zh-cn/start/frontend/svelte/" />
+  <LinkCard title="Vite" href="/zh-cn/start/frontend/vite/" />
+  <LinkCard title="Webpack" href="/zh-cn/start/frontend/webpack/" />
 </CardGrid>
 
 ## Rust
 
 <CardGrid>
-  <LinkCard title="Leptos" href="/zh-cn/start/frontend/leptos" />
-  <LinkCard title="Sycamore" href="/zh-cn/start/frontend/sycamore" />
-  <LinkCard title="Trunk" href="/zh-cn/start/frontend/trunk" />
-  <LinkCard title="Yew" href="/zh-cn/start/frontend/yew" />
+  <LinkCard title="Leptos" href="/zh-cn/start/frontend/leptos/" />
+  <LinkCard title="Sycamore" href="/zh-cn/start/frontend/sycamore/" />
+  <LinkCard title="Trunk" href="/zh-cn/start/frontend/trunk/" />
+  <LinkCard title="Yew" href="/zh-cn/start/frontend/yew/" />
 </CardGrid>
 
 ## 配置清单


### PR DESCRIPTION
#### Description

- This PR fixes an issue caused by missing slashes in the `href` elements. The slashes have been added to resolve the problem.
- Fixed Issue #2580 and  #2542 

- Similar PR #2605 