### PR TITLE
Add a note on plugin command scheduling on Android

### DIFF
--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -216,6 +216,20 @@ class ExamplePlugin(private val activity: Activity): Plugin(activity) {
 }
 ```
 
+:::note
+On Android native commands are scheduled on the main thread. Performing long-running operations will cause the UI to freeze and potentially "Application Not Responding" (ANR) error.
+
+If you need to wait for some blocking IO, you can launch a corouting like that:
+
+```kotlin
+CoroutineScope(Dispatchers.IO).launch {
+  val result = myLongRunningOperation()
+  invoke.resolve(result)
+}
+```
+
+:::
+
 </TabItem>
 <TabItem label="iOS">
 
@@ -259,20 +273,6 @@ impl<R: Runtime> <plugin-name;pascal-case><R> {
   }
 }
 ```
-
-:::note
-On Android native commands are scheduled on the main thread. Performing long-running operations will cause the UI to freeze and potentially "Application Not Responding" (ANR) error.
-
-If you need to wait for some blocking IO, you can launch a corouting like that:
-
-```kotlin
-CoroutineScope(Dispatchers.IO).launch {
-  val result = myLongRunningOperation()
-  invoke.resolve(result)
-}
-```
-
-:::
 
 ## Command Arguments
 

--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -260,6 +260,20 @@ impl<R: Runtime> <plugin-name;pascal-case><R> {
 }
 ```
 
+:::note
+On Android native commands are scheduled on the main thread. Performing long-running operations will cause the UI to freeze and potentially "Application Not Responding" (ANR) error.
+
+If you need to wait for some blocking IO, you can launch a corouting like that:
+
+```kotlin
+CoroutineScope(Dispatchers.IO).launch {
+  val result = myLongRunningOperation()
+  invoke.resolve(result)
+}
+```
+
+:::
+
 ## Command Arguments
 
 Arguments are serialized to commands and can be parsed on the mobile plugin with the `Invoke::parseArgs` function, taking a class describing the argument object.


### PR DESCRIPTION
#### Description

This kind of note can be helpful to anyone hoping that Tauri will do some magic to prevent UI freezes, given that commands' `Invoke` API  implies support for async behavior and longer-running operations.