### PR TITLE
fix: commas in JSON code block

### DIFF
--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -213,9 +213,9 @@ See the [Capabilities Overview](/security/capabilities/) for more information an
 		"stronghold:allow-create-client",
 		"stronghold:allow-load-client",
 		"stronghold:allow-save",
-		"stronghold:allow-save-store-record"
+		"stronghold:allow-save-store-record",
 		"stronghold:allow-get-store-record",
-		"stronghold:allow-remove-store-record",
+		"stronghold:allow-remove-store-record"
 	]
 }
 ```

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -209,13 +209,13 @@ See the [Capabilities Overview](/security/capabilities/) for more information an
 	"windows": ["main"],
 	"permissions": [
 		"path:default",
-		"stronghold:allow-initialize",
 		"stronghold:allow-create-client",
-		"stronghold:allow-load-client",
-		"stronghold:allow-save",
-		"stronghold:allow-save-store-record",
 		"stronghold:allow-get-store-record",
-		"stronghold:allow-remove-store-record"
+		"stronghold:allow-initialize",
+		"stronghold:allow-load-client",
+		"stronghold:allow-remove-store-record",
+		"stronghold:allow-save",
+		"stronghold:allow-save-store-record"
 	]
 }
 ```

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -209,13 +209,13 @@ See the [Capabilities Overview](/security/capabilities/) for more information an
 	"windows": ["main"],
 	"permissions": [
 		"path:default",
-		"stronghold:allow-create-client",
-		"stronghold:allow-get-store-record",
 		"stronghold:allow-initialize",
+		"stronghold:allow-create-client",
 		"stronghold:allow-load-client",
-		"stronghold:allow-remove-store-record",
 		"stronghold:allow-save",
-		"stronghold:allow-save-store-record"
+		"stronghold:allow-save-store-record",
+		"stronghold:allow-get-store-record",
+		"stronghold:allow-remove-store-record"
 	]
 }
 ```


### PR DESCRIPTION
#### Description
- What does this PR change? Give us a brief description.
This PR addresses a comma-related issue in the V2 documentation that causes JSON formatting errors. Specifically: - a missing comma has been added; - an extraneous comma at the end of the JSON has been removed.
These changes ensure that the documentation's JSON syntax is valid and can be correctly parsed.

