### PR TITLE
fix(example): correct the path string used in tauri.conf.json

### DIFF
--- a/src/content/docs/distribute/windows-installer.mdx
+++ b/src/content/docs/distribute/windows-installer.mdx
@@ -293,11 +293,11 @@ Distributing a fixed WebView2 Runtime version increases the Windows Installer by
 :::
 
 1. Download the WebView2 fixed version runtime from [Microsoft's website][download-webview2-runtime].
-   In this example, the downloaded filename is `Microsoft.WebView2.FixedVersionRuntime.128.0.2739.42.x64.cab`
+   In this example, the downloaded filename is `Microsoft.WebView2.FixedVersionRuntime.142.0.3595.80.x64.cab`
 2. Extract the file to the core folder:
 
 ```powershell
-Expand .\Microsoft.WebView2.FixedVersionRuntime.128.0.2739.42.x64.cab -F:* ./src-tauri
+Expand .\Microsoft.WebView2.FixedVersionRuntime.142.0.3595.80.x64.cab -F:* ./src-tauri
 ```
 
 3. Configure the WebView2 runtime path in `tauri.conf.json`:
@@ -308,7 +308,7 @@ Expand .\Microsoft.WebView2.FixedVersionRuntime.128.0.2739.42.x64.cab -F:* ./src
     "windows": {
       "webviewInstallMode": {
         "type": "fixedRuntime",
-        "path": "./Microsoft.WebView2.FixedVersionRuntime.98.0.1108.50.x64/"
+        "path": "Microsoft.WebView2.FixedVersionRuntime.142.0.3595.80.x64"
       }
     }
   }


### PR DESCRIPTION
update version number, to indicate the edit time, also removed "./"and"/"around path to prevent a bug

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
before this patch the documentation will lead user (me for example...😡) to create a totally broken bundle where the Webview Runtime will be extracted in a recursive folder e.g. \Microsoft.WebView2.FixedVersionRuntime.142.0.3595.80.x64\Microsoft.WebView2.FixedVersionRuntime.142.0.3595.80.x64\ and the installed app won't be able to find the webview runtime correctly.

This can be fixed by removing the "./" and "/" around tauri.conf.json::bundle.windows.webviewInstallMode.path in the documentation.

I hope this pr can be merged so that this mislead won't bother more peple like me...

[chat with copilot who gave me this solution](https://github.com/copilot/share/c2470228-09a0-8ce0-9811-820e60c708e4)

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
