### PR TITLE
fix PluginLinks undefined in language zh-cn

### DIFF
--- a/src/content/docs/zh-cn/plugin/localhost.mdx
+++ b/src/content/docs/zh-cn/plugin/localhost.mdx
@@ -1,6 +1,7 @@
 ---
 title: Localhost
 description: 在生产环境中使用 localhost 服务器。
+plugin: localhost
 ---
 
 import PluginLinks from '@components/PluginLinks.astro';


### PR DESCRIPTION
PluginLinks has undefined url path in language zh-cn
![image](https://github.com/user-attachments/assets/d2556c19-964b-46ba-a443-fa0127750ad3)
