### PR TITLE
fix(plugins/fs): fix watchImmediate example

### DIFF
--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -531,7 +531,7 @@ To watch a directory or file for changes, use the `watch` or `watchImmediate` fu
   `watchImmediate` immediately notifies listeners of an event:
 
   ```js
-  import { watch, BaseDirectory } from '@tauri-apps/plugin-fs';
+  import { watchImmediate, BaseDirectory } from '@tauri-apps/plugin-fs';
   await watchImmediate(
     'logs',
     (event) => {

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -532,7 +532,7 @@ To watch a directory or file for changes, use the `watch` or `watchImmediate` fu
 
   ```js
   import { watch, BaseDirectory } from '@tauri-apps/plugin-fs';
-  await watch(
+  await watchImmediate(
     'logs',
     (event) => {
       console.log('logs directory event', event);


### PR DESCRIPTION
#### Description
Changes the function used in the example for watchImmediate from `watch` to `watchImmediate`