### PR TITLE
Update pkg version for Node.js sidecar example

### DIFF
--- a/src/content/docs/learn/sidecar-nodejs.mdx
+++ b/src/content/docs/learn/sidecar-nodejs.mdx
@@ -59,9 +59,9 @@ Without the plugin being initialized and configured the example won't work.
     Let's install it as a development dependency:
 
     <CommandTabs
-      npm="npm add pkg --save-dev"
-      yarn="yarn add pkg --dev"
-      pnpm="pnpm add pkg --save-dev"
+      npm="npm add @yao-pkg/pkg --save-dev"
+      yarn="yarn add @yao-pkg/pkg --dev"
+      pnpm="pnpm add @yao-pkg/pkg --save-dev"
     />
 
 1.  ##### Write Sidecar Logic


### PR DESCRIPTION
#### Description
- point at up to date fork of pkg given Vercel's is now deprecated and doesn't support Node 20
- I was also unable to use the provided command `npm run pkg index.js --output app` and instead added a build script `"build": "pkg index.js --output app"` but I'm not sure if that's too large a change of step 3