### PR TITLE
fix: delete redundant content in Passing Arguments section

### DIFF
--- a/src/content/docs/develop/calling-rust.mdx
+++ b/src/content/docs/develop/calling-rust.mdx
@@ -162,6 +162,8 @@ You can use `snake_case` for the arguments with the `rename_all` attribute:
 fn my_custom_command(invoke_message: String) {}
 ```
 
+The corresponding JavaScript:
+
 ```javascript
 invoke('my_custom_command', { invoke_message: 'Hello!' });
 ```
@@ -169,12 +171,6 @@ invoke('my_custom_command', { invoke_message: 'Hello!' });
 :::
 
 Arguments can be of any type, as long as they implement [`serde::Deserialize`].
-
-The corresponding JavaScript:
-
-```javascript
-invoke('my_custom_command', { invoke_message: 'Hello!' });
-```
 
 ### Returning Data
 


### PR DESCRIPTION
#### Description
There's redundant content in Passing Arguments section about the JavaScript code corresponding to the command with a snake_case argument.