### PR TITLE
docs(en): fix incorrect configuration option for iOS

### DIFF
--- a/src/content/docs/distribute/app-store.mdx
+++ b/src/content/docs/distribute/app-store.mdx
@@ -48,13 +48,13 @@ The value provided in the _Bundle ID_ field **must** match the identifier define
 The Tauri CLI can package your app for macOS and iOS. Running on a macOS machine is a requirement.
 
 Tauri derives the [`CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion) from the value defined in [`tauri.conf.json > version`].
-You can set a custom bundle version in the [`tauri.conf.json > bundle > ios > bundleVersion`] or [`tauri.conf.json > bundle > macOS > bundleVersion`] configuration
+You can set a custom bundle version in the [`tauri.conf.json > bundle > iOS > bundleVersion`] or [`tauri.conf.json > bundle > macOS > bundleVersion`] configuration
 if you need a different bundle version scheme e.g. sequential codes:
 
 ```json title="tauri.conf.json" ins={4}
 {
   "bundle": {
-    "ios": {
+    "iOS": {
       "bundleVersion": "100"
     }
   }


### PR DESCRIPTION

#### Description

`ios` is not a valid option, `iOS` is:
```sh
npm run tauri ios build -- --config '{"bundle": { "ios": { "bundleVersion": 20 } } }'  --export-method release-testing

> tauri ios build --config {"bundle": { "ios": { "bundleVersion": 20 } } } --export-method release-testing

       Error `tauri.conf.json` error on `bundle`: Additional properties are not allowed ('ios' was unexpected)
```

```sh
npm run tauri ios build -- --config '{"bundle": { "iOS": { "bundleVersion": "20" } } }'  --export-method release-testing

> tauri ios build --config {"bundle": { "iOS": { "bundleVersion": "20" } } } --export-method release-testing
...
```