### PR TITLE
docs: fix typo in `plugin/updater`

### DIFF
--- a/src/content/docs/plugin/updater.mdx
+++ b/src/content/docs/plugin/updater.mdx
@@ -148,7 +148,7 @@ On Windows, Tauri will create the normal MSI and NSIS installers inside the targ
 - `myapp-setup.exe` - The standard app bundle. It will be re-used by the updater.
 - `myapp-setup.exe.sig` - The signature of the update bundle.
 - `myapp.msi` - The standard app bundle. It will be re-used by the updater.
-- `myapp.msi.sig` - Tthe signature of the update bundle.
+- `myapp.msi.sig` - The signature of the update bundle.
 
 {''}
 


### PR DESCRIPTION
#### Description
Removed an extra `t` from word `The` on [page](https://github.com/tauri-apps/tauri-docs/blob/88466fc1ae4148f8d2973de9c232ac12dbb7aa7e/src/content/docs/plugin/updater.mdx#:~:text=msi.sig%20%2D-,Tthe,-signature%20of%20the)