### PR TITLE
adjust doc

### DIFF
--- a/src/content/docs/develop/calling-frontend.mdx
+++ b/src/content/docs/develop/calling-frontend.mdx
@@ -161,20 +161,17 @@ use tauri::{AppHandle, ipc::Channel};
 use serde::Serialize;
 
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase", tag = "event", content = "data")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "event", content = "data")]
 enum DownloadEvent<'a> {
-  #[serde(rename_all = "camelCase")]
   Started {
     url: &'a str,
     download_id: usize,
     content_length: usize,
   },
-  #[serde(rename_all = "camelCase")]
   Progress {
     download_id: usize,
     chunk_length: usize,
   },
-  #[serde(rename_all = "camelCase")]
   Finished {
     download_id: usize,
   },


### PR DESCRIPTION

#### Description
Consolidate all Serde renaming into a single top-level annotation (rename_all = "camelCase" + rename_all_fields = "camelCase") to remove redundant per-variant attributes and reduce boilerplate – keeps behavior identical while making the code more concise and maintainable

No change to the serialized JSON output; only internal attribute placement is modified