### PR TITLE
Update vite.mdx

### DIFF
--- a/docs/guides/getting-started/setup/vite.mdx
+++ b/docs/guides/getting-started/setup/vite.mdx
@@ -130,6 +130,7 @@ Note that if you are not using vanilla JavaScript, you must keep the framework-s
 
 Now that we have scaffolded our frontend and initialized the Rust project the created `tauri.conf.json` file should look like this:
 
+in V1 :
 ```json title=src-tauri/tauri.conf.json
 {
   "build": {
@@ -141,6 +142,24 @@ Now that we have scaffolded our frontend and initialized the Rust project the cr
     "distDir": "../dist"
   },
 ```
+
+in V2 :
+```json title=src-tauri/tauri.conf.json
+  "app": {
+    "windows": [
+      {
+        "title": "yourapp",
+        "width": 800,
+        "height": 600
+      }
+    ],
+    "security": {
+      "csp": null
+    },
+    "withGlobalTauri":true
+  },
+```
+
 
 And that's it! Now you can run the following command in your terminal to start a development build of your app:
 


### PR DESCRIPTION
Corrected the withGlobalTauri mention in the configuration, which switches places depending on V1 or V2

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- Simply added the JSON for the app object, so that anyone using V2 will not be confused about the option `    "withGlobalTauri":true` not working in build.

Here's the reference for the change I made : [Appconfig](https://v2.tauri.app/reference/config/#appconfig)
