### PR TITLE
Add docs for target-specific formatters in log plugin

### DIFF
--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -350,7 +350,7 @@ to remove the default formatter, which is applied to all targets:
 
 ```rust
 tauri_plugin_log::Builder::new()
-    .reset_format()
+    .clear_format()
     .targets([
         tauri_plugin_log::Target::new(
             tauri_plugin_log::TargetKind::Stdout

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -345,7 +345,7 @@ tauri_plugin_log::Builder::new()
 ### Applying a different format to targets
 
 You can specify your own log format for specific targets by using the `format` method
-on `tauri_plugin_log::Target`. You may also wish to call `reset_format` on the builder
+on `tauri_plugin_log::Target`. You may also wish to call `clear_format` on the builder
 to remove the default formatter, which is applied to all targets:
 
 ```rust

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -342,6 +342,32 @@ tauri_plugin_log::Builder::new()
   .build()
 ```
 
+### Applying a different format to targets
+
+You can specify your own log format for specific targets by using the `format` method
+on `tauri_plugin_log::Target`. You may also wish to call `clear_format` on the builder
+to remove the default formatter, which is applied to all targets:
+
+```rust
+tauri_plugin_log::Builder::new()
+    .clear_format()
+    .targets([
+        tauri_plugin_log::Target::new(
+            tauri_plugin_log::TargetKind::Stdout
+        )
+        .format(move |out, message, record| {
+            // custom formatter for stdout
+        }),
+        tauri_plugin_log::Target::new(
+            tauri_plugin_log::TargetKind::LogDir { file_name: None }
+        )
+        .format(move |out, message, record| {
+            // custom formatter for log files
+        }),
+    ])
+    .build(),
+```
+
 #### Log dates
 
 By default the log plugin uses the UTC timezone to format dates

--- a/src/content/docs/plugin/logging.mdx
+++ b/src/content/docs/plugin/logging.mdx
@@ -345,12 +345,12 @@ tauri_plugin_log::Builder::new()
 ### Applying a different format to targets
 
 You can specify your own log format for specific targets by using the `format` method
-on `tauri_plugin_log::Target`. You may also wish to call `clear_format` on the builder
+on `tauri_plugin_log::Target`. You may also wish to call `reset_format` on the builder
 to remove the default formatter, which is applied to all targets:
 
 ```rust
 tauri_plugin_log::Builder::new()
-    .clear_format()
+    .reset_format()
     .targets([
         tauri_plugin_log::Target::new(
             tauri_plugin_log::TargetKind::Stdout


### PR DESCRIPTION
This PR updates the log plugin docs in conjunction with https://github.com/tauri-apps/plugins-workspace/pull/3065, which allows a formatter per target.