### PR TITLE
feat: commands can be defined as pub in crate root on tauri 2.4

### DIFF
--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -34,23 +34,6 @@ fn my_custom_command() {
 Command names must be unique.
 :::
 
-:::note
-Commands defined in the `lib.rs` file cannot be marked as `pub` due to a limitation in the glue code generation.
-You will see an error like this if you mark it as a public function:
-
-````
-error[E0255]: the name `__cmd__command_name` is defined multiple times
-  --> src/lib.rs:28:8
-   |
-27 | #[tauri::command]
-   | ----------------- previous definition of the macro `__cmd__command_name` here
-28 | pub fn x() {}
-   |        ^ `__cmd__command_name` reimported here
-   |
-   = note: `__cmd__command_name` must be defined only once in the macro namespace of this module
-```
-:::
-
 You will have to provide a list of your commands to the builder function like so:
 
 ```rust title="src-tauri/src/lib.rs" ins={4}


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/pull/12979
