### PR TITLE
docs(updater): fix timeout example

### DIFF
--- a/src/content/docs/plugin/updater.mdx
+++ b/src/content/docs/plugin/updater.mdx
@@ -582,7 +582,7 @@ import { check } from '@tauri-apps/plugin-updater';
 
 const update = await check({
   proxy: '<proxy url>',
-  timeout: 30 /* seconds */,
+  timeout: 30000 /* milliseconds */,
   headers: {
     Authorization: 'Bearer <token>',
   },


### PR DESCRIPTION
Fixed timeout argument for check function being in milliseconds not seconds

