### PR TITLE
docs(window): add userland example for detecting drag-stopped and res…

### DIFF
--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -306,4 +306,42 @@ Create the main window and change its background color:
     		.run(tauri::generate_context!())
     		.expect("error while running tauri application");
     }
+
+
+    ## Detecting When Window Drag or Resize Has Stopped (Userland Example)
+
+Tauri does not currently expose native “drag finished” or “resize finished” events
+from the operating system. However, you can implement this behavior in userland
+by listening to the continuously emitted `tauri://move` and `tauri://resize`
+events and detecting when movement or resizing stops.
+
+```ts
+import { appWindow } from "@tauri-apps/api/window";
+
+// Detect when window dragging stops
+let dragTimer: number | null = null;
+appWindow.listen("tauri://move", () => {
+  clearTimeout(dragTimer);
+  dragTimer = setTimeout(() => {
+    window.dispatchEvent(new CustomEvent("drag-stopped"));
+  }, 120);
+});
+
+// Detect when window resizing stops
+let resizeTimer: number | null = null;
+appWindow.listen("tauri://resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    window.dispatchEvent(new CustomEvent("resize-stopped"));
+  }, 120);
+});
+
+// Usage example
+window.addEventListener("drag-stopped", () => {
+  console.log("Window drag stopped");
+});
+
+window.addEventListener("resize-stopped", () => {
+  console.log("Window resize stopped");
+});
     ```


### PR DESCRIPTION
docs(window): add userland example for detecting drag-stopped and resize-stopped events

This PR adds a userland JavaScript example demonstrating how developers can
detect when a window drag or resize operation has *stopped* by listening to
the continuously emitted `tauri://move` and `tauri://resize` events and
debouncing them.

Since native drag-end / resize-end events are not currently exposed by Tauri
and JS event detection is not reliable enough to be implemented in the
runtime, this example provides a recommended, practical solution for
developers needing this behavior.

The new section is added to `learn/window-customization.mdx` where other
window interaction examples (dragging, maximizing, custom titlebars) are
already documented.