### PR TITLE
i18n(zh-cn): Update `deep-linking.mdx`  following the update of `deep-linking`'s `configuration`

### DIFF
--- a/src/content/docs/zh-cn/plugin/deep-linking.mdx
+++ b/src/content/docs/zh-cn/plugin/deep-linking.mdx
@@ -146,10 +146,13 @@ fn run() {
 {
   "plugins": {
     "deep-link": {
-      "domains": [
+      "mobile": [
         { "host": "your.website.com", "pathPrefix": ["/open"] },
         { "host": "another.site.br" }
-      ]
+      ],
+      "desktop": {
+        "schemes": ["something", "my-tauri-app"]
+      }
     }
   }
 }


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
The latest configuration of the `deep-linking` plugin has changed, but the `zh-cn` translation still follows the old configuration format.

Current configuration:
```json
{
  "plugins": {
    "deep-link": {
      "domains": [
        { "host": "your.website.com", "pathPrefix": ["/open"] },
        { "host": "another.site.br" }
      ]
    }
  }
}
```
Modify to:
```json
{
  "plugins": {
    "deep-link": {
      "mobile": [
        { "host": "your.website.com", "pathPrefix": ["/open"] },
        { "host": "another.site.br" }
      ],
      "desktop": {
        "schemes": ["something", "my-tauri-app"]
      }
    }
  }
}
```

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
