### PR TITLE
docs: details typo

### DIFF
--- a/src/content/docs/blog/tauri-board-elections-2024.md
+++ b/src/content/docs/blog/tauri-board-elections-2024.md
@@ -2,7 +2,7 @@
 title: Tauri Board Elections 2024
 date: 2024-06-28
 authors: [jbolda]
-excerpt: The Tauri Programme is celebrating it's third anniversary of Tauri becoming a programme within The Commons Conservancy. We are hard at work bringing v2 to a stable release, and now the next round of Tauri Board Director elections is upon us!
+excerpt: The Tauri Programme is celebrating its third anniversary of Tauri becoming a programme within The Commons Conservancy. We are hard at work bringing v2 to a stable release, and now the next round of Tauri Board Director elections is upon us!
 ---
 
 The Tauri Programme is celebrating its third anniversary of Tauri becoming a programme within [The Commons Conservancy](https://commonsconservancy.org/). We are hard at work bringing v2 to a stable release, and now the next round of Tauri Board Director elections is upon us! Want to [get involved in other ways](#interested-in-getting-involved) and help Tauri towards v2? We would love your contributions especially to help evolve the documentation!

--- a/src/content/docs/concept/size.mdx
+++ b/src/content/docs/concept/size.mdx
@@ -103,7 +103,7 @@ This won't be accounting for dynamically added ACLs at runtime so make sure to c
 and let them generate a list of allowed commands from the ACL,
 this will then be used by the `generate_handler` macro to remove unused commands based on that
 
-An internal detial is this environment variable is currently `REMOVE_UNUSED_COMMANDS`,
+An internal detail is this environment variable is currently `REMOVE_UNUSED_COMMANDS`,
 and it's set to project's directory, usually the `src-tauri` directory, this is used for the build scripts to find the capability files,
 and although it's not encouraged, you can still set this environment variable yourself if you can't or don't want to use `tauri-cli` to get this to work
 (**do note that as this is an implementation detail, we don't guarantee the stability of it**)


### PR DESCRIPTION
#### Description

Corrects a few spelling English spelling mistakes in the docs. 

