### PR TITLE
Docs: Document transaction handling in migrations

### DIFF
--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -277,6 +277,8 @@ To apply the migrations when the plugin is initialized, add the connection strin
 }
 ```
 
+> **Note:** All migrations are executed within a transaction, ensuring atomicity. If any migration fails, the entire transaction is rolled back, leaving the database in a consistent state.
+
 Alternatively, the client side `load()` also runs the migrations for a given connection string:
 
 ```ts

--- a/src/content/docs/plugin/sql.mdx
+++ b/src/content/docs/plugin/sql.mdx
@@ -277,8 +277,6 @@ To apply the migrations when the plugin is initialized, add the connection strin
 }
 ```
 
-> **Note:** All migrations are executed within a transaction, ensuring atomicity. If any migration fails, the entire transaction is rolled back, leaving the database in a consistent state.
-
 Alternatively, the client side `load()` also runs the migrations for a given connection string:
 
 ```ts
@@ -287,6 +285,10 @@ const db = await Database.load('sqlite:mydatabase.db');
 ```
 
 Ensure that the migrations are defined in the correct order and are safe to run multiple times.
+
+:::note
+All migrations are executed within a transaction, ensuring atomicity. If any migration fails, the entire transaction is rolled back, leaving the database in a consistent state.
+:::
 
 ### Migration Management
 


### PR DESCRIPTION
Added note about transaction handling during migrations.

#### Description
- Why open this PR? I had a rather standard question regarding if the SQL plugin automatically executes migrations inside of transaction, I wasn't able to find an answer in the docs or via the discord channel so I had to look inside of sqlx' and this plugin's code to verify that it does.
- What does this PR change? Adds a small note that migrations are automatically being run inside of transactions.