### PR TITLE
[i18n-ignore] fix(docs): add -A flag to openssl base64 command for CI/CD compatibility

### DIFF
--- a/src/content/docs/distribute/Sign/macos.mdx
+++ b/src/content/docs/distribute/Sign/macos.mdx
@@ -82,7 +82,7 @@ and configure the `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` environme
 4. Convert the `.p12` file to base64 running the following script on the terminal:
 
 ```sh
-openssl base64 -in /path/to/certificate.p12 -out certificate-base64.txt
+openssl base64 -A -in /path/to/certificate.p12 -out certificate-base64.txt
 ```
 
 5. Set the contents of the `certificate-base64.txt` file to the `APPLE_CERTIFICATE` environment variable.

--- a/src/content/docs/ja/distribute/Sign/macos.mdx
+++ b/src/content/docs/ja/distribute/Sign/macos.mdx
@@ -82,7 +82,7 @@ CI/CD プラットフォームで証明書を使用するためには、以下�
 4. ターミナルで次のスクリプトを実行して、「`.p12` ファイル」を base64 に変換します：
 
 ```sh
-openssl base64 -in /path/to/certificate.p12 -out certificate-base64.txt
+openssl base64 -A -in /path/to/certificate.p12 -out certificate-base64.txt
 ```
 
 5. 「`certificate-base64.txt` ファイル」の内容を環境変数の「`APPLE_CERTIFICATE`」に設定します。

--- a/src/content/docs/reference/environment-variables.mdx
+++ b/src/content/docs/reference/environment-variables.mdx
@@ -32,7 +32,7 @@ If both environment variable and CLI flag are used, the CLI flag will have prior
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.
 - `TAURI_WINDOWS_SIGNTOOL_PATH` — Specify a path to `signtool.exe` used for code signing the application on Windows.
-- `APPLE_CERTIFICATE` — Base64 encoded of the `.p12` certificate for code signing. To get this value, run `openssl base64 -in MyCertificate.p12 -out MyCertificate-base64.txt`.
+- `APPLE_CERTIFICATE` — Base64 encoded of the `.p12` certificate for code signing. To get this value, run `openssl base64 -A -in MyCertificate.p12 -out MyCertificate-base64.txt`.
 - `APPLE_CERTIFICATE_PASSWORD` — The password you used to export the certificate.
 - `APPLE_ID` — The Apple ID used to notarize the application. If this environment variable is provided, `APPLE_PASSWORD` and `APPLE_TEAM_ID` must also be set. Alternatively, `APPLE_API_KEY` and `APPLE_API_ISSUER` can be used to authenticate.
 - `APPLE_PASSWORD` — The Apple password used to authenticate for application notarization. Required if `APPLE_ID` is specified. An [app-specific password](https://support.apple.com/en-ca/HT204397) can be used. Alternatively to entering the password in plaintext, it may also be specified using a '@keychain:' or '@env:' prefix followed by a keychain password item name or environment variable name.

--- a/src/content/docs/zh-cn/distribute/Sign/macos.mdx
+++ b/src/content/docs/zh-cn/distribute/Sign/macos.mdx
@@ -68,7 +68,7 @@ security find-identity -v -p codesigning
 4. 在终端运行以下脚本将 `.p12` 文件转换为 base64：
 
 ```
-openssl base64 -in /path/to/certificate.p12 -out certificate-base64.txt
+openssl base64 -A -in /path/to/certificate.p12 -out certificate-base64.txt
 ```
 
 5. 将 `certificate-base64.txt` 文件的内容设置为 `APPLE_CERTIFICATE` 环境变量的值。


### PR DESCRIPTION
#### Description
- Adds the `-A` flag to `openssl base64` commands in macOS signing documentation to output single-line base64 strings, which is required for CI/CD environment variables to work correctly.
- Closes #3699