### PR TITLE
Update References > Rust (docs.rs) to point to latest API doc

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -308,7 +308,7 @@ export default defineConfig({
             },
             {
               label: 'Rust (docs.rs)',
-              link: 'https://docs.rs/tauri/2.0.0-rc/tauri/index.html',
+              link: 'https://docs.rs/tauri/~2/',
             },
           ],
         },


### PR DESCRIPTION
#### Description

Update the target of the navbar link `References` > `Rust (docs.rs)` to point to the latest version of Tauri matching `~2`, instead of `2.0.0-rc`.

Cf. https://docs.rs/about/redirections