### PR TITLE
Correct path for `bundleMediaFramework` config

### DIFF
--- a/src/content/docs/distribute/appimage.mdx
+++ b/src/content/docs/distribute/appimage.mdx
@@ -10,7 +10,7 @@ AppImages are convenient, simplifying the distribution process if you cannot mak
 
 ## Multimedia support via GStreamer
 
-If your app plays audio/video you need to enable `tauri.conf.json > bundle > appimage > bundleMediaFramework`. This will increase the size of the AppImage bundle to include additional gstreamer files needed for media playback. This flag is currently only fully supported on Ubuntu build systems. Make sure that your build system has all the plugins your app may need at runtime.
+If your app plays audio/video you need to enable `tauri.conf.json > bundle > linux > appimage > bundleMediaFramework`. This will increase the size of the AppImage bundle to include additional gstreamer files needed for media playback. This flag is currently only fully supported on Ubuntu build systems. Make sure that your build system has all the plugins your app may need at runtime.
 
 :::caution
 


### PR DESCRIPTION
The "path" of the bundleMediaFramework config in tauri.conf.json is specified wrongly I think. This fixes that, it should be  tauri.conf.json > bundle > linux > appimage > bundleMediaFramework.