### PR TITLE
fix(docs): fix reference to tokio mutex

### DIFF
--- a/src/content/docs/develop/state-management.mdx
+++ b/src/content/docs/develop/state-management.mdx
@@ -106,7 +106,7 @@ For more information on commands, see [Calling Rust from the Frontend](/develop/
 
 #### Async commands
 
-If you are using `async` commands and want to use Tokio's async [`Mutex`], you can set it up the same way and access the state like this:
+If you are using `async` commands and want to use Tokio's async [`Mutex`](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html), you can set it up the same way and access the state like this:
 
 ```rust
 #[tauri::command]


### PR DESCRIPTION
#### Description
The reference for tokio's Mutex implementation was pointing to the std implementation instead. The updated version points to the page that is implied by the sentence.