### PR TITLE
fix(geolocation/ios): proper `Info.plist` key

### DIFF
--- a/src/content/docs/plugin/geolocation.mdx
+++ b/src/content/docs/plugin/geolocation.mdx
@@ -92,7 +92,7 @@ Apple requires privacy descriptions to be specified in Info.plist for location i
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
-        <key>NSLocationWhenInUseDescription</key>
+        <key>NSLocationWhenInUseUsageDescription</key>
         <string>Required to do XY</string>
     </dict>
 </plist>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

On iOS, the key in Info.plist for geolocation usage is `NSLocationWhenInUseUsageDescription`.
When mistyped, an error can be logged saying geolocation can not be used because this key is missing. 

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
