### PR TITLE
Update docs for brownfield configuration path to be app.security.pattern

### DIFF
--- a/src/content/docs/concept/Inter-Process Communication/brownfield.md
+++ b/src/content/docs/concept/Inter-Process Communication/brownfield.md
@@ -16,13 +16,15 @@ legacy systems.
 ## Configuration
 
 Because the Brownfield pattern is the default pattern, it doesn't require a configuration option to be set. To explicitly set
-it, you can use the `tauri > pattern` object in the `tauri.conf.json` configuration file.
+it, you can use the `app > security > pattern` object in the `tauri.conf.json` configuration file.
 
 ```json
 {
-  "tauri": {
-    "pattern": {
-      "use": "brownfield"
+  "app": {
+    "security": {
+      "pattern": {
+        "use": "brownfield"
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- This MR updates the documentation for `tauri.conf.json` for the Brownfield config which references an outdated Tauri 1.0 `tauri > pattern` config setting.  
  This MR updates this path to the one used in Tauri 2.x: `app > security > pattern`.  
  The relevant upgrade docs are here: https://tauri.app/start/migrate/from-tauri-1/

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
