### PR TITLE
docs: fix typo in Start the development server paragraph

### DIFF
--- a/src/content/docs/start/create-project.mdx
+++ b/src/content/docs/start/create-project.mdx
@@ -107,7 +107,7 @@ Once completed, the utility reports that the template has been created and displ
 
 #### Start the development server
 
-After `create-tauri-app` has complete you can navigate into your project's folder, install dependencies, then use the [Tauri CLI](/reference/cli/) to start the development server:
+After `create-tauri-app` has completed, you can navigate into your project's folder, install dependencies, and then use the [Tauri CLI](/reference/cli/) to start the development server:
 
 import CommandTabs from '@components/CommandTabs.astro';
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- Fixes a small typo in  `src/content/docs/start/create-project.mdx` "Start the development server" paragraph;
<!-- If it's an update try adding the commits as reference -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
