### PR TITLE
fix(v1): Correct Debian Bundle Example Path

### DIFF
--- a/docs/guides/building/linux.md
+++ b/docs/guides/building/linux.md
@@ -41,7 +41,7 @@ To include custom files in the Debian package, you can provide a list of files o
       "deb": {
         "files": {
           "/usr/share/README.md": "../README.md", // copies the README.md file to /usr/share/README.md
-          "usr/share/assets": "../assets/" // copies the entire assets directory to /usr/share/assets
+          "/usr/share/assets": "../assets/" // copies the entire assets directory to /usr/share/assets
         }
       }
     }


### PR DESCRIPTION
Updates the Debian example bundling code block to use the correct path as mentioned in the code comment.