### PR TITLE
docs: add missing link to `log` crate

### DIFF
--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -371,3 +371,5 @@ See the [Capabilities Overview](/security/capabilities/) for more information an
 ```
 
 <PluginPermissions plugin={frontmatter.plugin} />
+
+[`log` crate]: https://crates.io/crates/log


### PR DESCRIPTION
#### Description

There are several mentions but none are properly linked.