### PR TITLE
docs: fix apt-get install snippet in Ubuntu CI example

### DIFF
--- a/src/content/docs/develop/Tests/WebDriver/ci.md
+++ b/src/content/docs/develop/Tests/WebDriver/ci.md
@@ -52,10 +52,10 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update &&
-          sudo apt-get install -y
-          libwebkit2gtk-4.1-dev
-          libayatana-appindicator3-dev
-          webkit2gtk-driver
+          sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libayatana-appindicator3-dev \
+          webkit2gtk-driver \
           xvfb
 
       # install a matching Microsoft Edge Driver version using msedgedriver-tool


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
This PR fixes a small issue in the documentation for setting up Tauri dependencies on Ubuntu in GitHub Actions

**Problem**
The `apt-get install -y` line in the example was split across multiple lines without backslashes, causing each package name to be interpreted as a separate shell command. This led to errors like:
```
line 3: libwebkit2gtk-4.1-dev: command not found
```
**Fix**
Updated the snippet to install all required packages using backslashes for line continuation
<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
