### PR TITLE
fix(docs): correct malformed SVG path tag in Tauri documentation

### DIFF
--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -122,7 +122,7 @@ Put this at the top of your `<body>` tag:
     <button id="titlebar-minimize" title="minimize">
       <!-- https://api.iconify.design/mdi:window-minimize.svg -->
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-        <path fill="currentColor" d="M19 13H5v-2h14z" /><path>
+        <path fill="currentColor" d="M19 13H5v-2h14z" />
       </svg>
     </button>
     <button id="titlebar-maximize" title="maximize">


### PR DESCRIPTION
Fixed a malformed <path> tag in an SVG element within the Tauri documentation. The SVG had an incomplete second <path> tag with no attributes or closing syntax, which could lead to rendering issues or unexpected behavior.

Original (buggy):
```
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
  <path fill="currentColor" d="M19 13H5v-2h14z" /><path>
</svg>
```

Updated:
```
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
  <path fill="currentColor" d="M19 13H5v-2h14z" />
</svg>
```

This change ensures that the SVG is valid and renders correctly.