### PR TITLE
Corrects read only example for open function

### DIFF
--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -256,7 +256,9 @@ Always call `file.close()` when you are done manipulating the file.
     read: true,
     baseDir: BaseDirectory.AppData,
   });
-  const buf = new Uint8Array();
+
+  const stat = await file.stat();
+  const buf = new Uint8Array(stat.size);
   await file.read(buf);
   const textContents = new TextDecoder().decode(buf);
   await file.close();


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->

The current example will read nothing because the U8Array is initialized with length of 0 because `file.read()` reads up to the bytelength of the buffer.

This example works, or the example in the JavaScript doc block of `new Uint8Array(100)` would work.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
