### PR TITLE
docs: update app-store.mdx

### DIFF
--- a/src/content/docs/distribute/app-store.mdx
+++ b/src/content/docs/distribute/app-store.mdx
@@ -20,14 +20,14 @@ Additionally, you must setup code signing for [macOS][macOS code signing] and [i
 
 ## Changing App Icon
 
-After running `tauri ios init` to setup the Xcode project, you can use the `tauri icon` command to update the app icons.
+After running `tauri ios init` to setup the Xcode project, you can use the `tauri icon` command to update the app icons. You will need to manually copy the icons generated under `icons/ios` to `gen > apple > Assets.xcassets > AppIcon.appiconset`.
 
 <CommandTabs
-  npm="npm run tauri icon /path/to/app-icon.png -- --ios-color #fff"
-  yarn="yarn tauri icon /path/to/app-icon.png --ios-color #fff"
-  pnpm="pnpm tauri icon /path/to/app-icon.png --ios-color #fff"
-  deno="deno task tauri icon /path/to/app-icon.png --ios-color #fff"
-  cargo="cargo tauri icon /path/to/app-icon.png --ios-color #fff"
+  npm="npm run tauri icon /path/to/app-icon.png -- --ios-color '#fff'"
+  yarn="yarn tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  pnpm="pnpm tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  deno="deno task tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  cargo="cargo tauri icon /path/to/app-icon.png --ios-color '#fff'"
 />
 
 The `--ios-color` argument defines the background color for the iOS icons.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

I noticed that after running `cargo tauri ios init` and then following the docs to do `cargo tauri icon <path> --ios-color #fff` is that:

1. I get an error `error: a value is required for '--ios-color <IOS_COLOR>' but none was supplied` (fish shell)
2. It doesn't overwrite the icons that are generated under `apple/` from `cargo tauri ios init`; meaning the user needs to manually copy it

This PR improves the docs by fixing the command by adding quotes around `#fff` and a step to manually copy.