### PR TITLE
Describe Ad-hoc signing on MacOS

### DIFF
--- a/src/content/docs/distribute/Sign/macos.mdx
+++ b/src/content/docs/distribute/Sign/macos.mdx
@@ -195,6 +195,7 @@ Ad-hoc code signing does not prevent MacOS from requiring users to
 :::
 
 To configure an ad-hoc signature, provide the pseudo-identity `-` to Tauri, e.g.
+
 ```json
 "signingIdentity": "-"
 ```

--- a/src/content/docs/distribute/Sign/macos.mdx
+++ b/src/content/docs/distribute/Sign/macos.mdx
@@ -52,7 +52,7 @@ With the certificate installed in your Mac computer keychain, you can configure 
 
 The name of the certificate's keychain entry represents the `signing identity`, which can also be found by executing:
 
-```
+```sh
 security find-identity -v -p codesigning
 ```
 
@@ -79,7 +79,7 @@ and configure the `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` environme
 3. Select the path to save the certificate's `.p12` file and define a password for the exported certificate.
 4. Convert the `.p12` file to base64 running the following script on the terminal:
 
-```
+```sh
 openssl base64 -in /path/to/certificate.p12 -out certificate-base64.txt
 ```
 
@@ -182,3 +182,21 @@ Notarization is required when using a _Developer ID Application_ certificate.
 [creating a certificate signing request]: https://developer.apple.com/help/account/create-certificates/create-a-certificate-signing-request
 [Certificates, IDs & Profiles page]: https://developer.apple.com/account/resources/certificates/list
 [app-specific password]: https://support.apple.com/en-ca/HT204397
+
+## Ad-Hoc Signing
+
+If you do not wish to provide an Apple-authenticated identity, but still wish to sign your application, you can configure an _ad-hoc_ signature.
+
+This is useful on ARM (Apple Silicon) devices, where code-signing is required for all apps from the Internet.
+
+:::caution
+Ad-hoc code signing does not prevent MacOS from requiring users to
+[whitelist the installation in their Privacy & Security settings](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac).
+:::
+
+To configure an ad-hoc signature, provide the pseudo-identity `-` to Tauri, e.g.
+```json
+"signingIdentity": "-"
+```
+
+For details on configuring Tauri's signing identity, see [above](#configuring-tauri).


### PR DESCRIPTION
### Description

Adds a section to the MacOS Signing guide describing "ad-hoc" signing.

Also tweaks the markup for a few other code snippets to add `sh` coloring.

Relates to issue: https://github.com/tauri-apps/tauri/issues/8763

### Background

I ran into lots of confusion with this, as an older build of my app built by GitHub worked fine when downloaded, but when I rolled back to the same revision, the build output from GitHub failed to start on MacOS. This was because the original build was carried out on an Intel MacOS runner, and the newer build ran on an Apple Silicon runner.

On opening the newly generated build, I got the "App Is Damaged And Can’t Be Opened" error, even though my app wasn't signed. Turns out MacOS on ARM _requires_ a signature for apps to run, and my app was quarantined as it lacked this signature. I haven't set up the identity with my organization's Apple Developer account yet, but I wanted the build to still be runnable.

Setting the identity to the pseudo-identity "-" allowed the app to run on an M3 MBP, though I still needed to whitelist the app in Privacy & Security settings. This is consistent with the prior behavior for "unsigned" apps built by GitHub.