### PR TITLE
fix: rename starlight-toc component

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -13,12 +13,12 @@ const { labels, toc } = Astro.props;
 
 {
   toc && (
-    <starlight-toc data-min-h={toc.minHeadingLevel} data-max-h={toc.maxHeadingLevel}>
+    <tauri-starlight-toc data-min-h={toc.minHeadingLevel} data-max-h={toc.maxHeadingLevel}>
       <nav aria-labelledby="starlight__on-this-page">
         <h2 id="starlight__on-this-page">{labels['tableOfContents.onThisPage']}</h2>
         <TableOfContentsList toc={toc.items} collapseLevel={toc.collapseLevel} />
       </nav>
-    </starlight-toc>
+    </tauri-starlight-toc>
   )
 }
 

--- a/src/components/overrides/TableOfContents/starlight-toc.ts
+++ b/src/components/overrides/TableOfContents/starlight-toc.ts
@@ -107,4 +107,4 @@ export class StarlightTOC extends HTMLElement {
   }
 }
 
-customElements.define('starlight-toc', StarlightTOC);
+customElements.define('tauri-starlight-toc', StarlightTOC);


### PR DESCRIPTION
fixes `Uncaught NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry': the name "starlight-toc" has already been used with this registry`
