### PR TITLE
Clarify explanation of rust dependencies as they relate to the CLI version

### DIFF
--- a/src/content/docs/develop/configuration-files.mdx
+++ b/src/content/docs/develop/configuration-files.mdx
@@ -201,7 +201,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.0.0", features = [ ] }
 ```
 
-The most important parts to take note of are the `tauri-build` and `tauri` dependencies. Generally, they must both be on the latest minor versions as the Tauri CLI, but this is not strictly required. If you encounter issues while trying to run your app you should check that any Tauri versions (`tauri` and `tauri-cli`) are on the latest versions for their respective minor releases.
+The most important parts to take note of are the `tauri-build` and `tauri` dependencies. Generally, they must both be on the same latest minor versions as the Tauri CLI, but this is not strictly required. If you encounter issues while trying to run your app you should check that any Tauri versions (`tauri` and `tauri-cli`) are on the latest versions for their respective minor releases.
 
 Cargo version numbers use [Semantic Versioning]. Running `cargo update` in the `src-tauri` folder will pull the latest available Semver-compatible versions of all dependencies. For example, if you specify `2.0.0` as the version for `tauri-build`, Cargo will detect and download version `2.0.0.0` because it is the latest Semver-compatible version available. Tauri will update the major version number whenever a breaking change is introduced, meaning you should always be capable of safely upgrading to the latest minor and patch versions without fear of your code breaking.
 


### PR DESCRIPTION
Reading through the docs, I saw in the explanation of the tauri and tauri-build dependencies and was a little confused. This PR attempts to clarify (though it's possible I am incorrect in this edit).

Thank you!
