### PR TITLE
Sign Windows: singing → signing

### DIFF
--- a/src/content/docs/distribute/Sign/windows.mdx
+++ b/src/content/docs/distribute/Sign/windows.mdx
@@ -301,17 +301,17 @@ If you want to sign with Github Actions everything should be installed.
 
 ### Getting Started
 
-You need to install [trusted-singing-cli](https://github.com/Levminer/trusted-signing-cli) and configure your environment variables.
+You need to install [trusted-signing-cli](https://github.com/Levminer/trusted-signing-cli) and configure your environment variables.
 
 <Steps>
 
-1. #### Install trusted-singing-cli
+1. #### Install trusted-signing-cli
 
-   - `cargo install trusted-singing-cli`
+   - `cargo install trusted-signing-cli`
 
 2. #### Configure environment variables
 
-   - trusted-singing-cli needs the following environment variables to be set, don't forget to add these as Github Actions [secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions):
+   - trusted-signing-cli needs the following environment variables to be set, don't forget to add these as Github Actions [secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions):
 
      - `AZURE_CLIENT_ID`: The client ID of your [App Registration](https://melatonin.dev/blog/code-signing-on-windows-with-azure-trusted-signing/#step-4-create-app-registration-user-credentials)
      - `AZURE_CLIENT_SECRET`: The client secret of [App Registration](https://melatonin.dev/blog/code-signing-on-windows-with-azure-trusted-signing/#step-4-create-app-registration-user-credentials)


### PR DESCRIPTION
Corrects typo (in an area we really don’t want any typos, given it’s code signing and  typosquatting is a thing)