### PR TITLE
Update action sponsors

### DIFF
--- a/.github/workflows/syncSponsorsData.yml
+++ b/.github/workflows/syncSponsorsData.yml
@@ -1,4 +1,4 @@
-name: 'Sync Sponsors and Contributors Data'
+name: 'Sync Sponsors Data'
 
 on:
   schedule:
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  fetch-sponsors-data:
-    name: Sync Sponsors and Contributors Data
+  sync-sponsors-data:
+    name: Sync Sponsors Data
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,8 +26,8 @@ jobs:
 
       - run: pnpm i
               
-      - name: fetch-sponsors
-        run: pnpm --filter fetch-sponsors run build
+      - name: sync-sponsors
+        run: pnpm sync:sponsors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
@@ -43,9 +43,8 @@ jobs:
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
-          commit-message: 'chore(docs): Update Sponsors & Contributors Data'
-          branch: ci/v2/update-data-docs
+          commit-message: 'chore(docs): Update Sponsors Data'
+          branch: ci/v2/update-sponsors
           path: tauri-docs
-          title: Update Sponsors & Contributors Data
+          title: Update Sponsors Data
           labels: 'bot'
-            

--- a/.github/workflows/syncSponsorsData.yml
+++ b/.github/workflows/syncSponsorsData.yml
@@ -10,8 +10,6 @@ jobs:
   sync-sponsors-data:
     name: Sync Sponsors Data
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     
     steps:
       - name: Checkout repository
@@ -45,6 +43,5 @@ jobs:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
           commit-message: 'chore(docs): Update Sponsors Data'
           branch: ci/v2/update-sponsors
-          path: tauri-docs
           title: Update Sponsors Data
           labels: 'bot'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev:setup:tauri": "pnpm install -C packages/tauri/packages/api --ignore-workspace --no-frozen-lockfile",
     "dev:setup:plugins-workspace": "pnpm -C packages/plugins-workspace install",
     "dev:setup": "pnpm dev:setup:submodules && pnpm dev:setup:tauri && pnpm dev:setup:plugins-workspace && pnpm build:compatibility-table",
+    "sync:sponsors": "pnpm --filter fetch-sponsors run build -- sponsors",
+    "sync:contributors": "pnpm --filter fetch-sponsors run build -- contributors",
     "dev": "astro dev",
     "format": "prettier -w --cache --plugin prettier-plugin-astro .",
     "format:check": "prettier -c --cache --plugin prettier-plugin-astro .",

--- a/packages/fetch-sponsors/main.ts
+++ b/packages/fetch-sponsors/main.ts
@@ -2,10 +2,21 @@ import { fetchGitHubContributorsData } from './githubContributors.ts';
 import { fetchGitHubSponsors } from './githubSponsors.ts';
 import { fetchOpenCollectiveData } from './openCollective.ts';
 
-async function main() {
-  await fetchOpenCollectiveData();
-  await fetchGitHubSponsors();
+export async function fetchContributors() {
   await fetchGitHubContributorsData();
 }
 
-main();
+export async function fetchSponsors() {
+  await fetchOpenCollectiveData();
+  await fetchGitHubSponsors();
+}
+
+const target = process.argv[2];
+
+if (target === 'contributors') {
+  await fetchContributors();
+} else if (target === 'sponsors') {
+  await fetchSponsors();
+} else {
+  process.exit(1);
+}


### PR DESCRIPTION
mostly rename from fetch->sync and removed path because I copied this from v1 and missed that, thus it failed because it should run on root

also now it just runs sponsors because it what we need for now

for contributors I'll make another action that will run monthly or maybe improve the script to be incremental, right now it takes a long time and it isn't efficient