### PR TITLE
fix: sidecar arguments documentation not mentioning true and false values

### DIFF
--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -171,7 +171,7 @@ The string provided to `Command.sidecar` must match one of the strings defined i
 
 You can pass arguments to Sidecar commands just like you would for running normal [Command][std::process::Command].
 
-Arguments can be either **static** (e.g. `-o` or `serve`) or **dynamic** (e.g. `<file_path>` or `localhost:<PORT>`). You define the arguments in the exact order in which you'd call them. Static arguments are defined as-is, while dynamic arguments can be defined using a regular expression.
+Arguments can be either **static** (e.g. `-o` or `serve`) or **dynamic** (e.g. `<file_path>` or `localhost:<PORT>`). A value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. If neither `true` or `false` is set, you define the arguments in the exact order in which you'd call them. Static arguments are defined as-is, while dynamic arguments can be defined using a regular expression.
 
 First, define the arguments that need to be passed to the sidecar command in `src-tauri/capabilities/default.json`:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
This PR updates the [Sidecar](https://v2.tauri.app/develop/sidecar/) documentation page to mention a missing (but important) catch when declaring arguments for a sidecar.

As [the source code mentions](https://github.com/tauri-apps/tauri-plugin-shell/blob/v2/build.rs#L46) (and personally tested), a value of `true` for the `args` key in the Capabilities file will allow any arguments to be passed to the command, while `false` will disable all arguments. This is not mentioned in the current version of the docs.


<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
