### PR TITLE
Use @tauri-apps/cli@latest instead of @next

### DIFF
--- a/src/content/docs/es/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/es/start/migrate/from-tauri-1.mdx
@@ -53,13 +53,13 @@ fn main() {
 La CLI de Tauri v2 incluye un comando `migrate` que automatiza la mayor parte del proceso y te ayuda a finalizar la migración:
 
 <CommandTabs
-  npm="npm install @tauri-apps/cli@next
+  npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
-  cargo='cargo install tauri-cli --version "^2.0.0-rc" --locked
+  cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'
 />
 
@@ -183,7 +183,7 @@ El sistema de eventos fue rediseñado para ser más fácil de usar. En lugar de 
 
 - La función `emit` ahora emite el evento a todos los escuchadores de eventos.
 - Se agregó una nueva función `emit_to` para desencadenar un evento a un objetivo específico.
-- `emit_filter` ahora filtra en función de [`EventTarget`](https://docs.rs/tauri/2.0.0-rc/tauri/event/enum.EventTarget.html) en lugar de una ventana.
+- `emit_filter` ahora filtra en función de [`EventTarget`](https://docs.rs/tauri/2.0.0/tauri/event/enum.EventTarget.html) en lugar de una ventana.
 - Se renombró `listen_global` a `listen_any`. Ahora escucha todos los eventos independientemente de sus filtros y objetivos.
 
 ### Soporte Multiwebview
@@ -715,7 +715,7 @@ tauri::Builder::default()
     })
 ```
 
-`tauri::Builder::menu` ahora toma un cierre porque el menú necesita una instancia de Manager para ser construido. Consulta [la documentación](https://docs.rs/tauri/2.0.0-rc/tauri/struct.Builder.html#method.menu) para obtener más información.
+`tauri::Builder::menu` ahora toma un cierre porque el menú necesita una instancia de Manager para ser construido. Consulta [la documentación](https://docs.rs/tauri/2.0.0/tauri/struct.Builder.html#method.menu) para obtener más información.
 
 #### Eventos de Menú
 
@@ -1003,7 +1003,7 @@ Utiliza `tauri::tray::TrayIconBuilder` en lugar de `tauri::SystemTray`:
 let tray = tauri::tray::TrayIconBuilder::with_id("mi-bandeja").build(app)?;
 ```
 
-Consulta [TrayIconBuilder](https://docs.rs/tauri/2.0.0-rc/tauri/tray/struct.TrayIconBuilder.html) para más información.
+Consulta [TrayIconBuilder](https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html) para más información.
 
 #### Migrar a Menú
 

--- a/src/content/docs/fr/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/fr/start/migrate/from-tauri-1.mdx
@@ -16,9 +16,9 @@ Tauri v2 contient la commande `migrate` qui simplifie votre migration:
 <CommandTabs
   npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'

--- a/src/content/docs/reference/_cli.mdx
+++ b/src/content/docs/reference/_cli.mdx
@@ -15,9 +15,9 @@ The Tauri command line interface (CLI) is the way to interact with Tauri through
 You can add the Tauri CLI to your current project using your package manager of choice:
 
 <CommandTabs
-  npm="npm install --save-dev @tauri-apps/cli@next"
-  yarn="yarn add -D @tauri-apps/cli@next"
-  pnpm="pnpm add -D @tauri-apps/cli@next"
+  npm="npm install --save-dev @tauri-apps/cli@latest"
+  yarn="yarn add -D @tauri-apps/cli@latest"
+  pnpm="pnpm add -D @tauri-apps/cli@latest"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked'
 />
 

--- a/src/content/docs/start/create-project.mdx
+++ b/src/content/docs/start/create-project.mdx
@@ -86,9 +86,9 @@ The following example assumes you are creating a new project. If you've already 
     2. Then, install Tauri's CLI tool using your package manager of choice. If you are using `cargo` to install the Tauri CLI, you will have to install it globally.
 
         <CommandTabs
-            npm="npm install -D @tauri-apps/cli@next"
-            yarn="yarn add -D @tauri-apps/cli@next"
-            pnpm="pnpm add -D @tauri-apps/cli@next"
+            npm="npm install -D @tauri-apps/cli@latest"
+            yarn="yarn add -D @tauri-apps/cli@latest"
+            pnpm="pnpm add -D @tauri-apps/cli@latest"
             cargo='cargo install tauri-cli --version "^2.0.0" --locked'
         />
 

--- a/src/content/docs/start/frontend/qwik.mdx
+++ b/src/content/docs/start/frontend/qwik.mdx
@@ -42,9 +42,9 @@ This guide will walk you through creating your Tauri app using the Qwik web fram
 1.  ##### Add the Tauri CLI to your project
 
     <CommandTabs
-      npm="npm install -D @tauri-apps/cli@next"
-      yarn="yarn add -D @tauri-apps/cli@next"
-      pnpm="pnpm add -D @tauri-apps/cli@next"
+      npm="npm install -D @tauri-apps/cli@latest"
+      yarn="yarn add -D @tauri-apps/cli@latest"
+      pnpm="pnpm add -D @tauri-apps/cli@latest"
     />
 
 1.  ##### Initiate a new Tauri project

--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -53,11 +53,11 @@ fn main() {
 The Tauri v2 CLI includes a `migrate` command that automates most of the process and helps you finish the migration:
 
 <CommandTabs
-  npm="npm install @tauri-apps/cli@next
+  npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'

--- a/src/content/docs/start/migrate/from-tauri-2-beta.mdx
+++ b/src/content/docs/start/migrate/from-tauri-2-beta.mdx
@@ -15,11 +15,11 @@ This guide walks you through upgrading your Tauri 2.0 beta application to Tauri 
 The Tauri v2 CLI includes a `migrate` command that automates most of the process and helps you finish the migration:
 
 <CommandTabs
-  npm="npm install @tauri-apps/cli@next
+  npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'

--- a/src/content/docs/zh-cn/start/create-project.mdx
+++ b/src/content/docs/zh-cn/start/create-project.mdx
@@ -87,9 +87,9 @@ import CommandTabs from '@components/CommandTabs.astro';
     2. 接着，使用您选择的包管理器安装 Tauri 的 CLI 工具。如果您使用 `cargo` 来安装 Tauri CLI，您需要全局安装它。
 
         <CommandTabs
-            npm="npm install -D @tauri-apps/cli@next"
-            yarn="yarn add -D @tauri-apps/cli@next"
-            pnpm="pnpm add -D @tauri-apps/cli@next"
+            npm="npm install -D @tauri-apps/cli@latest"
+            yarn="yarn add -D @tauri-apps/cli@latest"
+            pnpm="pnpm add -D @tauri-apps/cli@latest"
             cargo='cargo install tauri-cli --version "^2.0.0" --locked'
         />
 

--- a/src/content/docs/zh-cn/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/zh-cn/start/migrate/from-tauri-1.mdx
@@ -54,11 +54,11 @@ fn main() {
 Tauri v2 的命令行工具包括一个 `migrate` 命令，可自动执行大部分流程，并帮助你完成迁移：
 
 <CommandTabs
-  npm="npm install @tauri-apps/cli@next
+  npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'

--- a/src/content/docs/zh-cn/start/migrate/from-tauri-2-beta.mdx
+++ b/src/content/docs/zh-cn/start/migrate/from-tauri-2-beta.mdx
@@ -15,11 +15,11 @@ import CommandTabs from '@components/CommandTabs.astro';
 Tauri v2 CLI 包含一个 `migrate` 命令，它自动化了大部分过程，并帮助您完成迁移。
 
 <CommandTabs
-  npm="npm install @tauri-apps/cli@next
+  npm="npm install @tauri-apps/cli@latest
     npm run tauri migrate"
-  yarn="yarn upgrade @tauri-apps/cli@next
+  yarn="yarn upgrade @tauri-apps/cli@latest
     yarn tauri migrate"
-  pnpm="pnpm update @tauri-apps/cli@next
+  pnpm="pnpm update @tauri-apps/cli@latest
     pnpm tauri migrate"
   cargo='cargo install tauri-cli --version "^2.0.0" --locked
     cargo tauri migrate'


### PR DESCRIPTION
Now that Tauri 2.0 is released, the tag `@latest` should be used to install the latest released Tauri 2.0 version of `@tauri-apps/cli`.

Cf https://www.npmjs.com/package/@tauri-apps/cli?activeTab=versions

Also replace `2.0.0-rc` by `2.0.0` in Spanish translation.
