### PR TITLE
feat: add case-sensitive notice for configuration

### DIFF
--- a/src/content/docs/develop/configuration-files.mdx
+++ b/src/content/docs/develop/configuration-files.mdx
@@ -76,7 +76,7 @@ pubkey = "updater pub key"
 endpoints = ["https://my.app.updater/{{target}}/{{current_version}}"]
 ```
 
-Note that JSON5 and TOML supports comments, and TOML can use kebab-case for config names which are more idiomatic.
+Note that JSON5 and TOML supports comments, and TOML can use kebab-case for config names which are more idiomatic. JSON5 field names are case-sensitive.
 
 ### Platform-specific Configuration
 

--- a/src/content/docs/develop/configuration-files.mdx
+++ b/src/content/docs/develop/configuration-files.mdx
@@ -76,7 +76,7 @@ pubkey = "updater pub key"
 endpoints = ["https://my.app.updater/{{target}}/{{current_version}}"]
 ```
 
-Note that JSON5 and TOML supports comments, and TOML can use kebab-case for config names which are more idiomatic. JSON5 field names are case-sensitive.
+Note that JSON5 and TOML supports comments, and TOML can use kebab-case for config names which are more idiomatic. Field names are case-sensitive in all 3 formats.
 
 ### Platform-specific Configuration
 


### PR DESCRIPTION
#### Description
- Added a brief note about JSON5 field case sensitivity in the configuration formats section
- Related [tauri-apps/tauri#13480](https://github.com/tauri-apps/tauri/issues/13480)

https://github.com/tauri-apps/tauri/issues/13480
> > > The `macOS` key is case-sensitive so you need `bundle.macOS` not ` bundle.macos`macOS `` 密钥区分大小写，因此您需要 `bundle.macOS` 而不是 `bundle.macos`
> > 
> > 
> > [@FabianLars](https://github.com/FabianLars)
> > “Hi, could you add a section on the official website for common issues or FAQs?”
> 
> @AprilNEA: JSON itself is case-sensitive, I don't think there is any need to add explanations. But if we need it: [tauri-apps/tauri-docs#3380](https://github.com/tauri-apps/tauri-docs/pull/3380)

