### PR TITLE
Update multi-level menu example to include MacOS gotchas

### DIFF
--- a/src/content/docs/learn/window-menu.mdx
+++ b/src/content/docs/learn/window-menu.mdx
@@ -143,13 +143,29 @@ fn main() {
 
 ## Creating a multi-level menu
 
-To create a multi-level menu, you can add some submenus to the menu item:
+Multi-level menus allow you to group menu items under categories like "File," "Edit," etc. These will appear as part of the application window for Windows or Linux, or in the menu bar on MacOS.
+
+**Note:** When using submenus on MacOS, all items must be grouped under a submenu. Top-level items will be ignored. Additionally, the first submenu will be placed under the application's about menu by default, regardless of the `text` label. You should include a submenu as the first entry (say, an "About" submenu) to fill this space.
 
 <Tabs>
 <TabItem label="JavaScript">
 
 ```javascript
 import { Menu, MenuItem, Submenu } from '@tauri-apps/api/menu';
+
+// Will become the application submenu on MacOS
+const aboutSubmenu = await Submenu.new({
+  text: 'About',
+  items: [
+    await MenuItem.new({
+      id: 'quit',
+      text: 'Quit',
+      action: () => {
+        console.log('Quit pressed');
+      },
+    }),
+  ],
+});
 
 const fileSubmenu = await Submenu.new({
   text: 'File',
@@ -200,15 +216,9 @@ const editSubmenu = await Submenu.new({
 
 const menu = await Menu.new({
   items: [
+    aboutSubmenu,
     fileSubmenu,
     editSubmenu,
-    await MenuItem.new({
-      id: 'quit',
-      text: 'Quit',
-      action: () => {
-        console.log('Quit pressed');
-      },
-    }),
   ],
 });
 

--- a/src/content/docs/learn/window-menu.mdx
+++ b/src/content/docs/learn/window-menu.mdx
@@ -215,11 +215,7 @@ const editSubmenu = await Submenu.new({
 });
 
 const menu = await Menu.new({
-  items: [
-    aboutSubmenu,
-    fileSubmenu,
-    editSubmenu,
-  ],
+  items: [aboutSubmenu, fileSubmenu, editSubmenu],
 });
 
 menu.setAsAppMenu();


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

I copied the multi-level menu example into my app, and was surprised to find some broken behavior on MacOS:
- the "Quit" option was ignored because it was a top-level property
- the "File" menu was swallowed into the application submenu

This updates the multi-level menu to better explain what multi-level menus accomplish, and how to avoid these pitfalls on MacOS. I also updated the JavaScript example to what I'd recommend for cross-system multi-level menus. I noticed the Rust example was entirely different from the JavaScript example, so I didn't touch that one. Curious if that should be updated to match.

<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
