### PR TITLE
Fix hover color for links outside the header

### DIFF
--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -121,7 +121,7 @@ const links: Link[] = [
 		color: var(--sl-color-gray-2);
 	}
 	:root[data-theme='light'] {
-		a:hover {
+		.header a:hover {
 			color: var(--sl-color-gray-3);
 		}
 	}


### PR DESCRIPTION
#### Description
Fix hover color for links outside the header

Using the light theme, all links with `:hover` are grey, which renders with a very poor contrast. This gray color should be only for links in the header, as it was most certainly intended.

Before (home page):
![image](https://github.com/user-attachments/assets/559a40c6-d85f-47e1-8f81-11dd183a8193)

After (home page): 
![image](https://github.com/user-attachments/assets/d2427df2-ae6d-45a1-9b9c-789647169c85)

Before (navbar):
![image](https://github.com/user-attachments/assets/910fb7f9-ab2f-439e-ae38-8da8fb03a32d)

After (navbar):
![image](https://github.com/user-attachments/assets/352d0422-dc94-40fd-875b-2f249e9b10ae)
