### PR TITLE
docs: fix typo in blog/tauri-2.0

### DIFF
--- a/src/content/docs/blog/tauri-2.0.mdx
+++ b/src/content/docs/blog/tauri-2.0.mdx
@@ -440,7 +440,7 @@ We can not automatically migrate your Rust code, so make sure to go through the 
 
 ## Call To Action
 
-If you are familiar with Tauri and have used it already during your journey, please take your time to check out the [Github Discssions](https://github.com/tauri-apps/tauri/discussions), [Github Issues](https://github.com/tauri-apps/tauri/issues). Maybe you have already solved the issues your fellow newcomers to Tauri are experiencing right now.
+If you are familiar with Tauri and have used it already during your journey, please take your time to check out the [Github Discussions](https://github.com/tauri-apps/tauri/discussions), [Github Issues](https://github.com/tauri-apps/tauri/issues). Maybe you have already solved the issues your fellow newcomers to Tauri are experiencing right now.
 
 If you think that some of these problems you have seen are generic and should be documented somewhere we probably have the perfect place for it in our official [documentation](https://v2.tauri.app).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
Changes "Discssions" to "Discussions" in the [Call To Action](https://tauri.app/blog/tauri-20/#call-to-action) section of the 2.0 stable release blog post.