### PR TITLE
docs: Clarify header configuration for frameworks

### DIFF
--- a/src/content/docs/security/http-headers.mdx
+++ b/src/content/docs/security/http-headers.mdx
@@ -112,6 +112,12 @@ timing-allow-origin: https://developer.mozilla.org, https://example.com
 
 Some development environments require extra settings, to emulate the production environment.
 
+:::note
+In order to get headers to work for these frameworks, you may need to define them in both the framework's configuration (for development mode) and the Tauri config (for build mode). This is because: 
+- The frameworks won't include headers defined in their config files at build time.
+- Tauri can't inject headers into the framework's dev server – it can only inject headers to the final build output.
+:::
+
 #### JavaScript/TypeScript
 
 For setups running the build tool **Vite** (those include **Qwik, React, Solid, Svelte, and Vue**) add the wanted headers to `vite.config.ts`. 


### PR DESCRIPTION
#### Description
Context from Discord:
https://discord.com/channels/616186924390023171/1447703272520679475

Added note about configuring headers for frameworks in both development and build modes.

Open to feedback on the wording, thanks!