### PR TITLE
Add permission setup section for running sidecar in Javascript

### DIFF
--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -135,18 +135,18 @@ When running the sidecar, Tauri requires you to give the sidecar permission to r
 
 ```json title="src-tauri/capabilities/default.json" ins={4-13}
 {
-   "permissions": [
-      "core:default",
-      {
-        "identifier": "shell:allow-execute",
-        "allow": [
-          {
-            "name": "binaries/app",
-            "sidecar": true
-          }
-        ]
-      },
-      "shell:allow-open"
+  "permissions": [
+    "core:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "binaries/app",
+          "sidecar": true
+        }
+      ]
+    },
+    "shell:allow-open"
   ]
 }
 ```

--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -133,17 +133,10 @@ You can place this code inside a Tauri command to easily pass the AppHandle or y
 
 When running the sidecar, Tauri requires you to give the sidecar permission to run the `execute` or `spawn` method on the child process. To grant this permission, go to the file `<PROJECT ROOT>/src-tauri/capabilities/default.json` and add the section below to the permissions array. Don't forget to name your sidecar according to the relative path mentioned earlier.
 
-```json title="src-tauri/capabilities/default.json" ins={11-20}
+```json title="src-tauri/capabilities/default.json" ins={4-13}
 {
    "permissions": [
-      "core:path:default",
-      "core:event:default",
-      "core:window:default",
-      "core:app:default",
-      "core:resources:default",
-      "core:menu:default",
-      "core:tray:default",
-      "store:default",
+      "core:default",
       {
         "identifier": "shell:allow-execute",
         "allow": [
@@ -184,20 +177,14 @@ Arguments can be either **static** (e.g. `-o` or `serve`) or **dynamic** (e.g. `
 
 First, define the arguments that need to be passed to the sidecar command in `src-tauri/capabilities/default.json`:
 
-```json title="src-tauri/capabilities/default.json" ins={14-31}
+```json title="src-tauri/capabilities/default.json" ins={8-25}
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
   "permissions": [
-    "core:path:default",
-    "core:event:default",
-    "core:window:default",
-    "core:app:default",
-    "core:resources:default",
-    "core:menu:default",
-    "core:tray:default",
+    "core:default",
     {
       "identifier": "shell:allow-execute",
       "allow": [

--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -131,6 +131,39 @@ You can place this code inside a Tauri command to easily pass the AppHandle or y
 
 ## Running it from JavaScript
 
+When running the sidecar, Tauri requires you to give the sidecar permission to run the `execute` or `spawn` method on the child process. To grant this permission, go to the file `<PROJECT ROOT>/src-tauri/capabilities/default.json` and add the section below to the permissions array. Don't forget to name your sidecar according to the relative path mentioned earlier.
+
+```json title="src-tauri/capabilities/default.json" ins={11-20}
+{
+   "permissions": [
+      "core:path:default",
+      "core:event:default",
+      "core:window:default",
+      "core:app:default",
+      "core:resources:default",
+      "core:menu:default",
+      "core:tray:default",
+      "store:default",
+      {
+        "identifier": "shell:allow-execute",
+        "allow": [
+          {
+            "name": "binaries/app",
+            "sidecar": true
+          }
+        ]
+      },
+      "shell:allow-open"
+  ]
+}
+```
+
+:::note
+
+The `shell:allow-execute` identifier is used because the sidecar's child process will be started using the `command.execute()` method. To run it with `command.spawn()`, you need to change the identifier to `shell:allow-spawn` or add another entry to the array with the same structure as the one above, but with the identifier set to `shell:allow-spawn`.
+
+:::
+
 In the JavaScript code, import the `Command` class from the `@tauri-apps/plugin-shell` module and use the `sidecar` static method.
 
 ```javascript


### PR DESCRIPTION
### Description
This PR adds documentation for configuring permissions required to run a sidecar in a Tauri application from Javascript. It includes details on granting the appropriate permissions for the execute or spawn methods used by the sidecar's child process.

Specifically, the following updates were made:

Added a new section in the Tauri documentation under <PROJECT ROOT>/src-tauri/capabilities/default.json.
Provided an example JSON structure demonstrating how to configure the permissions array for sidecar functionality.
Clarified the use of the shell:allow-execute identifier and how to modify it to shell:allow-spawn for specific use cases.
Closes https://github.com/tauri-apps/tauri/issues/1298#issuecomment-2504261926_