### PR TITLE
Fix minor typo in System Tray docs

### DIFF
--- a/src/content/docs/plugin/system-tray.mdx
+++ b/src/content/docs/plugin/system-tray.mdx
@@ -22,7 +22,7 @@ tauri = { version = "2.0.0", features = [ "tray-icon" ] }
 
 The tray API is available in both JavaScript and Rust.
 
-### Creata a Tray Icon
+### Create a Tray Icon
 
 <Tabs>
 <TabItem label="JavaScript">


### PR DESCRIPTION
#### Description

Fixes a typo "Creata a Tray Icon" -> "Create a Tray Icon" located here https://v2.tauri.app/plugin/system-tray/#creata-a-tray-icon