### PR TITLE
Rename `APPLE_ID_PASSWORD` (incorrect / unused) to `APPLE_PASSWORD`

### DIFF
--- a/src/content/docs/distribute/Sign/macos.mdx
+++ b/src/content/docs/distribute/Sign/macos.mdx
@@ -96,7 +96,7 @@ openssl base64 -in /path/to/certificate.p12 -out certificate-base64.txt
 Required secrets:
 
 - `APPLE_ID` - Your Apple ID email
-- `APPLE_ID_PASSWORD` - Your Apple ID password
+- `APPLE_PASSWORD` - Your Apple ID password
 - `APPLE_CERTIFICATE` - The base64 encoded `.p12` file
 - `APPLE_CERTIFICATE_PASSWORD` - The password for your exported `.p12` file
 - `KEYCHAIN_PASSWORD` - The password for your keychain
@@ -124,7 +124,7 @@ jobs:
     runs-on: macos-latest
     env:
       APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
     steps:
       - name: Import Apple Developer Certificate
         env:


### PR DESCRIPTION
#### Description

I was confused that on the same page `APPLE_PASSWORD` and `APPLE_ID_PASSWORD` are mentioned.

<details>
  <summary>See examples</summary>
  
https://v2.tauri.app/distribute/sign/macos/#signing-in-cicd-platforms
<img width="720" height="276" alt="Screenshot 2025-11-18 at 13 34 24" src="https://github.com/user-attachments/assets/6d96b565-fff2-4f6a-9cd2-320d9ed22a4a" />

https://v2.tauri.app/distribute/sign/macos/#notarization
<img width="748" height="341" alt="Screenshot 2025-11-18 at 13 34 02" src="https://github.com/user-attachments/assets/b91a6d5b-abc9-4efc-b8a6-5fd94226f78d" />

</details>

So I looked around all repos:
https://github.com/search?q=org%3Atauri-apps+APPLE_ID_PASSWORD&type=code
https://github.com/search?q=org%3Atauri-apps+APPLE_PASSWORD&type=code

I found out in https://github.com/tauri-apps/tauri/blob/f855caf8a3830aa5dd6d0b039312866a5d9c3606/crates/tauri-bundler/src/bundle/macos/sign.rs#L100 that actually only `APPLE_PASSWORD` is used.

So this PR removes the confusion by renaming to the correct variable.

Note: I tried this in my own GitHub Actions and can confirm that it works.