### PR TITLE
Mention 'wasm-unsafe-eval' in the CSP documentation.

### DIFF
--- a/src/content/docs/security/csp.mdx
+++ b/src/content/docs/security/csp.mdx
@@ -36,6 +36,11 @@ example of Tauri, but every application developer needs to tailor this to their 
       },
 ```
 
+:::tip
+When using Rust to develop your frontend, or if your frontend otherwise uses WebAssembly, remember
+to include `'wasm-unsafe-eval'` as a `script-src`.
+:::
+
 See [`script-src`], [`style-src`] and [CSP Sources] for more
 information about this protection.
 


### PR DESCRIPTION
I just spent a very frustrating hour trying to figure out why my Tauri app wasn't loading, because Safari apparently can't be bothered to log any kind of warning if the CSP blocks WebAssembly execution (it does log warnings for other CSP issues).

I'm not sure if this is the best way to communicate this information, but I decided to make the proposal.