### PR TITLE
feat(plugins): finalize Stronghold plugin docs

### DIFF
--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -85,18 +85,18 @@ The Stronghold plugin offers a default hash function using the [argon2] algorith
 use tauri::Manager;
 
 pub fn run() {
-		tauri::Builder::default()
-				.setup(|app| {
-						let salt_path = app
-								.path()
-								.app_local_data_dir()
-								.expect("could not resolve app local data path")
-								.join("salt.txt");
-						app.handle().plugin(tauri_plugin_stronghold::Builder::with_argon2(&salt_path).build())?;
-						Ok(())
-				})
-				.run(tauri::generate_context!())
-				.expect("error while running tauri application");
+    tauri::Builder::default()
+        .setup(|app| {
+            let salt_path = app
+                .path()
+                .app_local_data_dir()
+                .expect("could not resolve app local data path")
+                .join("salt.txt");
+            app.handle().plugin(tauri_plugin_stronghold::Builder::with_argon2(&salt_path).build())?;
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 ```
 
@@ -110,31 +110,30 @@ The password hash must contain exactly 32 bytes. This is a Stronghold requiremen
 
 ```rust title="src-tauri/src/lib.rs"
 pub fn run() {
-		tauri::Builder::default()
-				.plugin(
-						tauri_plugin_stronghold::Builder::new(|password| {
-								// Hash the password here with e.g. argon2, blake2b or any other secure algorithm
-								// Here is an example implementation using the `rust-argon2` crate for hashing the password
-								use argon2::{hash_raw, Config, Variant, Version};
+    tauri::Builder::default()
+        .plugin(
+            tauri_plugin_stronghold::Builder::new(|password| {
+                // Hash the password here with e.g. argon2, blake2b or any other secure algorithm
+                // Here is an example implementation using the `rust-argon2` crate for hashing the password
+                use argon2::{hash_raw, Config, Variant, Version};
 
-								let config = Config {
-										lanes: 4,
-										mem_cost: 10_000,
-										time_cost: 10,
-										variant: Variant::Argon2id,
-										version: Version::Version13,
-										..Default::default()
-								};
-								let salt = "your-salt".as_bytes();
-								let key =
-										hash_raw(password.as_ref(), salt, &config).expect("failed to hash password");
+                let config = Config {
+                    lanes: 4,
+                    mem_cost: 10_000,
+                    time_cost: 10,
+                    variant: Variant::Argon2id,
+                    version: Version::Version13,
+                    ..Default::default()
+                };
+                let salt = "your-salt".as_bytes();
+                let key = hash_raw(password.as_ref(), salt, &config).expect("failed to hash password");
 
-								key.to_vec()
-						})
-						.build(),
-				)
-				.run(tauri::generate_context!())
-				.expect("error while running tauri application");
+                key.to_vec()
+            })
+            .build(),
+        )
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 ```
 

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -1,10 +1,6 @@
 ---
 title: Stronghold
 description: Encrypted, secure database.
-sidebar:
-  badge:
-    text: WIP
-    variant: caution
 plugin: stronghold
 ---
 
@@ -17,7 +13,7 @@ import PluginPermissions from '@components/PluginPermissions.astro';
 
 <PluginLinks plugin={frontmatter.plugin} />
 
-Store secrets and keys using the [IOTA Stronghold](https://github.com/iotaledger/stronghold.rs) encrypted database and secure runtime.
+Store secrets and keys using the [IOTA Stronghold](https://github.com/iotaledger/stronghold.rs) secret management engine.
 
 ## Supported Platforms
 
@@ -79,7 +75,38 @@ Install the stronghold plugin to get started.
 
 ## Usage
 
+The plugin must be initialized with a password hash function, which takes the password string and must return a 32 bytes hash derived from it.
+
+### Initialize with argon2 password hash function
+
+The Stronghold plugin offers a default hash function using the [argon2] algorithm.
+
+```rust title="src-tauri/src/lib.rs"
+use tauri::Manager;
+
+pub fn run() {
+		tauri::Builder::default()
+				.setup(|app| {
+						let salt_path = app
+								.path()
+								.app_local_data_dir()
+								.expect("could not resolve app local data path")
+								.join("salt.txt");
+						app.handle().plugin(tauri_plugin_stronghold::Builder::with_argon2(&salt_path).build())?;
+						Ok(())
+				})
+				.run(tauri::generate_context!())
+				.expect("error while running tauri application");
+}
+```
+
 ### Initialize with custom password hash function
+
+Alternatively you can provide your own hash algorithm by using the `tauri_plugin_stronghold::Builder::new` constructor.
+
+:::note
+The password hash must contain exactly 32 bytes. This is a Stronghold requirement.
+:::
 
 ```rust title="src-tauri/src/lib.rs"
 pub fn run() {
@@ -106,27 +133,6 @@ pub fn run() {
 						})
 						.build(),
 				)
-				.run(tauri::generate_context!())
-				.expect("error while running tauri application");
-}
-```
-
-### Initialize with argon2 password hash function
-
-```rust title="src-tauri/src/lib.rs"
-use tauri::Manager;
-
-pub fn run() {
-		tauri::Builder::default()
-				.setup(|app| {
-						let salt_path = app
-								.path()
-								.app_local_data_dir()
-								.expect("could not resolve app local data path")
-								.join("salt.txt");
-						app.handle().plugin(tauri_plugin_stronghold::Builder::with_argon2(&salt_path).build())?;
-						Ok(())
-				})
 				.run(tauri::generate_context!())
 				.expect("error while running tauri application");
 }
@@ -220,3 +226,5 @@ See the [Capabilities Overview](/security/capabilities/) for more information an
 ```
 
 <PluginPermissions plugin={frontmatter.plugin} />
+
+[argon2]: https://docs.rs/rust-argon2/latest/argon2/

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -205,21 +205,11 @@ By default all potentially dangerous plugin commands and scopes are blocked and 
 
 See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
-```json title="src-tauri/capabilities/main.json" ins={8-14}
+```json title="src-tauri/capabilities/main.json" ins={4}
 {
-	"$schema": "../gen/schemas/desktop-schema.json",
-	"identifier": "main-capability",
-	"description": "Capability for the main window",
-	"windows": ["main"],
+	...,
 	"permissions": [
-		"path:default",
-		"stronghold:allow-initialize",
-		"stronghold:allow-create-client",
-		"stronghold:allow-load-client",
-		"stronghold:allow-save",
-		"stronghold:allow-save-store-record"
-		"stronghold:allow-get-store-record",
-		"stronghold:allow-remove-store-record",
+		"stronghold:default",
 	]
 }
 ```


### PR DESCRIPTION
This clarifies some requirements on the password hash function and cleans up its documentation page overall. It could use some additional cleanup on the API usage section (and include Rust API usage), but I don't think that's a requirement until we see more people using it - so far I've only seen a couple developers actively working with it.
