### PR TITLE
fix: correct typo in deep-linking plugin Windows section

### DIFF
--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -357,7 +357,7 @@ which must be installed in the `/Applications` directory.
 
 #### Windows
 
-To trigger a deep link on Linux you can either open `<scheme>://url` in the browser or run the following command in the terminal:
+To trigger a deep link on Windows you can either open `<scheme>://url` in the browser or run the following command in the terminal:
 
 ```sh
 start <scheme>://url


### PR DESCRIPTION
#### Description

- Fixes a typo in the deep-linking documentation for v2 ("Linux" -> "Windows")