### PR TITLE
docs: temporarily use `@next` for tauri in qwik guide

### DIFF
--- a/src/content/docs/start/frontend/qwik.mdx
+++ b/src/content/docs/start/frontend/qwik.mdx
@@ -42,9 +42,9 @@ This guide will walk you through creating your Tauri app using the Qwik web fram
 1.  ##### Add the Tauri CLI to your project
 
     <CommandTabs
-      npm="npm install -D @tauri-apps/cli"
-      yarn="yarn add -D @tauri-apps/cli"
-      pnpm="pnpm add -D @tauri-apps/cli"
+      npm="npm install -D @tauri-apps/cli@next"
+      yarn="yarn add -D @tauri-apps/cli@next"
+      pnpm="pnpm add -D @tauri-apps/cli@next"
     />
 
 1.  ##### Initiate a new Tauri project


### PR DESCRIPTION
the current version in v2 docs for qwik installs the old version of tauri, not v2

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
