### PR TITLE
Fix Initialize Plugin Project command.

### DIFF
--- a/src/content/docs/develop/Plugins/index.mdx
+++ b/src/content/docs/develop/Plugins/index.mdx
@@ -38,9 +38,7 @@ To bootstrap a new plugin project, run `plugin new`. If you do not need the NPM 
 
 After installing, you can run the following to create a plugin project:
 
-<CommandTabs
-  npm="npx @tauri-apps/cli plugin new [name]"
-/>
+<CommandTabs npm="npx @tauri-apps/cli plugin new [name]" />
 
 This will initialize the plugin at the directory `tauri-plugin-[name]` and, depending on the used CLI flags, the resulting project will look like this:
 

--- a/src/content/docs/develop/Plugins/index.mdx
+++ b/src/content/docs/develop/Plugins/index.mdx
@@ -39,10 +39,7 @@ To bootstrap a new plugin project, run `plugin new`. If you do not need the NPM 
 After installing, you can run the following to create a plugin project:
 
 <CommandTabs
-  npm="npm run tauri plugin new [name]"
-  yarn="yarn tauri plugin new [name]"
-  pnpm="pnpm tauri plugin new [name]"
-  cargo="cargo tauri plugin new [name]"
+  npm="npx @tauri-apps/cli plugin new [name]"
 />
 
 This will initialize the plugin at the directory `tauri-plugin-[name]` and, depending on the used CLI flags, the resulting project will look like this:


### PR DESCRIPTION
#### Description

The command to create a plugin project was a command that had to be executed within the tauri project.
Therefore, we have changed it to a command that does not depend on the tauri project.

For the following reasons, we have revised the example to only include `npx`.

- `npx`: Can be run without prior preparation
- `yarn dlx`: Requires package.json
- `pnpm dlx`: Requires package.jxon
- `cargo`: Requires a Cargo project with tauri installed

Closes #2422
