### PR TITLE
docs: fix Distribute docs platform links

### DIFF
--- a/src/content/docs/distribute/index.mdx
+++ b/src/content/docs/distribute/index.mdx
@@ -20,17 +20,17 @@ Signing is required on most platforms. See the documentation for each platform f
 <CardGrid>
   <LinkCard
     title="macOS"
-    href="/distribute/signing/ios/"
+    href="/distribute/signing/macos/"
     description="Code signing and notarization for macOS apps"
   />
   <LinkCard
     title="Windows"
-    href="/distribute/signing/ios/"
+    href="/distribute/signing/windows/"
     description="Code signing Windows installers"
   />
   <LinkCard
     title="Linux"
-    href="/distribute/signing/ios/"
+    href="/distribute/signing/linux/"
     description="Code signing Linux packages"
   />
   <LinkCard


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
This PR fixes the Distribute > Overview page in the documentation to correctly link to the proper platform Code Signing pages. Currently: macOS, Windows and Linux all link to the iOS Code Signing page.
Related to #2583. I couldn't find an open issue.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
