### PR TITLE
fix: wrong JavaScript example in upload plugin

### DIFF
--- a/src/content/docs/zh-cn/plugin/upload.mdx
+++ b/src/content/docs/zh-cn/plugin/upload.mdx
@@ -79,7 +79,7 @@ import { upload } from '@tauri-apps/plugin-upload';
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`), // 上传进度时调用的回调函数
+  ({progress, total}) => console.log(`Uploaded ${progress} of ${total} bytes`), // 上传进度时调用的回调函数
   { 'Content-Type': 'text/plain' } // 与请求一起发送的可选头信息
 );
 ```
@@ -90,7 +90,7 @@ import { download } from '@tauri-apps/plugin-upload';
 download(
   'https://example.com/file-download-link',
   './path/to/save/my/file.txt',
-  (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`), // 下载进度时调用的回调函数
+  ({progress, total}) => console.log(`Downloaded ${progress} of ${total} bytes`), // 下载进度时调用的回调函数
   { 'Content-Type': 'text/plain' } // 与请求一起发送的可选头信息
 );
 ```

--- a/src/content/docs/zh-cn/plugin/upload.mdx
+++ b/src/content/docs/zh-cn/plugin/upload.mdx
@@ -79,7 +79,8 @@ import { upload } from '@tauri-apps/plugin-upload';
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  ({progress, total}) => console.log(`Uploaded ${progress} of ${total} bytes`), // 上传进度时调用的回调函数
+  ({ progress, total }) =>
+    console.log(`Uploaded ${progress} of ${total} bytes`), // 上传进度时调用的回调函数
   { 'Content-Type': 'text/plain' } // 与请求一起发送的可选头信息
 );
 ```
@@ -90,7 +91,8 @@ import { download } from '@tauri-apps/plugin-upload';
 download(
   'https://example.com/file-download-link',
   './path/to/save/my/file.txt',
-  ({progress, total}) => console.log(`Downloaded ${progress} of ${total} bytes`), // 下载进度时调用的回调函数
+  ({ progress, total }) =>
+    console.log(`Downloaded ${progress} of ${total} bytes`), // 下载进度时调用的回调函数
   { 'Content-Type': 'text/plain' } // 与请求一起发送的可选头信息
 );
 ```


### PR DESCRIPTION
#### Description
upload plugin uses [ProgressHandler](https://github.com/tauri-apps/plugins-workspace/blob/7e1c17a635f10d69e10ea9f35081a68c71276203/plugins/upload/guest-js/index.ts#L7) as a parameter, which needs destructuring assignment in order to get its two parameters, `progress` and `total`.