### PR TITLE
docs: fix typos and grammar in events documentation

### DIFF
--- a/src/content/docs/develop/_sections/frontend-listen.mdx
+++ b/src/content/docs/develop/_sections/frontend-listen.mdx
@@ -64,8 +64,8 @@ appWebview.once('ready', () => {});
 ```
 
 :::note
-Events emitted in the frontend also triggers listeners registed by these APIs.
-For more information see the [Calling Rust from the Frontend] documentation.
+Events emitted in the frontend also trigger listeners registered by these APIs.
+For more information, see the [Calling Rust from the Frontend] documentation.
 :::
 
 #### Listening to Events on Rust


### PR DESCRIPTION
This PR fixes a few minor typos and a subject-verb agreement issue in the events documentation.

Changes made:
- "registed" → "registered"
- Updated "triggers" to "trigger" to match plural subject "Events"
- Added a comma after "For more information" for grammatical correctness

These small fixes improve readability and accuracy without altering meaning.
