### PR TITLE
docs: Add section for bundleVersion property

### DIFF
--- a/src/content/docs/distribute/app-store.mdx
+++ b/src/content/docs/distribute/app-store.mdx
@@ -46,6 +46,20 @@ The value provided in the _Bundle ID_ field **must** match the identifier define
 
 The Tauri CLI can package your app for macOS and iOS. Running on a macOS machine is a requirement.
 
+Tauri derives the [`CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion) from the value defined in [`tauri.conf.json > version`].
+You can set a custom bundle version in the [`tauri.conf.json > bundle > ios > bundleVersion`] or [`tauri.conf.json > bundle > macOS > bundleVersion`] configuration
+if you need a different bundle version scheme e.g. sequential codes:
+
+```json title="tauri.conf.json" ins={4}
+{
+  "bundle": {
+    "ios": {
+      "bundleVersion": "100"
+    }
+  }
+}
+```
+
 :::caution
 Code signing is required. See the documentation for [macOS][macOS code signing] and [iOS][iOS code signing].
 :::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description.
Adds documentation for new iOS/macOS property `bundleVersion` added in [PR 13030](https://github.com/tauri-apps/tauri/pull/13030).

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
