### PR TITLE
docs(plugins/global-shortcut): add ShortcutState usage

### DIFF
--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -108,7 +108,7 @@ pub fn run() {
         .setup(|app| {
             #[cfg(desktop)]
             {
-                use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+                use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
                 let ctrl_n_shortcut = Shortcut::new(Some(Modifiers::CONTROL), Code::KeyN);
                 app.handle().plugin(

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -115,7 +115,14 @@ pub fn run() {
                     tauri_plugin_global_shortcut::Builder::new().with_handler(move |_app, shortcut| {
                         println!("{:?}", shortcut);
                         if shortcut == &ctrl_n_shortcut {
-                            println!("Ctrl-N Detected!");
+                            match event.state() {
+                              ShortcutState::Pressed => {
+                                println!("Ctrl-N Pressed!");
+                              }
+                              ShortcutState::Released => {
+                                println!("Ctrl-N Released!");
+                              }
+                            }
                         }
                     })
                     .build(),

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -112,7 +112,7 @@ pub fn run() {
 
                 let ctrl_n_shortcut = Shortcut::new(Some(Modifiers::CONTROL), Code::KeyN);
                 app.handle().plugin(
-                    tauri_plugin_global_shortcut::Builder::new().with_handler(move |_app, shortcut| {
+                    tauri_plugin_global_shortcut::Builder::new().with_handler(move |_app, shortcut, event| {
                         println!("{:?}", shortcut);
                         if shortcut == &ctrl_n_shortcut {
                             match event.state() {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Add `ShortcutState` in the usage for making users know that there is an api to know whether the shortcut is pressed or released.

https://github.com/tauri-apps/plugins-workspace/issues/1748#issue-2511535398

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
