### PR TITLE
Update imports in base-level menu rust implementation

### DIFF
--- a/src/content/docs/learn/window-menu.mdx
+++ b/src/content/docs/learn/window-menu.mdx
@@ -46,7 +46,7 @@ menu.setAsAppMenu().then((res) => {
 
 ```rust
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-use tauri::menu::{Menu, MenuItem};
+use tauri::menu::{MenuBuilder};
 
 fn main() {
   tauri::Builder::default()


### PR DESCRIPTION
#### Description
Fixes an import statement in the base-level menu example.
Instead of importing `tauri::menu::{Menu, MenuItem}` which aren't used in the example, it should `MenuBuilder` which is used.