### PR TITLE
refactor(plugins): use global API usage from `window.__TAURI__`

### DIFF
--- a/src/content/docs/plugin/autostart.mdx
+++ b/src/content/docs/plugin/autostart.mdx
@@ -92,7 +92,7 @@ The autostart plugin is available in both JavaScript and Rust.
 ```javascript
 import { enable, isEnabled, disable } from '@tauri-apps/plugin-autostart';
 // when using `"withGlobalTauri": true`, you may use
-// const { enable, isEnabled, disable } = window.__TAURI_PLUGIN_AUTOSTART__;
+// const { enable, isEnabled, disable } = window.__TAURI__.autostart;
 
 // Enable autostart
 await enable();

--- a/src/content/docs/plugin/barcode-scanner.mdx
+++ b/src/content/docs/plugin/barcode-scanner.mdx
@@ -106,7 +106,7 @@ The barcode scanner plugin is available in JavaScript.
 ```javascript
 import { scan, Format } from '@tauri-apps/plugin-barcode-scanner';
 // when using `"withGlobalTauri": true`, you may use
-// const { scan, Format } = window.__TAURI_PLUGIN_BARCODE_SCANNER__;
+// const { scan, Format } = window.__TAURI__.barcodeScanner;
 
 // `windowed: true` actually sets the webview to transparent
 // instead of opening a separate view for the camera

--- a/src/content/docs/plugin/cli.mdx
+++ b/src/content/docs/plugin/cli.mdx
@@ -223,7 +223,7 @@ The CLI plugin is available in both JavaScript and Rust.
 ```javascript
 import { getMatches } from '@tauri-apps/plugin-cli';
 // when using `"withGlobalTauri": true`, you may use
-// const { getMatches } = window.__TAURI_PLUGIN_CLI_;
+// const { getMatches } = window.__TAURI__.cli;
 
 const matches = await getMatches();
 if (matches.subcommand?.name === 'run') {

--- a/src/content/docs/plugin/clipboard.mdx
+++ b/src/content/docs/plugin/clipboard.mdx
@@ -87,7 +87,7 @@ The clipboard plugin is available in both JavaScript and Rust.
 ```javascript
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 // when using `"withGlobalTauri": true`, you may use
-// const { writeText, readText } = window.__TAURI_PLUGIN_CLIPBOARD_MANAGER__;
+// const { writeText, readText } = window.__TAURI__.clipboardManager;
 
 // Write content to clipboard
 await writeText('Tauri is awesome!');

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -223,7 +223,7 @@ When a deep link triggers your app to be opened, the `onOpenUrl` callback is exe
 ```javascript
 import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
 // when using `"withGlobalTauri": true`, you may use
-// const { onOpenUrl } = window.__TAURI_PLUGIN_DEEP_LINK__;
+// const { onOpenUrl } = window.__TAURI__.deepLink;
 
 await onOpenUrl((urls) => {
   console.log('deep link:', urls);

--- a/src/content/docs/plugin/dialog.mdx
+++ b/src/content/docs/plugin/dialog.mdx
@@ -106,7 +106,7 @@ Shows a question dialog with `Yes` and `No` buttons.
 ```javascript
 import { ask } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
-// const { ask } = window.__TAURI_PLUGIN_DIALOG__;
+// const { ask } = window.__TAURI__.dialog;
 
 // Create a Yes/No dialog
 const answer = await ask('This action cannot be reverted. Are you sure?', {
@@ -127,7 +127,7 @@ Shows a question dialog with `Ok` and `Cancel` buttons.
 ```javascript
 import { confirm } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
-// const { confirm } = window.__TAURI_PLUGIN_DIALOG__;
+// const { confirm } = window.__TAURI__.dialog;
 
 // Creates a confirmation Ok/Cancel dialog
 const confirmation = await confirm(
@@ -148,7 +148,7 @@ Shows a message dialog with an `Ok` button. Keep in mind that if the user closes
 ```javascript
 import { message } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
-// const { message } = window.__TAURI_PLUGIN_DIALOG__;
+// const { message } = window.__TAURI__.dialog;
 
 // Shows message
 await message('File not found', { title: 'Tauri', kind: 'error' });
@@ -165,7 +165,7 @@ The `multiple` option controls whether the dialog allows multiple selection or n
 ```javascript
 import { open } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
-// const { open } = window.__TAURI_PLUGIN_DIALOG__;
+// const { open } = window.__TAURI__.dialog;
 
 // Open a dialog
 const file = await open({
@@ -185,7 +185,7 @@ Open a file/directory save dialog.
 ```javascript
 import { save } from '@tauri-apps/plugin-dialog';
 // when using `"withGlobalTauri": true`, you may use
-// const { save } = window.__TAURI_PLUGIN_DIALOG__;
+// const { save } = window.__TAURI__.dialog;
 
 // Prompt to save a 'My Filter' with extension .png or .jpeg
 const path = await save({

--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -84,7 +84,7 @@ The fs plugin is available in both JavaScript and Rust.
 ```javascript
 import { exists, BaseDirectory } from '@tauri-apps/plugin-fs';
 // when using `"withGlobalTauri": true`, you may use
-// const { exists, BaseDirectory } = window.__TAURI_PLUGIN_FS__;
+// const { exists, BaseDirectory } = window.__TAURI__.fs;
 
 // Check if the `$APPDATA/avatar.png` file exists
 await exists('avatar.png', { baseDir: BaseDirectory.AppData });

--- a/src/content/docs/plugin/global-shortcut.mdx
+++ b/src/content/docs/plugin/global-shortcut.mdx
@@ -93,7 +93,7 @@ The global-shortcut plugin is available in both JavaScript and Rust.
 ```javascript
 import { register } from '@tauri-apps/plugin-global-shortcut';
 // when using `"withGlobalTauri": true`, you may use
-// const { register } = window.__TAURI_PLUGIN_GLOBAL_SHORTCUT__;
+// const { register } = window.__TAURI__.globalShortcut;
 
 await register('CommandOrControl+Shift+C', () => {
   console.log('Shortcut triggered');

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -105,7 +105,7 @@ Install the log plugin to get started.
       attachLogger,
     } from '@tauri-apps/plugin-log';
     // when using `"withGlobalTauri": true`, you may use
-    // const { warn, debug, trace, info, error, attachConsole, attachLogger } = window.__TAURI_PLUGIN_LOG__;
+    // const { warn, debug, trace, info, error, attachConsole, attachLogger } = window.__TAURI__.log;
     ```
 
   </Steps>

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -109,7 +109,7 @@ import {
   sendNotification,
 } from '@tauri-apps/plugin-notification';
 // when using `"withGlobalTauri": true`, you may use
-// const { isPermissionGranted, requestPermission, sendNotification, } = window.__TAURI_PLUGIN_NOTIFICATION__;
+// const { isPermissionGranted, requestPermission, sendNotification, } = window.__TAURI__.notification;
 
 // Do you have permission to send a notification?
 let permissionGranted = await isPermissionGranted();

--- a/src/content/docs/plugin/os-info.mdx
+++ b/src/content/docs/plugin/os-info.mdx
@@ -90,7 +90,7 @@ With this plugin you can query multiple information from current operational sys
 ```javascript
 import { platform } from '@tauri-apps/plugin-os';
 // when using `"withGlobalTauri": true`, you may use
-// const { platform } = window.__TAURI_PLUGIN_OS__;
+// const { platform } = window.__TAURI__.os;
 
 const currentPlatform = await platform();
 console.log(currentPlatform);

--- a/src/content/docs/plugin/positioner.mdx
+++ b/src/content/docs/plugin/positioner.mdx
@@ -126,7 +126,7 @@ The plugin's APIs are available through the JavaScript guest bindings:
 ```javascript
 import { moveWindow, Position } from '@tauri-apps/plugin-positioner';
 // when using `"withGlobalTauri": true`, you may use
-// const { moveWindow, Position } = window.__TAURI_PLUGIN_POSITIONER__;
+// const { moveWindow, Position } = window.__TAURI__.positioner;
 
 moveWindow(Position.TopRight);
 ```

--- a/src/content/docs/plugin/process.mdx
+++ b/src/content/docs/plugin/process.mdx
@@ -84,7 +84,7 @@ The process plugin is available in both JavaScript and Rust.
 ```javascript
 import { exit, relaunch } from '@tauri-apps/plugin-process';
 // when using `"withGlobalTauri": true`, you may use
-// const { exit, relaunch } = window.__TAURI_PLUGIN_PROCESS__;
+// const { exit, relaunch } = window.__TAURI__.process;
 
 // exits the app with the given status code
 await exit(0);

--- a/src/content/docs/plugin/shell.mdx
+++ b/src/content/docs/plugin/shell.mdx
@@ -84,7 +84,7 @@ The shell plugin is available in both JavaScript and Rust.
 ```javascript
 import { Command } from '@tauri-apps/plugin-shell';
 // when using `"withGlobalTauri": true`, you may use
-// const { Command } = window.__TAURI_PLUGIN_SHELL__;
+// const { Command } = window.__TAURI__.shell;
 
 let result = await Command.create('exec-sh', [
   '-c',

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -115,7 +115,7 @@ The path is relative to [`tauri::api::path::BaseDirectory::AppConfig`](https://d
 ```javascript
 import Database from '@tauri-apps/plugin-sql';
 // when using `"withGlobalTauri": true`, you may use
-// const V = window.__TAURI_PLUGIN_SQL__;
+// const V = window.__TAURI__.sql;
 
 const db = await Database.load('sqlite:test.db');
 await db.execute('INSERT INTO ...');
@@ -127,7 +127,7 @@ await db.execute('INSERT INTO ...');
 
 import Database from '@tauri-apps/plugin-sql';
 // when using `"withGlobalTauri": true`, you may use
-// const Database = window.__TAURI_PLUGIN_SQL__;
+// const Database = window.__TAURI__.sql;
 
 const db = await Database.load('mysql://user:pass@host/database');
 await db.execute('INSERT INTO ...');

--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -78,7 +78,7 @@ Install the store plugin to get started.
 ```javascript
 import { Store } from '@tauri-apps/plugin-store';
 // when using `"withGlobalTauri": true`, you may use
-// const { Store } = window.__TAURI_PLUGIN_STORE__;
+// const { Store } = window.__TAURI__.store;
 
 // Store will be loaded automatically when used in JavaScript binding.
 const store = new Store('store.bin');

--- a/src/content/docs/plugin/stronghold.mdx
+++ b/src/content/docs/plugin/stronghold.mdx
@@ -139,7 +139,7 @@ The stronghold plugin is available in JavaScript.
 ```javascript
 import { Client, Stronghold } from '@tauri-apps/plugin-stronghold';
 // when using `"withGlobalTauri": true`, you may use
-// const { Client, Stronghold } = window.__TAURI_PLUGIN_STRONGHOLD__;
+// const { Client, Stronghold } = window.__TAURI__.stronghold;
 import { appDataDir } from '@tauri-apps/api/path';
 // when using `"withGlobalTauri": true`, you may use
 // const { appDataDir } = window.__TAURI__.path;

--- a/src/content/docs/plugin/upload.mdx
+++ b/src/content/docs/plugin/upload.mdx
@@ -84,7 +84,7 @@ Here's an example of how you can use the plugin to upload and download files:
 ```javascript
 import { upload } from '@tauri-apps/plugin-upload';
 // when using `"withGlobalTauri": true`, you may use
-// const { upload } = window.__TAURI_PLUGIN_UPLOAD__;
+// const { upload } = window.__TAURI__.upload;
 
 upload(
   'https://example.com/file-upload',
@@ -98,7 +98,7 @@ upload(
 ```javascript
 import { download } from '@tauri-apps/plugin-upload';
 // when using `"withGlobalTauri": true`, you may use
-// const { download } = window.__TAURI_PLUGIN_UPLOAD__;
+// const { download } = window.__TAURI__.upload;
 
 download(
   'https://example.com/file-download-link',

--- a/src/content/docs/plugin/websocket.mdx
+++ b/src/content/docs/plugin/websocket.mdx
@@ -84,7 +84,7 @@ The websocket plugin is available in JavaScript.
 ```javascript
 import WebSocket from '@tauri-apps/plugin-websocket';
 // when using `"withGlobalTauri": true`, you may use
-// const WebSocket = window.__TAURI_PLUGIN_WEBSOCKET__;
+// const WebSocket = window.__TAURI__.websocket;
 
 const ws = await WebSocket.connect('ws://127.0.0.1:8080');
 

--- a/src/content/docs/plugin/window-state.mdx
+++ b/src/content/docs/plugin/window-state.mdx
@@ -95,7 +95,7 @@ You can use `saveWindowState` to manually save the window state:
 ```javascript
 import { saveWindowState, StateFlags } from '@tauri-apps/plugin-window-state';
 // when using `"withGlobalTauri": true`, you may use
-// const { saveWindowState, StateFlags } = window.__TAURI_PLUGIN_WINDOW_STATE__;
+// const { saveWindowState, StateFlags } = window.__TAURI__.windowState;
 
 saveWindowState(StateFlags.ALL);
 ```
@@ -108,7 +108,7 @@ import {
   StateFlags,
 } from '@tauri-apps/plugin-window-state';
 // when using `"withGlobalTauri": true`, you may use
-// const { restoreStateCurrent, StateFlags } = window.__TAURI_PLUGIN_WINDOW_STATE__;
+// const { restoreStateCurrent, StateFlags } = window.__TAURI__.windowState;
 
 restoreStateCurrent(StateFlags.ALL);
 ```


### PR DESCRIPTION
follows the global API usage for Tauri itself, and is the intended way for accessing the plugin APIs injected in the window object directly when `withGlobalTauri` is true