### PR TITLE
fix 'platform-specific' heading on js api

### DIFF
--- a/packages/js-api-generator/build.ts
+++ b/packages/js-api-generator/build.ts
@@ -184,10 +184,19 @@ class TauriThemeRenderContext extends MarkdownThemeContext {
       },
       // Remove heading markers from JSDoc comments to prevent accidental markdown headings
       comment: function (comment, options) {
+        const headingStringsToReplace = [
+          // known to break
+          '#### Platform-specific',
+          // just to be sure
+          '### Platform-specific',
+        ];
+
         if (comment?.summary) {
           comment.summary.forEach((line) => {
             if (line.kind === 'text' && typeof line.text === 'string') {
-              line.text = line.text.replace(/^([ 	]*)(#{1,6})(\s+)/gm, '$1$3');
+              headingStringsToReplace.forEach((headingString) => {
+                line.text = line.text.replace(headingString, headingString.replace(/^#+\s*/, ''));
+              });
             }
           });
         }
@@ -195,7 +204,9 @@ class TauriThemeRenderContext extends MarkdownThemeContext {
           comment.blockTags.forEach((tag) => {
             tag.content.forEach((line) => {
               if (line.kind === 'text' && typeof line.text === 'string') {
-                line.text = line.text.replace(/^([ 	]*)(#{1,6})(\s+)/gm, '$1$3');
+                headingStringsToReplace.forEach((headingString) => {
+                  line.text = line.text.replace(headingString, headingString.replace(/^#+\s*/, ''));
+                });
               }
             });
           });

--- a/packages/js-api-generator/build.ts
+++ b/packages/js-api-generator/build.ts
@@ -169,6 +169,8 @@ function pageEventEnd(event: PageEvent<DeclarationReflection>) {
 class TauriThemeRenderContext extends MarkdownThemeContext {
   constructor(theme: MarkdownTheme, page: MarkdownPageEvent<Reflection>, options: Options) {
     super(theme, page, options);
+    const originalCommentPartial = this.partials.comment;
+
     this.partials = {
       ...this.partials,
       // Formats `@source` to be a single line
@@ -179,6 +181,26 @@ class TauriThemeRenderContext extends MarkdownThemeContext {
         let label = model.sources.length > 1 ? '**Sources**: ' : '**Source**: ';
         const sources = model.sources.map((source) => `${source.url}`);
         return label + sources.join(', ');
+      },
+      // Remove heading markers from JSDoc comments to prevent accidental markdown headings
+      comment: function (comment, options) {
+        if (comment?.summary) {
+          comment.summary.forEach((line) => {
+            if (line.kind === 'text' && typeof line.text === 'string') {
+              line.text = line.text.replace(/^([ 	]*)(#{1,6})(\s+)/gm, '$1$3');
+            }
+          });
+        }
+        if (comment?.blockTags) {
+          comment.blockTags.forEach((tag) => {
+            tag.content.forEach((line) => {
+              if (line.kind === 'text' && typeof line.text === 'string') {
+                line.text = line.text.replace(/^([ 	]*)(#{1,6})(\s+)/gm, '$1$3');
+              }
+            });
+          });
+        }
+        return originalCommentPartial.call(this, comment, options);
       },
     };
   }

--- a/packages/js-api-generator/package.json
+++ b/packages/js-api-generator/package.json
@@ -15,6 +15,7 @@
     "tsm": "^2.3.0",
     "typedoc": "0.26.6",
     "typedoc-plugin-markdown": "4.2.6",
-    "typedoc-plugin-mdn-links": "3.2.11"
+    "typedoc-plugin-mdn-links": "3.2.11",
+    "typescript": "5.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,13 +130,16 @@ importers:
         version: 2.3.0
       typedoc:
         specifier: 0.26.6
-        version: 0.26.6(typescript@5.8.3)
+        version: 0.26.6(typescript@5.5.4)
       typedoc-plugin-markdown:
         specifier: 4.2.6
-        version: 4.2.6(typedoc@0.26.6(typescript@5.8.3))
+        version: 4.2.6(typedoc@0.26.6(typescript@5.5.4))
       typedoc-plugin-mdn-links:
         specifier: 3.2.11
-        version: 3.2.11(typedoc@0.26.6(typescript@5.8.3))
+        version: 3.2.11(typedoc@0.26.6(typescript@5.5.4))
+      typescript:
+        specifier: '5.5'
+        version: 5.5.4
 
   packages/releases-generator:
     dependencies:
@@ -3632,6 +3635,11 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -8354,22 +8362,24 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typedoc-plugin-markdown@4.2.6(typedoc@0.26.6(typescript@5.8.3)):
+  typedoc-plugin-markdown@4.2.6(typedoc@0.26.6(typescript@5.5.4)):
     dependencies:
-      typedoc: 0.26.6(typescript@5.8.3)
+      typedoc: 0.26.6(typescript@5.5.4)
 
-  typedoc-plugin-mdn-links@3.2.11(typedoc@0.26.6(typescript@5.8.3)):
+  typedoc-plugin-mdn-links@3.2.11(typedoc@0.26.6(typescript@5.5.4)):
     dependencies:
-      typedoc: 0.26.6(typescript@5.8.3)
+      typedoc: 0.26.6(typescript@5.5.4)
 
-  typedoc@0.26.6(typescript@5.8.3):
+  typedoc@0.26.6(typescript@5.5.4):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       shiki: 1.29.2
-      typescript: 5.8.3
+      typescript: 5.5.4
       yaml: 2.6.0
+
+  typescript@5.5.4: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
https://github.com/tauri-apps/tauri/blob/dev/packages/api/src/window.ts#L639

related #3297 (don't close as the issue may still be lingering)



~it should fix situations where comment blocks with hashes causes heading as detailed in the issue~




~...not that simple, some heading in code blocks are actually needed~