### PR TITLE
fix: add missing frontmatter in persisted-scope

### DIFF
--- a/src/content/docs/zh-cn/plugin/persisted-scope.mdx
+++ b/src/content/docs/zh-cn/plugin/persisted-scope.mdx
@@ -1,6 +1,7 @@
 ---
 title: 持久化作用域（Persisted Scope）
 description: 将运行时作用域的更改持久化到文件系统上。
+plugin: persisted-scope
 ---
 
 import PluginLinks from '@components/PluginLinks.astro';


### PR DESCRIPTION
`plugin: persisted-scope` is missing in `src/content/docs/zh-cn/plugin/persisted-scope.mdx`, which led to [invalid links](https://tauri.app/zh-cn/plugin/persisted-scope/) in the description.