### PR TITLE
Typo in npm installation command

### DIFF
--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -116,7 +116,7 @@ export const InstallTauriApi = () => {
     <Tabs groupId="package-manager">
       <TabItem value="npm" default>
         <CodeBlock className="language-shell" language="shell">
-          npm install @tauri-apps/api@^1.0.0
+          npm install @tauri-apps/api@1
         </CodeBlock>
       </TabItem>
       <TabItem value="Yarn">

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -116,7 +116,7 @@ export const InstallTauriApi = () => {
     <Tabs groupId="package-manager">
       <TabItem value="npm" default>
         <CodeBlock className="language-shell" language="shell">
-          npm install @tauri-apps/api@"^1.0.0"
+          npm install @tauri-apps/api@^1.0.0
         </CodeBlock>
       </TabItem>
       <TabItem value="Yarn">

--- a/src/theme/Command.js
+++ b/src/theme/Command.js
@@ -116,7 +116,7 @@ export const InstallTauriApi = () => {
     <Tabs groupId="package-manager">
       <TabItem value="npm" default>
         <CodeBlock className="language-shell" language="shell">
-          npm install @tauri-apps/api@"&gt;1.0.0"
+          npm install @tauri-apps/api@"^1.0.0"
         </CodeBlock>
       </TabItem>
       <TabItem value="Yarn">


### PR DESCRIPTION
#### Description
Changes `npm install --save-dev @tauri-apps/cli@">1.0.0"` to `npm install --save-dev @tauri-apps/cli@^1.0.0`
