### PR TITLE
docs(plugin/store): fix duplicated 'calls' in comment

### DIFF
--- a/src/content/docs/plugin/store.mdx
+++ b/src/content/docs/plugin/store.mdx
@@ -116,8 +116,9 @@ pub fn run() {
         .setup(|app| {
             // Create a new store or load the existing one
             // this also put the store in the app's resource table
-            // so your following calls `store` calls (from both rust and js)
-            // will reuse the same store
+            // so your following `store` calls (from both Rust and JS)
+            // will reuse the same store.
+
             let store = app.store("store.json")?;
 
             // Note that values must be serde_json::Value instances,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
This PR fixes a small typo in the plugin store documentation.
- Removed the duplicated word “calls” from the comment in `src/content/docs/plugin/store.mdx`.
- Improved clarity by keeping `store` in backticks and capitalizing “Rust” and “JS” for consistency.
Closes tauri-apps/tauri#14440
<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
