### PR TITLE
i18n(zh-cn): translate opener.mdx

### DIFF
--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -39,7 +39,7 @@ import PluginPermissions from '@components/PluginPermissions.astro';
     </TabItem>
     <TabItem label = "手动">
     	<Steps>
-          1. 在 `src-tauri` 目录下，运行下面的命令。将此插件添加到项目的 `Cargo.toml` 文件的 `dependecnies` 字段中：
+          1. 在 `src-tauri` 目录下，运行下面的命令。将此插件添加到项目的 `Cargo.toml` 文件的 `dependencies` 字段中：
 
               ```sh frame=none
               cargo add tauri-plugin-opener

--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -1,0 +1,135 @@
+---
+title: 指定打开应用
+description: 在外部应用中打开文件和URL。
+plugin: opener
+---
+
+import PluginLinks from '@components/PluginLinks.astro';
+import Compatibility from '@components/plugins/Compatibility.astro';
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+import PluginPermissions from '@components/PluginPermissions.astro';
+
+<PluginLinks plugin={frontmatter.plugin} />
+
+此插件允许你使用特定或者默认的应用程序打开文件或者 URL。它还可以在系统文件管理器中“显示”这些文件。
+
+## 支持的平台
+
+<Compatibility plugin={frontmatter.plugin} />
+
+## 设置
+
+首先安装“指定打开应用”插件。
+
+<Tabs>
+	<TabItem label="自动" >
+		使用项目的包管理器来添加依赖：
+    	{ ' ' }
+
+    	<CommandTabs
+            npm="npm run tauri add opener"
+            yarn="yarn run tauri add opener"
+            pnpm="pnpm tauri add opener"
+            deno="deno task tauri add opener"
+            bun="bun tauri add opener"
+            cargo="cargo tauri add opener"
+    	/>
+    </TabItem>
+    <TabItem label = "手动">
+    	<Steps>
+          1. 在 `src-tauri` 目录下，运行下面的命令。将此插件添加到项目的 `Cargo.toml` 文件的 `dependecnies` 字段中：
+
+              ```sh frame=none
+              cargo add tauri-plugin-opener
+              ```
+
+          2. 修改 `lib.rs` 文件，初始化此插件：
+
+              ```rust title="src-tauri/src/lib.rs" ins={4}
+              #[cfg_attr(mobile, tauri::mobile_entry_point)]
+              pub fn run() {
+                  tauri::Builder::default()
+                      .plugin(tauri_plugin_opener::init())
+                      .run(tauri::generate_context!())
+                      .expect("error while running tauri application");
+              }
+              ```
+
+          3. 使用你喜欢的 JavaScript 包管理器来添加 JavaScript 端的插件绑定：
+
+              <CommandTabs
+                  npm = "npm install @tauri-apps/plugin-opener"
+                  yarn = "yarn add @tauri-apps/plugin-opener"
+                  pnpm = "pnpm add @tauri-apps/plugin-opener"
+                  deno = "deno add npm:@tauri-apps/plugin-opener"
+                  bun = "bun add @tauri-apps/plugin-opener"
+              />
+    	</Steps>
+    </TabItem>
+
+</Tabs>
+
+## 用法
+
+此插件有 JavaScript 和 Rust 两种调用方式。
+
+<Tabs syncKey="lang">
+	<TabItem label="JavaScript" >
+
+```javascript
+import { openPath } from '@tauri-apps/plugin-opener';
+// 当配置为 `"withGlobalTauri": true` 时，你可以使用下面方式引入此插件
+// const { openPath } = window.__TAURI__.opener;
+
+// 使用默认的应用来打开文件
+await openPath('/path/to/file');
+// 在 Windows 上使用 `vlc` 打开文件
+await openPath('C:/path/to/file', 'vlc');
+```
+
+    </TabItem>
+    <TabItem label = "Rust" >
+
+下面代码中的 `app` 变量是 `App` 或者 [`AppHandle`](https://docs.rs/tauri/2.0.0/tauri/struct.AppHandle.html) 实例化后的结果。
+
+```rust
+use tauri_plugin_opener::OpenerExt;
+
+// 使用默认的应用来打开文件：
+app.opener().open_path("/path/to/file", None::<&str>);
+// 在 Windows 上使用 `vlc` 打开文件：
+app.opener().open_path("C:/path/to/file", Some("vlc"));
+```
+
+    </TabItem>
+
+</Tabs>
+
+## 权限
+
+默认情况下，所有插件命令都被阻止，无法访问。你必须修改 `tauri` 端的 `capabilities` 文件夹中的配置来启用它们。
+
+参见[能力概览](/zh-cn/security/capabilities/)以获取更多信息，以及[调整权限分步导览](/zh-cn/learn/security/using-plugin-permissions/)来调整插件的权限。
+
+```json title="src-tauri/capabilities/default.json" ins={6-15}
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": [
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "/path/to/file"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<PluginPermissions plugin={frontmatter.plugin} />

--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -109,7 +109,7 @@ app.opener().open_path("C:/path/to/file", Some("vlc"));
 
 ## 权限
 
-默认情况下，所有插件命令都被阻止，无法访问。你必须修改 `tauri` 端的 `capabilities` 文件夹中的配置来启用它们。
+默认情况下，所有具有潜在危险的插件命令和范围都会被阻止且无法访问。您必须修改  `capabilities`  文件夹中的配置来启用它们。
 
 参见[能力概览](/zh-cn/security/capabilities/)以获取更多信息，以及插件的[分步导览](/zh-cn/learn/security/using-plugin-permissions/)来调整插件权限。
 

--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -109,7 +109,7 @@ app.opener().open_path("C:/path/to/file", Some("vlc"));
 
 ## 权限
 
-默认情况下，所有具有潜在危险的插件命令和范围都会被阻止且无法访问。您必须修改  `capabilities`  文件夹中的配置来启用它们。
+默认情况下，所有具有潜在危险的插件命令和范围都会被阻止且无法访问。您必须修改 `capabilities` 文件夹中的配置来启用它们。
 
 参见[能力概览](/zh-cn/security/capabilities/)以获取更多信息，以及插件的[分步导览](/zh-cn/learn/security/using-plugin-permissions/)来调整插件权限。
 

--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -111,7 +111,7 @@ app.opener().open_path("C:/path/to/file", Some("vlc"));
 
 默认情况下，所有插件命令都被阻止，无法访问。你必须修改 `tauri` 端的 `capabilities` 文件夹中的配置来启用它们。
 
-参见[能力概览](/zh-cn/security/capabilities/)以获取更多信息，以及[调整权限分步导览](/zh-cn/learn/security/using-plugin-permissions/)来调整插件的权限。
+参见[能力概览](/zh-cn/security/capabilities/)以获取更多信息，以及插件的[分步导览](/zh-cn/learn/security/using-plugin-permissions/)来调整插件权限。
 
 ```json title="src-tauri/capabilities/default.json" ins={6-15}
 {

--- a/src/content/docs/zh-cn/plugin/opener.mdx
+++ b/src/content/docs/zh-cn/plugin/opener.mdx
@@ -92,7 +92,7 @@ await openPath('C:/path/to/file', 'vlc');
     </TabItem>
     <TabItem label = "Rust" >
 
-下面代码中的 `app` 变量是 `App` 或者 [`AppHandle`](https://docs.rs/tauri/2.0.0/tauri/struct.AppHandle.html) 实例化后的结果。
+下面代码中的 `app` 变量是 `App` 或者 [`AppHandle`](https://docs.rs/tauri/2.0.0/tauri/struct.AppHandle.html) 的实例。
 
 ```rust
 use tauri_plugin_opener::OpenerExt;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (zh-cn)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
   - translate `src/content/docs/plugin/opener.mdx` to `src/content/docs/zh-cn/plugin/opener.mdx` to Chinese Simplified
   - cause `Default Permission` and `Permission Table` section not include in this MDX file, so not translate it
 - glossary
> those word when I translate to Chinese, add some meaning to it, to make them more clear to understand

| original text | target text |
|-------------|------------|
| opener        | 指定打开应用 |
| Capabilities Overview | 能力概览 |
| step by step guide | 调整权限分步导览 |
<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
