### PR TITLE
fix: replace private field access with public method

### DIFF
--- a/src/content/docs/develop/_sections/frontend-listen.mdx
+++ b/src/content/docs/develop/_sections/frontend-listen.mdx
@@ -84,7 +84,7 @@ Global and webview-specific events are also delivered to listeners registered in
     tauri::Builder::default()
       .setup(|app| {
         app.listen("download-started", |event| {
-          if let Ok(payload) = serde_json::from_str::<DownloadStarted>(&event.data) {
+          if let Ok(payload) = serde_json::from_str::<DownloadStarted>(&event.payload()) {
             println!("downloading {}", payload.url);
           }
         });


### PR DESCRIPTION
#### Description

The example relied upon accessing a private field when there is a public method to access the data on a rust event listener event.