### PR TITLE
[request] add libxdo to arch and fedora prerequisites

### DIFF
--- a/src/content/docs/es/start/prerequisites.mdx
+++ b/src/content/docs/es/start/prerequisites.mdx
@@ -58,7 +58,8 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg
+  librsvg \
+  xdotool
 ```
 
   </TabItem>
@@ -72,7 +73,8 @@ sudo dnf install webkit2gtk4.1-devel \
   wget \
   file \
   libappindicator-gtk3-devel \
-  librsvg2-devel
+  librsvg2-devel \
+  libxdo-devel
 sudo dnf group install "c-development"
 ```
 

--- a/src/content/docs/fr/start/prerequisites.mdx
+++ b/src/content/docs/fr/start/prerequisites.mdx
@@ -56,7 +56,8 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg
+  librsvg \
+  xdotool
 ```
 
   </TabItem>
@@ -70,7 +71,8 @@ sudo dnf install webkit2gtk4.1-devel \
   wget \
   file \
   libappindicator-gtk3-devel \
-  librsvg2-devel
+  librsvg2-devel \
+  libxdo-devel
 sudo dnf group install "c-development"
 ```
 

--- a/src/content/docs/ja/start/prerequisites.mdx
+++ b/src/content/docs/ja/start/prerequisites.mdx
@@ -55,7 +55,8 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg
+  librsvg \
+  xdotool
 ```
 
   </TabItem>
@@ -69,7 +70,8 @@ sudo dnf install webkit2gtk4.1-devel \
   wget \
   file \
   libappindicator-gtk3-devel \
-  librsvg2-devel
+  librsvg2-devel \
+  libxdo-devel
 sudo dnf group install "c-development"
 ```
 

--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -55,7 +55,8 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg
+  librsvg \
+  xdotool
 ```
 
   </TabItem>
@@ -69,7 +70,8 @@ sudo dnf install webkit2gtk4.1-devel \
   wget \
   file \
   libappindicator-gtk3-devel \
-  librsvg2-devel
+  librsvg2-devel \
+  libxdo-devel
 sudo dnf group install "c-development"
 ```
 

--- a/src/content/docs/zh-cn/start/prerequisites.mdx
+++ b/src/content/docs/zh-cn/start/prerequisites.mdx
@@ -53,7 +53,8 @@ sudo pacman -S --needed \
   openssl \
   appmenu-gtk-module \
   libappindicator-gtk3 \
-  librsvg
+  librsvg \
+  xdotool
 ```
 
   </TabItem>
@@ -67,7 +68,8 @@ sudo dnf install webkit2gtk4.1-devel \
   wget \
   file \
   libappindicator-gtk3-devel \
-  librsvg2-devel
+  librsvg2-devel \
+  libxdo-devel
 sudo dnf group install "c-development"
 ```
 


### PR DESCRIPTION
This adds libxdo to Arch Linux and Fedora on every prerequisites page. Let me know if i need to change anything.

Closes #3358