### PR TITLE
Update windows-installer.mdx to display correct FIPS environment variable

### DIFF
--- a/src/content/docs/distribute/windows-installer.mdx
+++ b/src/content/docs/distribute/windows-installer.mdx
@@ -196,11 +196,11 @@ tauri-plugin-notification = { version = "2.0.0", features = [ "windows7-compat" 
 
 ## FIPS Compliance
 
-If your system requires the MSI bundle to be FIPS compliant you can set the `TAURI_FIPS_COMPLIANT` environment variable to `true`
+If your system requires the MSI bundle to be FIPS compliant you can set the `TAURI_BUNDLER_WIX_FIPS_COMPLIANT` environment variable to `true`
 before running `tauri build`. In PowerShell you can set it for the current terminal session like this:
 
 ```powershell
-$env:TAURI_FIPS_COMPLIANT="true"
+$env:TAURI_BUNDLER_WIX_FIPS_COMPLIANT="true"
 ```
 
 ## WebView2 Installation Options


### PR DESCRIPTION
**What does this PR change**? This pull request changes the Windows installer documentation to display the correct `TAURI_BUNDLER_WIX_FIPS_COMPLIANT` environment variable over `TAURI_FIPS_COMPLIANT`, which is being used in the documentation. This environment variable was renamed in https://github.com/tauri-apps/tauri/commit/8b166e9bf82e69ddb3200a3a825614980bd8d433.

