### PR TITLE
docs: use typed config in mobile plugin example

### DIFF
--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -81,9 +81,18 @@ class ExamplePlugin(private val activity: Activity): Plugin(activity) {
 <TabItem label="iOS">
 
 ```swift
+struct Config: Decodable {
+  let timeout: Int?
+}
+
 class ExamplePlugin: Plugin {
+  var timeout: Int? = 3000
+
   @objc public override func load(webview: WKWebView) {
-    let timeout = self.config["timeout"] as? Int ?? 30
+    do {
+      let config = try parseConfig(Config.self)
+      self.timeout = config.timeout
+    } catch {}
   }
 }
 ```

--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -58,11 +58,21 @@ The plugin instance on mobile has a getter for the plugin configuration:
 import android.app.Activity
 import android.webkit.WebView
 import app.tauri.annotation.TauriPlugin
+import app.tauri.annotation.InvokeArg
+
+@InvokeArg
+class Config {
+    var timeout: Int? = 3000
+}
 
 @TauriPlugin
 class ExamplePlugin(private val activity: Activity): Plugin(activity) {
+  private var timeout: Int? = 3000
+
   override fun load(webView: WebView) {
-    val timeout = this.config.getInt("timeout", 30)
+    getConfig(Config::class.java).let {
+       this.timeout = it.timeout
+    }
   }
 }
 ```


### PR DESCRIPTION
fix:  mobile plugin get  config of plugins from tauri.conf.json

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->

> **I don't have a mac and can't change ios config code. Please improve it**
