### PR TITLE
fix missing dependency `rustc` for nixos

### DIFF
--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -130,6 +130,7 @@ pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     pkg-config
     gobject-introspection
+    rustc
     cargo
     cargo-tauri
     nodejs


### PR DESCRIPTION
#### Description

- I'm using unstable version of nixos and it failed to launch without pkg `rustc`.