### PR TITLE
TypeScript error fix for NextJS 15

### DIFF
--- a/src/content/docs/start/frontend/nextjs.mdx
+++ b/src/content/docs/start/frontend/nextjs.mdx
@@ -94,7 +94,7 @@ Next.js is a meta framework for React. Learn more about Next.js at https://nextj
         unoptimized: true,
       },
       // Configure assetPrefix or else the server won't properly resolve your assets.
-      assetPrefix: isProd ? null : `http://${internalHost}:3000`,
+      assetPrefix: isProd ? undefined : `http://${internalHost}:3000`,
     };
 
     export default nextConfig;


### PR DESCRIPTION
#### Description

Documentation updated that fixes a TypeScript error.

`assetPrefix` requires type `string | undefined` giving `null` is a TypeScript error.