### PR TITLE
i18n(en): Fix a few missing steps for migration guide from Tauri v1 to v2

### DIFF
--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -89,6 +89,7 @@ Below is a summary of the changes from Tauri 1.0 to Tauri 2.0:
 - `tauri > systemTray` renamed to `app > trayIcon`.
 - `tauri > pattern` moved to `app > security > pattern`.
 - `tauri > bundle` moved top-level.
+- `tauri > bundle > identifier` moved to top-level object.
 - `tauri > bundle > dmg` moved to `bundle > macOS > dmg`
 - `tauri > bundle > deb` moved to `bundle > linux > deb`
 - `tauri > bundle > appimage` moved to `bundle > linux > appimage`

--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -1162,7 +1162,7 @@ tauri::Builder::default()
 
 ### Migrate to new Window API
 
-On the Rust side, `Window` was renamed to `WebviewWindow` and its builder `WindowBuilder` is now named `WebviewWindowBuilder`.
+On the Rust side, `Window` was renamed to `WebviewWindow`, its builder `WindowBuilder` is now named `WebviewWindowBuilder` and `WindowUrl` is now named `WebviewUrl`.
 
 Additionally, the `Manager::get_window` function was renamed to `get_webview_window` and
 the window's `parent_window` API was renamed to `parent_raw` to support a high level window parent API.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)"
- What does this PR change? Give us a brief description.
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

While following the steps described in the guide I noticed that a few breaking changes that required corresponding migration steps weren't mentioned in the guide. This PR aims to fix that.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
