### PR TITLE
docs(sidecar): recommend rustc --print host-tuple for rust >= 1.84.0

### DIFF
--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -52,6 +52,7 @@ rustc -Vv | grep host | cut -f2 -d' '
 # Windows PowerShell
 rustc -Vv | Select-String "host:" | ForEach-Object {$_.Line.split(" ")[1]}
 ```
+
 :::
 
 Here's a Node.js script to append the target triple to a binary:

--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -34,23 +34,25 @@ So `binaries/my-sidecar` would represent `<PROJECT ROOT>/src-tauri/binaries/my-s
 To make the external binary work on each supported architecture, a binary with the same name and a `-$TARGET_TRIPLE` suffix must exist on the specified path.
 For instance, `"externalBin": ["binaries/my-sidecar"]` requires a `src-tauri/binaries/my-sidecar-x86_64-unknown-linux-gnu` executable on Linux or `src-tauri/binaries/my-sidecar-aarch64-apple-darwin` on Mac OS with Apple Silicon.
 
-You can find your **current** platform's `-$TARGET_TRIPLE` suffix by looking at the `host:` property reported by the following command:
+You can find your **current** platform's `-$TARGET_TRIPLE` suffix by running the following command:
 
 ```sh
-rustc -Vv
+rustc --print host-tuple
 ```
 
-If the `grep` and `cut` commands are available, as they should on most Unix systems, you can extract the target triple directly with the following command:
+This directly outputs your host's target triple (e.g., `x86_64-unknown-linux-gnu` or `aarch64-apple-darwin`).
 
-```shell
+:::note
+The `--print host-tuple` flag was added in Rust 1.84.0. If you're using an older version, you'll need to parse the output of `rustc -Vv` instead:
+
+```sh
+# Unix (Linux/macOS)
 rustc -Vv | grep host | cut -f2 -d' '
-```
 
-On Windows you can use PowerShell instead:
-
-```powershell
+# Windows PowerShell
 rustc -Vv | Select-String "host:" | ForEach-Object {$_.Line.split(" ")[1]}
 ```
+:::
 
 Here's a Node.js script to append the target triple to a binary:
 
@@ -60,8 +62,7 @@ import fs from 'fs';
 
 const extension = process.platform === 'win32' ? '.exe' : '';
 
-const rustInfo = execSync('rustc -vV');
-const targetTriple = /host: (\S+)/g.exec(rustInfo)[1];
+const targetTriple = execSync('rustc --print host-tuple').toString().trim();
 if (!targetTriple) {
   console.error('Failed to determine platform target triple');
 }

--- a/src/content/docs/learn/sidecar-nodejs.mdx
+++ b/src/content/docs/learn/sidecar-nodejs.mdx
@@ -123,8 +123,7 @@ Without the plugin being initialized and configured the example won't work.
 
     const ext = process.platform === 'win32' ? '.exe' : '';
 
-    const rustInfo = execSync('rustc -vV');
-    const targetTriple = /host: (\S+)/g.exec(rustInfo)[1];
+    const targetTriple = execSync('rustc --print host-tuple').toString().trim();
     if (!targetTriple) {
       console.error('Failed to determine platform target triple');
     }
@@ -134,6 +133,16 @@ Without the plugin being initialized and configured the example won't work.
       `../src-tauri/binaries/my-sidecar-${targetTriple}${ext}`
     );
     ```
+
+    :::note
+    The `--print host-tuple` flag was added in Rust 1.84.0. If you're using an older version, you'll need to parse the output of `rustc -Vv` instead:
+
+    ```js
+    const rustInfo = execSync('rustc -vV');
+    const targetTriple = /host: (\S+)/g.exec(rustInfo)[1];
+    ```
+
+    :::
 
     And run `node rename.js` from the `sidecar-app` directory.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

<!-- #### Description -->
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->

Rust >= 1.84.0 now supports retrieving the host tuple directly with the newly added `--print host-tuple`. This pull request updates the sidecar docs to recommend this over `rustc -Vv`.

Closes #3675.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
