### PR TITLE
Update http-client.mdx

### DIFF
--- a/src/content/docs/plugin/http-client.mdx
+++ b/src/content/docs/plugin/http-client.mdx
@@ -81,7 +81,7 @@ The HTTP plugin is available in both Rust as a [reqwest](https://docs.rs/reqwest
 1.  Configure the allowed URLs
 
     ```json
-    //src-tauri/capabilities/base.json
+    //src-tauri/capabilities/default.json
     {
       "permissions": [
         {


### PR DESCRIPTION
The default capability file isn't called "base.json" its "default.json"

