### PR TITLE
docs: correct links to @yao-pkg/pkg fork

### DIFF
--- a/src/content/docs/learn/sidecar-nodejs.mdx
+++ b/src/content/docs/learn/sidecar-nodejs.mdx
@@ -259,5 +259,5 @@ Without the plugin being initialized and configured the example won't work.
 [sidecar guide]: /develop/sidecar/
 [process.argv]: https://nodejs.org/docs/latest/api/process.html#processargv
 [console.log]: https://nodejs.org/api/console.html#consolelogdata-args
-[pkg]: https://github.com/vercel/pkg
+[pkg]: https://github.com/yao-pkg/pkg
 [`bundle > externalBin`]: /reference/config/#externalbin


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->

#2965 missed this:

https://github.com/tauri-apps/tauri-docs/blob/30591e4c0d9fccf84f1a0ce14dabbec51331e851/src/content/docs/learn/sidecar-nodejs.mdx#L25
https://github.com/tauri-apps/tauri-docs/blob/30591e4c0d9fccf84f1a0ce14dabbec51331e851/src/content/docs/learn/sidecar-nodejs.mdx#L68-L69
https://github.com/tauri-apps/tauri-docs/blob/30591e4c0d9fccf84f1a0ce14dabbec51331e851/src/content/docs/learn/sidecar-nodejs.mdx#L262

It still links to vercel's frozen GitHub repo for https://www.npmjs.com/package/pkg and not one of its forks like https://www.npmjs.com/package/@yao-pkg/pkg that the rest of the documentation refers to.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
