### PR TITLE
feat: enhance documentation for desktop-only plugins

### DIFF
--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -105,25 +105,29 @@ disable();
   <TabItem label="Rust">
 
 ```rust
-use tauri_plugin_autostart::MacosLauncher;
-use tauri_plugin_autostart::ManagerExt;
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::LaunchAgent,
-            Some(vec!["--flag1", "--flag2"]),
-        ))
         .setup(|app| {
-            // Get the autostart manager
-            let autostart_manager = app.autolaunch();
-            // Enable autostart
-            let _ = autostart_manager.enable();
-            // Check enable state
-            println!("registered for autostart? {}", autostart_manager.is_enabled().unwrap());
-            // Disable autostart
-            let _ = autostart_manager.disable();
+            #[cfg(desktop)]
+            {
+                use tauri_plugin_autostart::MacosLauncher;
+                use tauri_plugin_autostart::ManagerExt;
+
+                app.handle().plugin(tauri_plugin_autostart::init(
+                    MacosLauncher::LaunchAgent,
+                    Some(vec!["--flag1", "--flag2"]),
+                ));
+
+                // Get the autostart manager
+                let autostart_manager = app.autolaunch();
+                // Enable autostart
+                let _ = autostart_manager.enable();
+                // Check enable state
+                println!("registered for autostart? {}", autostart_manager.is_enabled().unwrap());
+                // Disable autostart
+                let _ = autostart_manager.disable();
+            }
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src/content/docs/plugin/positioner.mdx
+++ b/src/content/docs/plugin/positioner.mdx
@@ -55,7 +55,7 @@ If you only intend on moving the window from Rust code, you only need the depend
     			1. Run the following command in the `src-tauri` folder to add the plugin to the project's dependencies in `Cargo.toml`:
 
     				```sh frame=none
-    				cargo add tauri-plugin-positioner
+    				cargo add tauri-plugin-positioner --target 'cfg(any(target_os = "macos", windows, target_os = "linux"))'
     				```
 
     			2. Modify `lib.rs` to initialize the plugin:
@@ -64,7 +64,11 @@ If you only intend on moving the window from Rust code, you only need the depend
     				#[cfg_attr(mobile, tauri::mobile_entry_point)]
     				pub fn run() {
     						tauri::Builder::default()
-    								.plugin(tauri_plugin_positioner::init())
+    								.setup(|app| {
+    										#[cfg(desktop)]
+    										app.handle().plugin(tauri_plugin_positioner::init());
+    										Ok(())
+    								})
     								.run(tauri::generate_context!())
     								.expect("error while running tauri application");
     				}
@@ -96,14 +100,17 @@ Additional setup is required to get tray-relative positions to work.
     	```rust title="src-tauri/src/lib.rs" ins={4-12}
     	pub fn run() {
     		tauri::Builder::default()
-    			.plugin(tauri_plugin_positioner::init())
     			// This is required to get tray-relative positions to work
     			.setup(|app| {
-    				TrayIconBuilder::new()
-    					.on_tray_icon_event(|tray_handle, event| {
-    						tauri_plugin_positioner::on_tray_event(tray_handle.app_handle(), &event);
-    					})
-    					.build(app)?;
+    					#[cfg(desktop)]
+    					{
+    						app.handle().plugin(tauri_plugin_positioner::init());
+    							tauri::tray::TrayIconBuilder::new()
+    								.on_tray_icon_event(|tray_handle, event| {
+    									tauri_plugin_positioner::on_tray_event(tray_handle.app_handle(), &event);
+    								})
+    								.build(app)?;
+    					}
     				Ok(())
     			})
     			.run(tauri::generate_context!())

--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -74,9 +74,9 @@ The closure has three arguments:
 
   <Steps>
 
-1. **`app` :** The [AppHandle](https://docs.rs/tauri/latest/tauri/struct.AppHandle.html) of the application.
-2. **`args` :** The list of arguments, that was passed by the user to initiate this new instance.
-3. **`cwd` :** The Current Working Directory denotes the directory from which the new application instance was launched.
+1. **`app`:** The [AppHandle](https://docs.rs/tauri/2.0.0-rc/tauri/struct.AppHandle.html) of the application.
+2. **`args`:** The list of arguments, that was passed by the user to initiate this new instance.
+3. **`cwd`:** The Current Working Directory denotes the directory from which the new application instance was launched.
 
   </Steps>
 
@@ -96,10 +96,15 @@ By default, when you initiate a new instance while the application is already ru
 use tauri::{AppHandle, Manager};
 
 pub fn run() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+    let mut builder = ;tauri::Builder::default()
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             let _ = show_window(app);
-        }))
+        }));
+    }
+
+    builder
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -96,7 +96,7 @@ By default, when you initiate a new instance while the application is already ru
 use tauri::{AppHandle, Manager};
 
 pub fn run() {
-    let mut builder = ;tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
     #[cfg(desktop)]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {

--- a/src/content/docs/plugin/updater.mdx
+++ b/src/content/docs/plugin/updater.mdx
@@ -420,114 +420,128 @@ To notify the frontend of the download progress consider using a command with a 
   <summary>Updater command</summary>
 
 ```rust
-use std::sync::Mutex;
-use serde::Serialize;
-use tauri::{ipc::Channel, AppHandle, State};
-use tauri_plugin_updater::{Update, UpdaterExt};
+#[cfg(desktop)]
+mod app_updates {
+    use std::sync::Mutex;
+    use serde::Serialize;
+    use tauri::{ipc::Channel, AppHandle, State};
+    use tauri_plugin_updater::{Update, UpdaterExt};
 
-#[derive(Debug, thiserror::Error)]
-enum Error {
-  #[error(transparent)]
-  Updater(#[from] tauri_plugin_updater::Error),
-  #[error("there is no pending update")]
-  NoPendingUpdate,
-}
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error(transparent)]
+        Updater(#[from] tauri_plugin_updater::Error),
+        #[error("there is no pending update")]
+        NoPendingUpdate,
+    }
 
-impl Serialize for Error {
-  fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-  where
-    S: serde::Serializer,
-  {
-    serializer.serialize_str(self.to_string().as_str())
-  }
-}
-
-type Result<T> = std::result::Result<T, Error>;
-
-#[derive(Clone, Serialize)]
-#[serde(tag = "event", content = "data")]
-enum DownloadEvent {
-  #[serde(rename_all = "camelCase")]
-  Started {
-    content_length: Option<u64>,
-  },
-  #[serde(rename_all = "camelCase")]
-  Progress {
-    chunk_length: usize,
-  },
-  Finished,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct UpdateMetadata {
-  version: String,
-  current_version: String,
-}
-
-#[tauri::command]
-async fn fetch_update(
-  app: AppHandle,
-  pending_update: State<'_, PendingUpdate>,
-) -> Result<Option<UpdateMetadata>> {
-  let channel = "stable";
-  let url = url::Url::parse(&format!(
-    "https://cdn.myupdater.com/{{{{target}}}}-{{{{arch}}}}/{{{{current_version}}}}?channel={channel}",
-  )).expect("invalid URL");
-
-  let update = app
-    .updater_builder()
-    .endpoints(vec![url])
-    .build()?
-    .check()
-    .await?;
-
-  let update_metadata = update.as_ref().map(|update| UpdateMetadata {
-    version: update.version.clone(),
-    current_version: update.current_version.clone(),
-  });
-
-  *pending_update.0.lock().unwrap() = update;
-
-  Ok(update_metadata)
-}
-
-#[tauri::command]
-async fn install_update(pending_update: State<'_, PendingUpdate>, on_event: Channel<DownloadEvent>) -> Result<()> {
-  let Some(update) = pending_update.0.lock().unwrap().take() else {
-    return Err(Error::NoPendingUpdate);
-  };
-
-  let started = false;
-
-  update
-    .download_and_install(
-      |chunk_length, content_length| {
-        if !started {
-          let _ = on_event.send(DownloadEvent::Started { content_length });
-          started = true;
+    impl Serialize for Error {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_str(self.to_string().as_str())
         }
+    }
 
-        let _ = on_event.send(DownloadEvent::Progress { chunk_length });
-      },
-      || {
-        let _ = on_event.send(DownloadEvent::Finished);
-      },
-    )
-    .await?;
+    type Result<T> = std::result::Result<T, Error>;
 
-  Ok(())
+    #[derive(Clone, Serialize)]
+    #[serde(tag = "event", content = "data")]
+    pub enum DownloadEvent {
+        #[serde(rename_all = "camelCase")]
+        Started {
+            content_length: Option<u64>,
+        },
+        #[serde(rename_all = "camelCase")]
+        Progress {
+            chunk_length: usize,
+        },
+        Finished,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct UpdateMetadata {
+        version: String,
+        current_version: String,
+    }
+
+    #[tauri::command]
+    pub async fn fetch_update(
+        app: AppHandle,
+        pending_update: State<'_, PendingUpdate>,
+    ) -> Result<Option<UpdateMetadata>> {
+        let channel = "stable";
+        let url = url::Url::parse(&format!(
+            "https://cdn.myupdater.com/{{{{target}}}}-{{{{arch}}}}/{{{{current_version}}}}?channel={channel}",
+        )).expect("invalid URL");
+
+      let update = app
+          .updater_builder()
+          .endpoints(vec![url])
+          .build()?
+          .check()
+          .await?;
+
+      let update_metadata = update.as_ref().map(|update| UpdateMetadata {
+          version: update.version.clone(),
+          current_version: update.current_version.clone(),
+      });
+
+      *pending_update.0.lock().unwrap() = update;
+
+      Ok(update_metadata)
+    }
+
+    #[tauri::command]
+    pub async fn install_update(pending_update: State<'_, PendingUpdate>, on_event: Channel<DownloadEvent>) -> Result<()> {
+        let Some(update) = pending_update.0.lock().unwrap().take() else {
+            return Err(Error::NoPendingUpdate);
+        };
+
+        let started = false;
+
+        update
+            .download_and_install(
+                |chunk_length, content_length| {
+                    if !started {
+                        let _ = on_event.send(DownloadEvent::Started { content_length });
+                        started = true;
+                    }
+
+                    let _ = on_event.send(DownloadEvent::Progress { chunk_length });
+                },
+                || {
+                    let _ = on_event.send(DownloadEvent::Finished);
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    struct PendingUpdate(Mutex<Option<Update>>);
 }
-
-struct PendingUpdate(Mutex<Option<Update>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .plugin(tauri_plugin_process::init())
-    .plugin(tauri_plugin_updater::Builder::new().build())
-    .invoke_handler(tauri::generate_handler![fetch_update, install_update])
-    .manage(PendingUpdate(Mutex::new(None)))
+    tauri::Builder::default()
+        .plugin(tauri_plugin_process::init())
+        .setup(|app| {
+            #[cfg(desktop)]
+            {
+                app.handle().plugin(tauri_plugin_updater::Builder::new().build());
+                app.manage(app_updates::PendingUpdate(Mutex::new(None)));
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            #[cfg(desktop)]
+            app_updates::fetch_update,
+            #[cfg(desktop)]
+            app_updates::install_update
+        ])
 }
 ```
 

--- a/src/content/docs/plugin/window-state.mdx
+++ b/src/content/docs/plugin/window-state.mdx
@@ -50,7 +50,7 @@ Use your project's package manager to add the dependency:
     1. Run the following command in the `src-tauri` folder to add the plugin to the project's dependencies in `Cargo.toml`:
 
         ```sh frame=none
-        cargo add tauri-plugin-window-state
+        cargo add tauri-plugin-window-state --target 'cfg(any(target_os = "macos", windows, target_os = "linux"))'
         ```
 
     2.  Modify `lib.rs` to initialize the plugin:
@@ -59,7 +59,11 @@ Use your project's package manager to add the dependency:
         #[cfg_attr(mobile, tauri::mobile_entry_point)]
         pub fn run() {
             tauri::Builder::default()
-                .plugin(tauri_plugin_window_state::Builder::default().build())
+                .setup(|app| {
+                    #[cfg(desktop)]
+                    app.handle().plugin(tauri_plugin_window_state::Builder::default().build());
+                    Ok(())
+                })
                 .run(tauri::generate_context!())
                 .expect("error while running tauri application");
         }


### PR DESCRIPTION
usage should actually be behind the #[cfg(desktop)] flag
