### PR TITLE
refactor: change NPM dependencies to install v1 instead of latest

### DIFF
--- a/blog/2022-09-15-tauri-1-1.mdx
+++ b/blog/2022-09-15-tauri-1-1.mdx
@@ -21,28 +21,28 @@ You can update the NPM dependencies with:
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
 ```
 
   </TabItem>

--- a/blog/2022-09-15-tauri-1-1.mdx
+++ b/blog/2022-09-15-tauri-1-1.mdx
@@ -110,19 +110,19 @@ In the 1.0 releases Tauri supports the `JSON` configuration format by default, a
 ```json title=tauri.conf.json
 {
   "build": {
-      "devPath": "http://localhost:8000",
-      "distDir": "../dist"
+    "devPath": "http://localhost:8000",
+    "distDir": "../dist"
   }
 }
 ```
 
 ```json5 title=tauri.conf.json5
 {
-  "build": {
-      // devServer URL (comments are allowed!)
-      "devPath": "http://localhost:8000",
-      "distDir": "../dist"
-  }
+  build: {
+    // devServer URL (comments are allowed!)
+    devPath: 'http://localhost:8000',
+    distDir: '../dist',
+  },
 }
 ```
 

--- a/blog/2022-11-08-tauri-1-2.mdx
+++ b/blog/2022-11-08-tauri-1-2.mdx
@@ -21,28 +21,28 @@ Make sure to update both NPM and Cargo dependencies to the 1.2.0 release. You ca
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
 ```
 
   </TabItem>

--- a/blog/2023-05-03-tauri-1-3.mdx
+++ b/blog/2023-05-03-tauri-1-3.mdx
@@ -23,21 +23,21 @@ Make sure to update both NPM and Cargo dependencies to the 1.3.0 release. You ca
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>

--- a/blog/2023-06-14-tauri-1-4.mdx
+++ b/blog/2023-06-14-tauri-1-4.mdx
@@ -23,28 +23,28 @@ Make sure to update both NPM and Cargo dependencies to the 1.4.0 release. You ca
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
 ```
 
   </TabItem>

--- a/docs/guides/development/updating-dependencies.md
+++ b/docs/guides/development/updating-dependencies.md
@@ -15,28 +15,28 @@ If you are using the `tauri` package:
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
 ```
 
   </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
@@ -15,28 +15,35 @@ Si vous utilisez le package `tauri` :
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
+```
+
+  </TabItem>
+  <TabItem value="Bun">
+
+```shell
+bun update @tauri-apps/cli @tauri-apps/api
 ```
 
   </TabItem>

--- a/i18n/it/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
@@ -15,28 +15,35 @@ If you are using the `tauri` package:
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
+```
+
+  </TabItem>
+  <TabItem value="Bun">
+
+```shell
+bun update @tauri-apps/cli @tauri-apps/api
 ```
 
   </TabItem>

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
@@ -15,28 +15,35 @@ import TabItem from '@theme/TabItem'
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-yarn upgrade @tauri-apps/cli @tauri-apps/api --latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-yarn up @tauri-apps/cli @tauri-apps/api
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-pnpm update @tauri-apps/cli @tauri-apps/api --latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
+```
+
+  </TabItem>
+  <TabItem value="Bun">
+
+```shell
+bun update @tauri-apps/cli @tauri-apps/api
 ```
 
   </TabItem>

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/development/updating-dependencies.md
@@ -15,28 +15,35 @@ import TabItem from '@theme/TabItem'
   <TabItem value="npm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+npm install @tauri-apps/cli@">1.0.0" @tauri-apps/api@">1.0.0"
 ```
 
   </TabItem>
   <TabItem value="Yarn Classic">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+yarn upgrade @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="Yarn Berry">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+yarn up @tauri-apps/cli@^1.0.0 @tauri-apps/api@^1.0.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```shell
-npm install @tauri-apps/cli@latest @tauri-apps/api@latest
+pnpm update @tauri-apps/cli@1 @tauri-apps/api@1
+```
+
+  </TabItem>
+  <TabItem value="Bun">
+
+```shell
+bun update @tauri-apps/cli @tauri-apps/api
 ```
 
   </TabItem>

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -71,7 +71,7 @@ export const InstallTauriCli = () => {
     <Tabs groupId="package-manager">
       <TabItem value="npm" default>
         <CodeBlock className="language-shell" language="shell">
-          npm install --save-dev @tauri-apps/cli
+          npm install --save-dev @tauri-apps/cli@"&gt;1.0.0"
         </CodeBlock>
         <div style={{ margin: 8 }}>
           For npm to detect Tauri correctly you need to add it to the "scripts"
@@ -89,22 +89,22 @@ export const InstallTauriCli = () => {
       </TabItem>
       <TabItem value="Yarn">
         <CodeBlock className="language-shell" language="shell">
-          yarn add -D @tauri-apps/cli
+          yarn add -D @tauri-apps/cli@^1.0.0
         </CodeBlock>
       </TabItem>
       <TabItem value="pnpm">
         <CodeBlock className="language-shell" language="shell">
-          pnpm add -D @tauri-apps/cli
+          pnpm add -D @tauri-apps/cli@1
         </CodeBlock>
       </TabItem>
       <TabItem value="Bun">
         <CodeBlock className="language-shell" language="shell">
-          bun add -D @tauri-apps/cli
+          bun add -D @tauri-apps/cli@1.0.0
         </CodeBlock>
       </TabItem>
       <TabItem value="Cargo">
         <CodeBlock className="language-shell" language="shell">
-          cargo install tauri-cli
+          cargo install tauri-cli --version "^1.0.0"
         </CodeBlock>
       </TabItem>
     </Tabs>
@@ -116,22 +116,22 @@ export const InstallTauriApi = () => {
     <Tabs groupId="package-manager">
       <TabItem value="npm" default>
         <CodeBlock className="language-shell" language="shell">
-          npm install @tauri-apps/api
+          npm install @tauri-apps/api@"&gt;1.0.0"
         </CodeBlock>
       </TabItem>
       <TabItem value="Yarn">
         <CodeBlock className="language-shell" language="shell">
-          yarn add @tauri-apps/api
+          yarn add @tauri-apps/api@^1.0.0
         </CodeBlock>
       </TabItem>
       <TabItem value="pnpm">
         <CodeBlock className="language-shell" language="shell">
-          pnpm add @tauri-apps/api
+          pnpm add @tauri-apps/api@1
         </CodeBlock>
       </TabItem>
       <TabItem value="Bun">
         <CodeBlock className="language-shell" language="shell">
-          bun add @tauri-apps/api
+          bun add @tauri-apps/api@1.0.0
         </CodeBlock>
       </TabItem>
     </Tabs>


### PR DESCRIPTION
we will launch v2 soon which will take over the `latest` tag, so the v1 instructions should properly use the v1 versions instead of latest
