### PR TITLE
Adding advice for using tray-icons with flatpak packaged apps

### DIFF
--- a/src/content/docs/distribute/flatpak.mdx
+++ b/src/content/docs/distribute/flatpak.mdx
@@ -75,6 +75,8 @@ finish-args:
   - --socket=fallback-x11 # Permission needed to show the window
   - --device=dri # OpenGL, not necessary for all projects
   - --share=ipc
+  - --talk-name=org.kde.StatusNotifierWatcher # Optional: needed only if your app uses the tray icon
+  - --filesystem=xdg-run/tray-icon:create # Optional: needed only if your app uses the tray icon - see an alternative way below
 
 modules:
   - name: binary
@@ -98,6 +100,19 @@ modules:
 ```
 
 The Gnome 46 runtime includes all dependencies of the standard Tauri app with their correct versions.
+
+:::note[Using tray-icon without changing the Flatpak manifest]
+If you prefer not opening access from your app to $XDG_RUNTIME_DIR (where tray-icon is saved on linux), you can change the path tauri saves the tray image:
+
+```rust
+TrayIconBuilder::new()
+  .icon(app.default_window_icon().unwrap().clone())
+  .temp_dir_path(app.path().app_cache_dir().unwrap()) // will save to the cache folder ($XDG_CACHE_HOME) where the app already has permission
+  .build()
+  .unwrap();
+```
+
+:::
 
 **5. Install, and Test the app**
 


### PR DESCRIPTION
#### Description
- What does this PR change? 
Adding a small (but extremely helpful - this took me almost 1 week of work until I figured it out) piece of advice to developers who want to use tray-icons with their flatpak packaged apps. 

Shows both ways of doing it, by giving app the `xdg-run/tray-icon` permission, or changing Tauri's tray icon path to use some path already open to the app by default.

- Closes https://github.com/tauri-apps/tauri/issues/13599