### PR TITLE
docs: platform target append code fix

### DIFF
--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -60,7 +60,7 @@ Here's a Node.js script to append the target triple to a binary:
 import { execSync } from 'child_process';
 import fs from 'fs';
 
-const ext = process.platform === 'win32' ? '.exe' : '';
+const extension = process.platform === 'win32' ? '.exe' : '';
 
 const rustInfo = execSync('rustc -vV');
 const targetTriple = /host: (\S+)/g.exec(rustInfo)[1];


### PR DESCRIPTION
#### Description
This PR fixes the code to append target triple to external binary(sidecar) in this page [Embedding External Binaries](https://tauri.app/develop/sidecar/)