### PR TITLE
docs: missing fn keyword in example code

### DIFF
--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -224,7 +224,7 @@ Create the main window and change its background color:
     ```rust title="src-tauri/src/lib.rs"
     use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
-    pub run() {
+    pub fn run() {
     	tauri::Builder::default()
     		.setup(|app| {
     			let win_builder =


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
This PR fixes the example code in [(macOS) Transparent Titlebar with Custom Window Background Color](https://tauri.app/learn/window-customization/#macos-transparent-titlebar-with-custom-window-background-color)

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
