### PR TITLE
minor dialog doc fix

### DIFF
--- a/src/content/docs/plugin/dialog.mdx
+++ b/src/content/docs/plugin/dialog.mdx
@@ -166,7 +166,7 @@ const file = await open({
   directory: false,
 });
 console.log(file);
-// Prints file path and name to the console
+// Prints file path or URI
 ```
 
 {/* SAVE */}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

based on https://github.com/tauri-apps/plugins-workspace/compare/6c823ae31ab05239d72316f5be62fb20852cea86...01c913e83e2527ec0420d5128ec94082a9252e3b#diff-9d86380a01dc27c93ae6577dd2e63f37e0835eb909749a09d526c19c25a7659e


> The `open` function now returns a string representing either the file path or URI instead of an object.
> To read the file data, use the `fs` APIs.
