### PR TITLE
docs: Correct key export instructions for macOS Code Signing

### DIFF
--- a/src/content/docs/distribute/Sign/macos.mdx
+++ b/src/content/docs/distribute/Sign/macos.mdx
@@ -74,7 +74,7 @@ To use the certificate in CI/CD platforms, you must export the certificate to a 
 and configure the `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` environment variables:
 
 1. Open the `Keychain Access` app, click the _My Certificates_ tab in the _login_ keychain and find your certificate's entry.
-2. Expand the entry, double-click on the key item, and select `Export "$KEYNAME"`.
+2. Expand the entry, right-click on the key item, and select `Export "$KEYNAME"`.
 3. Select the path to save the certificate's `.p12` file and define a password for the exported certificate.
 4. Convert the `.p12` file to base64 running the following script on the terminal:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR updates the "Signing in CI/CD platforms" section of the macOS Code Signing documentation.
It corrects the instructions for exporting a key item, changing "double-click" to "right-click" for accuracy on macOS.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
