### PR TITLE
docs: Update webkit2gtk package for Alpine installation

### DIFF
--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -125,7 +125,7 @@ sudo zypper in -t pattern devel_basis
 ```sh
 sudo apk add \
   build-base \
-  webkit2gtk \
+  webkit2gtk-4.1-dev \
   curl \
   wget \
   file \

--- a/src/content/docs/start/prerequisites.mdx
+++ b/src/content/docs/start/prerequisites.mdx
@@ -133,6 +133,9 @@ sudo apk add \
   libayatana-appindicator-dev \
   librsvg
 ```
+
+> Note: Alpine Linux containers don’t include any fonts by default. To ensure text renders correctly in your Tauri app, install at least one font package (for example, `font-dejavu `).
+
   </TabItem>
   <TabItem label="NixOS">
 


### PR DESCRIPTION
#### Description

- What does this PR change? Give us a brief description.

Fixed dependency name for alpine linux from `webkit2gtk` to `webkit2gtk-4.1-dev`.

I also want to note that when working with alpine in a container it's required to install a font manually, unlike when using a debian container, should this be mentioned under the prerequisites for alpine or not?