### PR TITLE
docs: Fix createNew documentation

### DIFF
--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -348,7 +348,7 @@ Always call `file.close()` when you are done manipulating the file.
 
 - createNew
 
-  `createNew` works similarly to `create`, but if the file does not exist, the operation fails.
+  `createNew` works similarly to `create`, but will fail if the file already exists.
 
   ```js
   import { open, BaseDirectory } from '@tauri-apps/plugin-fs';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- The createNew option for fs::open currently says it fails if the file does **not** exist, while the opposite is true.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
