### PR TITLE
Clarify mobile-only availability of Actions API

### DIFF
--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -151,6 +151,10 @@ tauri::Builder::default()
 
 ### Actions
 
+:::caution[Mobile Only]
+The Actions API is only available on mobile platforms.
+:::
+
 Actions add interactive buttons and inputs to notifications. Use them to create a responsive experience for your users.
 
 #### Register Action Types


### PR DESCRIPTION
This PR updates the documentation to clarify that the Actions API, specifically registerActionTypes, is only available on mobile platforms. A caution note has been added to alert users of this limitation.

Reference: [comment on issue #1903](https://github.com/tauri-apps/plugins-workspace/issues/1903#issuecomment-2408953977)

"registerActionTypes is a mobile only api. The error and docs should be clearer about that so I'll keep this issue open."

This update aims to prevent potential confusion for developers working in non-mobile environments.