### PR TITLE
Add warning about keeping Single instance initialization as the first one

### DIFF
--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -70,6 +70,13 @@ Install the Single Instance plugin to get started.
 
 </Tabs>
 
+
+:::info
+
+The Single Instance plugin must be the first one to be init()'ed to work well. Doing so prevents other plugins to initiate and eventually interfering with the app's instance that is already running.
+
+:::
+
 ## Usage
 
 The plugin is already installed and initialized, and it should be functioning correctly right away. Nevertheless, we can also enhance its functionality with the `init()` method.

--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -70,10 +70,9 @@ Install the Single Instance plugin to get started.
 
 </Tabs>
 
-
 :::info
 
-The Single Instance plugin must be the first one to be init()'ed to work well. Doing so prevents other plugins to initiate and eventually interfering with the app's instance that is already running.
+The Single Instance plugin must be the first one to be registered to work well. This assures that it runs before other plugins can interfere.
 
 :::
 


### PR DESCRIPTION

#### Description

- What does this PR change? Give us a brief description. 

Adds a warning about keeping single instance init() call as the first one, before other plugins' initialization.
