### PR TITLE
docs(opener): fix openUrl example name

### DIFF
--- a/src/content/docs/plugin/opener.mdx
+++ b/src/content/docs/plugin/opener.mdx
@@ -90,7 +90,7 @@ await openPath('/path/to/file');
 // opens a file using `vlc` command on Windows:
 await openPath('C:/path/to/file', 'vlc');
 // opens a URL using the default program:
-await openURL('https://tauri.app');
+await openUrl('https://tauri.app');
 ```
 
     </TabItem>


### PR DESCRIPTION
#### Description

Fixed incorrect function name in opener plugin JavaScript example. The code imports openUrl but incorrectly calls openURL.

```diff
-await openURL('https://tauri.app');
+await openUrl('https://tauri.app');
```