### PR TITLE
fix: Clarify Plugin Naming Convention

### DIFF
--- a/src/content/docs/develop/Plugins/index.mdx
+++ b/src/content/docs/develop/Plugins/index.mdx
@@ -28,11 +28,9 @@ A Tauri plugin is composed of a Cargo crate and an optional NPM package that pro
 
 ## Naming Convention
 
-{/* TODO: Add link to allowlist */}
+Tauri plugins have a prefix followed by the plugin name. The plugin name is specified on the plugin configuration under [`tauri.conf.json > plugins`](/reference/config/#pluginconfig).
 
-Tauri plugins have a prefix (`tauri-plugin-` prefix for the Rust crate name and `@tauri-apps/plugin-` for the NPM package) followed by the plugin name. The plugin name is specified on the plugin configuration under [`tauri.conf.json > plugins`](/reference/config/#pluginconfig) and on the allowlist configuration.
-
-By default Tauri prefixes your plugin crate with `tauri-plugin-`. This helps your plugin to be discovered by the Tauri community, but is not a requirement. When initializing a new plugin project, you must provide its name. The generated crate name will be `tauri-plugin-{plugin-name}` and the JavaScript NPM package name will be `tauri-plugin-{plugin-name}-api` (although we recommend using an [NPM scope](https://docs.npmjs.com/about-scopes) if possible). The Tauri naming convention for NPM packages is `@scope-name/plugin-{plugin-name}`.
+By default Tauri prefixes your plugin crate with `tauri-plugin-`. This helps your plugin to be discovered by the Tauri community and to be used with the Tauri CLI. When initializing a new plugin project, you must provide its name. The generated crate name will be `tauri-plugin-{plugin-name}` and the JavaScript NPM package name will be `tauri-plugin-{plugin-name}-api` (although we recommend using an [NPM scope](https://docs.npmjs.com/about-scopes) if possible). The Tauri naming convention for NPM packages is `@scope-name/plugin-{plugin-name}`.
 
 ## Initialize Plugin Project
 


### PR DESCRIPTION
Related to [Discsussion #9334](https://github.com/tauri-apps/tauri/discussions/9334) and clarifies that the prefix is a convention needed for our CLI tooling.
Fixes #2018 