### PR TITLE
fix: remove redundant await in platform

### DIFF
--- a/src/content/docs/plugin/os-info.mdx
+++ b/src/content/docs/plugin/os-info.mdx
@@ -90,7 +90,7 @@ import { platform } from '@tauri-apps/plugin-os';
 // when using `"withGlobalTauri": true`, you may use
 // const { platform } = window.__TAURI__.os;
 
-const currentPlatform = await platform();
+const currentPlatform = platform();
 console.log(currentPlatform);
 // Prints "windows" to the console
 ```

--- a/src/content/docs/zh-cn/plugin/os-info.mdx
+++ b/src/content/docs/zh-cn/plugin/os-info.mdx
@@ -81,7 +81,7 @@ import CommandTabs from '@components/CommandTabs.astro';
 ```javascript
 import { platform } from '@tauri-apps/plugin-os';
 
-const currentPlatform = await platform();
+const currentPlatform = platform();
 console.log(currentPlatform);
 // Prints "windows" to the console
 ```


### PR DESCRIPTION
[function platform(): Platform](https://github.com/tauri-apps/plugins-workspace/blob/d57df4debe7c75cfbd6d6558fff1beb07dbee54c/plugins/os/guest-js/index.ts#L79) is not an async function.