### PR TITLE
Fix: Update link in flatpak.mdx

### DIFF
--- a/src/content/docs/distribute/flatpak.mdx
+++ b/src/content/docs/distribute/flatpak.mdx
@@ -58,7 +58,7 @@ dev-util/flatpak-builder
 flatpak install flathub org.gnome.Platform//46 org.gnome.Sdk//46
 ```
 
-**3. [Build the .deb of your tauri-app](https://deploy-preview-2279--tauri-v2.netlify.app/reference/config/#bundleconfig)**
+**3. [Build the .deb of your tauri-app](https://v2.tauri.app/reference/config/#bundleconfig)**
 
 **4. Create the manifest**
 


### PR DESCRIPTION
#### Description
Updates a link to the `bundleConfig` docs. It was using the URL of a specific Netlify build.
