### PR TITLE
fix: Corrected the icon specifying an invalid color parameter

### DIFF
--- a/src/content/docs/distribute/app-store.mdx
+++ b/src/content/docs/distribute/app-store.mdx
@@ -24,12 +24,12 @@ Additionally, you must setup code signing for [macOS][macOS code signing] and [i
 After running `tauri ios init` to setup the Xcode project, you can use the `tauri icon` command to update the app icons.
 
 <CommandTabs
-  npm="npm run tauri icon /path/to/app-icon.png -- --ios-color #fff"
-  yarn="yarn tauri icon /path/to/app-icon.png --ios-color #fff"
-  pnpm="pnpm tauri icon /path/to/app-icon.png --ios-color #fff"
-  deno="deno task tauri icon /path/to/app-icon.png --ios-color #fff"
-  bun="bun tauri icon /path/to/app-icon.png --ios-color #fff"
-  cargo="cargo tauri icon /path/to/app-icon.png --ios-color #fff"
+  npm="npm run tauri icon /path/to/app-icon.png -- --ios-color '#fff'"
+  yarn="yarn tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  pnpm="pnpm tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  deno="deno task tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  bun="bun tauri icon /path/to/app-icon.png --ios-color '#fff'"
+  cargo="cargo tauri icon /path/to/app-icon.png --ios-color '#fff'"
 />
 
 The `--ios-color` argument defines the background color for the iOS icons.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

fix(distribute): Corrected the APP icon specifying an invalid color parameter.

In the `tauri icon path_to_icon.png --ios-color #fff` command, the parameter value of `--ios-color` is mistakenly recognized as a command comment by the terminal, leading to a failure in execution. It is necessary to add quotes around the color value to avoid this issue.

```
➜  app git:(master) ✗ yarn tauri icon ./src-tauri/icons/icon.png --ios-color #fff
error: a value is required for '--ios-color <IOS_COLOR>' but none was supplied
```