### PR TITLE
i18n(zh-cn): translation plugin directory missing and outdated docs

### DIFF
--- a/src/content/docs/zh-cn/plugin/biometric.mdx
+++ b/src/content/docs/zh-cn/plugin/biometric.mdx
@@ -1,0 +1,228 @@
+---
+title: 生物识别
+description: 在 Android 和 iOS 设备上向用户弹出生物识别认证。
+plugin: biometric
+i18nReady: true
+---
+
+import PluginLinks from '@components/PluginLinks.astro';
+import Compatibility from '@components/plugins/Compatibility.astro';
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+import PluginPermissions from '@components/PluginPermissions.astro';
+
+<PluginLinks plugin={frontmatter.plugin} />
+
+在 Android 和 iOS 设备上向用户弹出生物识别认证。
+
+## 支持的平台
+
+<Compatibility plugin={frontmatter.plugin} />
+
+## 设置
+
+安装生物识别插件开始使用。
+
+<Tabs>
+    <TabItem label="自动">
+
+    使用你项目的包管理器添加依赖：
+
+    <CommandTabs npm="npm run tauri add biometric"
+    yarn="yarn run tauri add biometric"
+    pnpm="pnpm tauri add biometric"
+    deno="deno task tauri add biometric"
+    bun="bun tauri add biometric"
+    cargo="cargo tauri add biometric" />
+
+    </TabItem>
+    <TabItem label="手动">
+        <Steps>
+        1.  在 `src-tauri` 文件夹中运行以下命令，将插件添加到 `Cargo.toml` 项目的依赖项中：
+
+            ```sh frame=none
+            cargo add tauri-plugin-biometric --target 'cfg(any(target_os = "android", target_os = "ios"))'
+            ```
+
+        2.  修改 `lib.rs` 以初始化插件：
+
+            ```rust title="src-tauri/src/lib.rs" ins={5-6}
+            #[cfg_attr(mobile, tauri::mobile_entry_point)]
+            pub fn run() {
+                tauri::Builder::default()
+                    .setup(|app| {
+                        #[cfg(mobile)]
+                        app.handle().plugin(tauri_plugin_biometric::Builder::new().build());
+                        Ok(())
+                    })
+                    .run(tauri::generate_context!())
+                    .expect("error while running tauri application");
+            }
+            ```
+
+        3.  使用你喜欢的 JavaScript 包管理器安装 JavaScript Guest 绑定：
+
+            <CommandTabs
+            npm = "npm install @tauri-apps/plugin-biometric"
+            yarn = "yarn add @tauri-apps/plugin-biometric"
+            pnpm = "pnpm add @tauri-apps/plugin-biometric"
+            deno = "deno add npm:@tauri-apps/plugin-biometric"
+            bun = "bun add @tauri-apps/plugin-biometric"
+            />
+        </Steps>
+    </TabItem>
+
+</Tabs>
+
+## 配置
+
+在 iOS 系统上，生物识别插件需要 `NSFaceIDUsageDescription` 信息属性列表值，你应该在其中描述应用为何需要使用生物识别认证。
+
+在 `src-tauri/Info.ios.plist` 文件中，添加以下代码片段：
+
+```xml title=src-tauri/Info.ios.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>NSFaceIDUsageDescription</key>
+		<string>Authenticate with biometric</string>
+	</dict>
+</plist>
+```
+
+## 使用
+
+该插件使你能够验证设备上生物识别认证的可用性，向用户发起生物识别认证请求，并检查结果以确定认证是否成功。
+
+### 检查状态
+
+你可以检查生物识别认证的状态，包括其可用性以及设备支持的生物识别认证方式类型。
+
+<Tabs syncKey="lang">
+<TabItem label="JavaScript">
+
+```javascript
+import { checkStatus } from '@tauri-apps/plugin-biometric';
+
+const status = await checkStatus();
+if (status.isAvailable) {
+  console.log('Yes! Biometric Authentication is available');
+} else {
+  console.log(
+    'No! Biometric Authentication is not available due to ' + status.error
+  );
+}
+```
+
+</TabItem>
+<TabItem label="Rust">
+
+```rust
+use tauri_plugin_biometric::BiometricExt;
+
+fn check_biometric(app_handle: tauri::AppHandle) {
+    let status = app_handle.biometric().status().unwrap();
+    if status.is_available {
+        println!("Yes! Biometric Authentication is available");
+    } else {
+        println!("No! Biometric Authentication is not available due to: {}", status.error.unwrap());
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### 认证
+
+要提示用户进行生物识别认证，请使用 `authenticate()` 方法。
+
+<Tabs syncKey="lang">
+
+<TabItem label="JavaScript">
+
+```javascript ins={18}
+import { authenticate } from '@tauri-apps/plugin-biometric';
+
+const options = {
+  // Set true if you want the user to be able to authenticate using phone password
+  allowDeviceCredential: false,
+  cancelTitle: "Feature won't work if Canceled",
+
+  // iOS only feature
+  fallbackTitle: 'Sorry, authentication failed',
+
+  // Android only features
+  title: 'Tauri feature',
+  subtitle: 'Authenticate to access the locked Tauri function',
+  confirmationRequired: true,
+};
+
+try {
+  await authenticate('This feature is locked', options);
+  console.log(
+    'Hooray! Successfully Authenticated! We can now perform the locked Tauri function!'
+  );
+} catch (err) {
+  console.log('Oh no! Authentication failed because ' + err.message);
+}
+```
+
+</TabItem>
+
+<TabItem label="Rust">
+
+```rust ins={21}
+use tauri_plugin_biometric::{BiometricExt, AuthOptions};
+
+fn bio_auth(app_handle: tauri::AppHandle) {
+
+    let options = AuthOptions {
+        // Set True if you want the user to be able to authenticate using phone password
+        allow_device_credential:false,
+        cancel_title: Some("Feature won't work if Canceled".to_string()),
+
+        // iOS only feature
+        fallback_title: Some("Sorry, authentication failed".to_string()),
+
+        // Android only features
+        title: Some("Tauri feature".to_string()),
+        subtitle: Some("Authenticate to access the locked Tauri function".to_string()),
+        confirmation_required: Some(true),
+    };
+
+    // if the authentication was successful, the function returns Result::Ok()
+    // otherwise returns Result::Error()
+    match app_handle.biometric().authenticate("This feature is locked".to_string(), options) {
+        Ok(_) => {
+            println!("Hooray! Successfully Authenticated! We can now perform the locked Tauri function!");
+        }
+        Err(e) => {
+            println!("Oh no! Authentication failed because : {e}");
+        }
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## 权限
+
+默认情况下，所有潜在的危险插件命令和作用域均被阻止，无法访问。你必须修改 `capabilities` 配置中的权限才能启用这些功能。
+
+有关更多信息，请参阅 [功能概述](/zh-cn/security/capabilities/)， 关于如何使用插件权限，请参阅 [分步指南](/zh-cn/learn/security/using-plugin-permissions/)。
+
+```json title="src-tauri/capabilities/default.json" ins={6}
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": ["biometric:default"]
+}
+```
+
+<PluginPermissions plugin={frontmatter.plugin} />

--- a/src/content/docs/zh-cn/plugin/biometric.mdx
+++ b/src/content/docs/zh-cn/plugin/biometric.mdx
@@ -147,14 +147,14 @@ fn check_biometric(app_handle: tauri::AppHandle) {
 import { authenticate } from '@tauri-apps/plugin-biometric';
 
 const options = {
-  // Set true if you want the user to be able to authenticate using phone password
+  // 如果你希望用户能够使用手机密码进行身份验证，请设为 true
   allowDeviceCredential: false,
   cancelTitle: "Feature won't work if Canceled",
 
-  // iOS only feature
+  // 仅 iOS 平台的功能
   fallbackTitle: 'Sorry, authentication failed',
 
-  // Android only features
+  // 仅 Android 平台的功能
   title: 'Tauri feature',
   subtitle: 'Authenticate to access the locked Tauri function',
   confirmationRequired: true,
@@ -180,21 +180,21 @@ use tauri_plugin_biometric::{BiometricExt, AuthOptions};
 fn bio_auth(app_handle: tauri::AppHandle) {
 
     let options = AuthOptions {
-        // Set True if you want the user to be able to authenticate using phone password
+        // 如果你希望用户能够使用手机密码进行身份验证，请设为 true
         allow_device_credential:false,
         cancel_title: Some("Feature won't work if Canceled".to_string()),
 
-        // iOS only feature
+        // 仅 iOS 平台的功能
         fallback_title: Some("Sorry, authentication failed".to_string()),
 
-        // Android only features
+        // 仅 Android 平台的功能
         title: Some("Tauri feature".to_string()),
         subtitle: Some("Authenticate to access the locked Tauri function".to_string()),
         confirmation_required: Some(true),
     };
 
-    // if the authentication was successful, the function returns Result::Ok()
-    // otherwise returns Result::Error()
+    // 如果认证成功，函数返回 Result::Ok()
+    // 否则返回 Result::Error()
     match app_handle.biometric().authenticate("This feature is locked".to_string(), options) {
         Ok(_) => {
             println!("Hooray! Successfully Authenticated! We can now perform the locked Tauri function!");

--- a/src/content/docs/zh-cn/plugin/geolocation.mdx
+++ b/src/content/docs/zh-cn/plugin/geolocation.mdx
@@ -1,0 +1,172 @@
+---
+title: 地理位置
+description: 获取并追踪设备的当前位置，包括海拔、航向和速度（如可用）等信息。
+plugin: geolocation
+i18nReady: true
+---
+
+import PluginLinks from '@components/PluginLinks.astro';
+import Compatibility from '@components/plugins/Compatibility.astro';
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+import PluginPermissions from '@components/PluginPermissions.astro';
+
+<PluginLinks plugin={frontmatter.plugin} />
+
+获取并追踪设备的当前位置，包括海拔、航向和速度（如可用）等信息。
+
+## 支持的平台
+
+<Compatibility plugin={frontmatter.plugin} />
+
+## 设置
+
+安装地理位置插件开始使用。
+
+<Tabs>
+  <TabItem label="自动">
+
+    使用你项目的包管理器添加依赖：
+
+    {' '}
+
+    <CommandTabs
+      npm="npm run tauri add geolocation"
+      yarn="yarn run tauri add geolocation"
+      pnpm="pnpm tauri add geolocation"
+      deno="deno task tauri add geolocation"
+      bun="bun tauri add geolocation"
+      cargo="cargo tauri add geolocation"
+    />
+
+  </TabItem>
+  <TabItem label="手动">
+    <Steps>
+
+      1.  在 `src-tauri` 文件夹中运行以下命令，将插件添加到 `Cargo.toml` 项目的依赖项中：
+
+          ```sh frame=none
+          cargo add tauri-plugin-geolocation --target 'cfg(any(target_os = "android", target_os = "ios"))'
+          ```
+
+      2.  修改 `lib.rs` 以初始化插件：
+
+          ```rust title="src-tauri/src/lib.rs" ins={5-6}
+          #[cfg_attr(mobile, tauri::mobile_entry_point)]
+          pub fn run() {
+              tauri::Builder::default()
+                  .setup(|app| {
+                      #[cfg(mobile)]
+                      app.handle().plugin(tauri_plugin_geolocation::init());
+                      Ok(())
+                  })
+                  .run(tauri::generate_context!())
+                  .expect("error while running tauri application");
+          }
+          ```
+
+      3.  使用你喜欢的 JavaScript 包管理器安装 JavaScript Guest 绑定：
+
+          <CommandTabs
+              npm="npm install @tauri-apps/plugin-geolocation"
+              yarn="yarn add @tauri-apps/plugin-geolocation"
+              pnpm="pnpm add @tauri-apps/plugin-geolocation"
+              deno="deno add npm:@tauri-apps/plugin-geolocation"
+              bun="bun add @tauri-apps/plugin-geolocation"
+          />
+
+    </Steps>
+
+  </TabItem>
+</Tabs>
+
+## 配置
+
+### iOS
+
+Apple 要求在 Info.plist 文件中必须指定定位信息的隐私说明，您需要在其中描述应用为何需要访问该信息。下面展示了一个说明示例：
+
+```xml {6-7}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>Required to do XY</string>
+    </dict>
+</plist>
+```
+
+### Android
+
+该插件会自动将以下权限添加到你的 `AndroidManifest.xml` 文件中：
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+如果你的应用需要 GPS 功能才能运行，你应该在 `AndroidManifest.xml` 文件中添加以下内容：
+
+```xml
+<uses-feature android:name="android.hardware.location.gps" android:required="true" />
+```
+
+Google Play 商店会利用此属性来决定是否向不具备 GPS 功能的设备展示该应用。
+
+## 使用
+
+地理位置插件可在 JavaScript 中使用。
+
+```javascript
+import {
+  checkPermissions,
+  requestPermissions,
+  getCurrentPosition,
+  watchPosition,
+} from '@tauri-apps/plugin-geolocation';
+
+let permissions = await checkPermissions();
+if (
+  permissions.location === 'prompt' ||
+  permissions.location === 'prompt-with-rationale'
+) {
+  permissions = await requestPermissions(['location']);
+}
+
+if (permissions.location === 'granted') {
+  const pos = await getCurrentPosition();
+
+  await watchPosition(
+    { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 },
+    (pos) => {
+      console.log(pos);
+    }
+  );
+}
+```
+
+## 权限
+
+默认情况下，所有潜在的危险插件命令和作用域均被阻止，无法访问。你必须修改 `capabilities` 配置中的权限才能启用这些功能。
+
+有关更多信息，请参阅 [功能概述](/zh-cn/security/capabilities/)， 关于如何使用插件权限，请参阅 [分步指南](/zh-cn/learn/security/using-plugin-permissions/)。
+
+```json title="src-tauri/capabilities/mobile.json" ins={7-11}
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile-capability",
+  "windows": ["main"],
+  "platforms": ["iOS", "android"],
+  "permissions": [
+    "core:default",
+    "geolocation:allow-check-permissions",
+    "geolocation:allow-request-permissions",
+    "geolocation:allow-get-current-position",
+    "geolocation:allow-watch-position"
+  ]
+}
+```
+
+<PluginPermissions plugin={frontmatter.plugin} />

--- a/src/content/docs/zh-cn/plugin/haptics.mdx
+++ b/src/content/docs/zh-cn/plugin/haptics.mdx
@@ -1,0 +1,125 @@
+---
+title: 触觉反馈
+description: Android 和 iOS 上的触觉反馈和振动。
+plugin: haptics
+i18nReady: true
+---
+
+import PluginLinks from '@components/PluginLinks.astro';
+import Compatibility from '@components/plugins/Compatibility.astro';
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+import PluginPermissions from '@components/PluginPermissions.astro';
+
+<PluginLinks plugin={frontmatter.plugin} />
+
+Android 和 iOS 上的触觉反馈和振动。
+
+Android 系统对于振动支持没有统一的标准或要求，因此反馈类 API 在一些价格更实惠的手机（包括近期发布的新机型）上可能无法正常工作。
+
+## 支持的平台
+
+<Compatibility plugin={frontmatter.plugin} />
+
+## 设置
+
+安装触觉反馈插件开始使用。
+
+<Tabs>
+  <TabItem label="自动">
+
+    使用你项目的包管理器添加依赖：
+
+    {' '}
+
+    <CommandTabs
+      npm="npm run tauri add haptics"
+      yarn="yarn run tauri add haptics"
+      pnpm="pnpm tauri add haptics"
+      deno="deno task tauri add haptics"
+      bun="bun tauri add haptics"
+      cargo="cargo tauri add haptics"
+    />
+
+  </TabItem>
+  <TabItem label="手动">
+    <Steps>
+
+      1.  在 `src-tauri` 文件夹中运行以下命令，将插件添加到 `Cargo.toml` 项目的依赖项中：
+
+          ```sh frame=none
+          cargo add tauri-plugin-haptics --target 'cfg(any(target_os = "android", target_os = "ios"))'
+          ```
+
+      2.  修改 `lib.rs` 以初始化插件：
+
+          ```rust title="src-tauri/src/lib.rs" ins={5-6}
+          #[cfg_attr(mobile, tauri::mobile_entry_point)]
+          pub fn run() {
+              tauri::Builder::default()
+                  .setup(|app| {
+                      #[cfg(mobile)]
+                      app.handle().plugin(tauri_plugin_haptics::init());
+                      Ok(())
+                  })
+                  .run(tauri::generate_context!())
+                  .expect("error while running tauri application");
+          }
+          ```
+
+      3.  使用你喜欢的 JavaScript 包管理器安装 JavaScript Guest 绑定：
+
+          <CommandTabs
+              npm="npm install @tauri-apps/plugin-haptics"
+              yarn="yarn add @tauri-apps/plugin-haptics"
+              pnpm="pnpm add @tauri-apps/plugin-haptics"
+              deno="deno add npm:@tauri-apps/plugin-haptics"
+              bun="bun add @tauri-apps/plugin-haptics"
+          />
+
+    </Steps>
+
+  </TabItem>
+</Tabs>
+
+## 使用
+
+触觉反馈插件可在 JavaScript 中使用。
+
+```javascript
+import {
+  vibrate,
+  impactFeedback,
+  notificationFeedback,
+  selectionFeedback,
+} from '@tauri-apps/plugin-haptics';
+
+await vibrate(1);
+await impactFeedback('medium');
+await notificationFeedback('warning');
+await selectionFeedback();
+```
+
+## 权限
+
+默认情况下，所有潜在的危险插件命令和作用域均被阻止，无法访问。你必须修改 `capabilities` 配置中的权限才能启用这些功能。
+
+有关更多信息，请参阅 [功能概述](/zh-cn/security/capabilities/)， 关于如何使用插件权限，请参阅 [分步指南](/zh-cn/learn/security/using-plugin-permissions/)。
+
+```json title="src-tauri/capabilities/mobile.json" ins={7-10}
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile-capability",
+  "windows": ["main"],
+  "platforms": ["iOS", "android"],
+  "permissions": [
+    "haptics:allow-impact-feedback",
+    "haptics:allow-notification-feedback",
+    "haptics:allow-selection-feedback",
+    "haptics:allow-vibrate"
+  ]
+}
+```
+
+<PluginPermissions plugin={frontmatter.plugin} />

--- a/src/content/docs/zh-cn/plugin/index.mdx
+++ b/src/content/docs/zh-cn/plugin/index.mdx
@@ -1,6 +1,9 @@
 ---
-title: 功能及秘诀列表
+title: 功能 & 示例
 i18nReady: true
+sidebar:
+  label: 概述
+tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
@@ -8,23 +11,31 @@ import FeaturesList from '@components/list/Features.astro';
 import CommunityList from '@components/list/Community.astro';
 import Search from '@components/CardGridSearch.astro';
 import AwesomeTauri from '@components/AwesomeTauri.astro';
+import TableCompatibility from '@components/plugins/TableCompatibility.astro';
+import { platformOptions } from 'src/types';
+import { platformFilters } from 'src/api/search.ts';
 
-Tauri 考虑到了可扩展性。在此页面上，你可以找到：
+Tauri 在设计之初就考虑到了可扩展性。在本页面中你将找到：
 
-- **[特性](#特性)**：Tauri 内置功能和特性
-- **[社区资源](#社区资源)**：更多由 Tauri 社区创作的插件和秘诀
+- **[官方功能](#官方功能)**: Tauri 内置的功能与特性
+- **[社区资源](#社区插件)**: 由 Tauri 社区开发的更多插件与示例。你也可以在 [Awesome Tauri](https://github.com/tauri-apps/awesome-tauri) 上贡献你自己的作品
+- **[支持表](#支持表)**: 一份兼容性表格，展示了每个官方插件所支持的平台
 
-<Search>
-  ## 特性
+<br />
+
+**使用搜索和筛选功能来查找功能或社区资源：**
+
+<Search filters={platformFilters}>
+  #### 官方功能
   <FeaturesList />
-  ## 社区资源
-  <LinkCard
-    title="有什么要分享？"
-    description="打开拉取请求，向我们展示您的惊人资源。"
-    href="https://github.com/tauri-apps/awesome-tauri/pulls"
-  />
-  ### 插件
+  #### 社区插件
   <AwesomeTauri section="plugins-no-official" />
-  ### 集成
+  #### 社区集成
   <AwesomeTauri section="integrations" />
 </Search>
+
+## 支持表
+
+将鼠标悬停在 "\*" 上以查看注释。了解详细信息，请访问插件页面
+
+<TableCompatibility />

--- a/src/content/docs/zh-cn/plugin/nfc.mdx
+++ b/src/content/docs/zh-cn/plugin/nfc.mdx
@@ -207,7 +207,7 @@ const scanType = {
 
 const options = {
   keepSessionAlive: false,
-  // configure the messages displayed in the "Scan NFC" dialog on iOS
+  // 配置 iOS 上 "扫描 NFC" 对话框中显示的信息
   message: 'Scan a NFC tag',
   successMessage: 'NFC tag successfully scanned',
 };
@@ -272,9 +272,9 @@ MIME 类型区分大小写，必须使用小写字母提供。
 import { scan, TechKind } from '@tauri-apps/plugin-nfc';
 
 const techLists = [
-  // capture anything using NfcF
+  // 使用 NfcF 捕获任意内容
   [TechKind.NfcF],
-  // capture all MIFARE Classics with NDEF payloads
+  // 捕获所有带有 NDEF 负载的 MIFARE Classic 卡片
   [TechKind.NfcA, TechKind.MifareClassic, TechKind.Ndef],
 ];
 
@@ -342,12 +342,11 @@ import { write, textRecord, uriRecord } from '@tauri-apps/plugin-nfc';
 const payload = [uriRecord('https://tauri.app'), textRecord('some payload')];
 
 const options = {
-  // the kind is only required if you do not have a scanned tag session alive
-  // its format is the same as the argument provided to scan()
+  // 仅在没有活跃的已扫描标签会话时才需要指定类型，其格式与提供给 scan() 方法的参数相同
   kind: {
     type: 'ndef',
   },
-  // configure the messages displayed in the "Scan NFC" dialog on iOS
+  // 配置 iOS 上“扫描 NFC”对话框中显示的信息
   message: 'Scan a NFC tag',
   successfulReadMessage: 'NFC tag successfully scanned',
   successMessage: 'NFC tag successfully written',
@@ -360,9 +359,9 @@ await write(payload, options);
 
 <TabItem label="Rust">
 :::caution
-The Rust API currently only provides a low level interface for writing NFC payloads.
+目前，Rust API 仅提供了用于写入 NFC 负载的低级接口。
 
-The API will be enhanced soon.
+该 API 将在近期得到增强。
 :::
 
 ```rust

--- a/src/content/docs/zh-cn/plugin/nfc.mdx
+++ b/src/content/docs/zh-cn/plugin/nfc.mdx
@@ -113,7 +113,7 @@ NFC 插件需要 iOS 14 及以上版本。这是使用 Tauri CLI v2.8 及以上�
 		};
 ```
 
-或者您可以在 Xcode 的  `General > Minimum Deployments > iOS` 配置中设置部署目标。
+或者您可以在 Xcode 的 `General > Minimum Deployments > iOS` 配置中设置部署目标。
 
 #### Info.plist
 

--- a/src/content/docs/zh-cn/plugin/nfc.mdx
+++ b/src/content/docs/zh-cn/plugin/nfc.mdx
@@ -1,0 +1,412 @@
+---
+title: NFC
+description: 在 Android 和 iOS 设备上读取和写入 NFC 标签.
+plugin: nfc
+i18nReady: true
+---
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import CommandTabs from '@components/CommandTabs.astro';
+import PluginPermissions from '@components/PluginPermissions.astro';
+import PluginLinks from '@components/PluginLinks.astro';
+import Compatibility from '@components/plugins/Compatibility.astro';
+
+<PluginLinks plugin={frontmatter.plugin} />
+
+在 Android 和 iOS 设备上读取和写入 NFC 标签。
+
+## 支持的平台
+
+<Compatibility plugin={frontmatter.plugin} />
+
+## 设置
+
+安装 nfc 插件开始使用。
+
+<Tabs>
+  <TabItem label="自动">
+
+    使用你项目的包管理器添加依赖：
+
+    {' '}
+
+    <CommandTabs
+      npm="npm run tauri add nfc"
+      yarn="yarn run tauri add nfc"
+      pnpm="pnpm tauri add nfc"
+      bun="bun tauri add nfc"
+      cargo="cargo tauri add nfc"
+    />
+
+  </TabItem>
+  <TabItem label="手动">
+    <Steps>
+
+      1.  在 `src-tauri` 文件夹中运行以下命令，将插件添加到 `Cargo.toml` 项目的依赖项中：
+
+          ```sh frame=none
+          cargo add tauri-plugin-nfc --target 'cfg(any(target_os = "android", target_os = "ios"))'
+          ```
+
+      2.  修改 `lib.rs` 以初始化插件：
+
+          ```rust title="src-tauri/src/lib.rs" ins={5-6}
+          #[cfg_attr(mobile, tauri::mobile_entry_point)]
+          pub fn run() {
+              tauri::Builder::default()
+                  .setup(|app| {
+                      #[cfg(mobile)]
+                      app.handle().plugin(tauri_plugin_nfc::init());
+                      Ok(())
+                  })
+                  .run(tauri::generate_context!())
+                  .expect("error while running tauri application");
+          }
+          ```
+
+      3.  使用你喜欢的 JavaScript 包管理器安装 JavaScript Guest 绑定：
+
+          <CommandTabs
+              npm="npm install @tauri-apps/plugin-nfc"
+              yarn="yarn add @tauri-apps/plugin-nfc"
+              pnpm="pnpm add @tauri-apps/plugin-nfc"
+              deno="deno add npm:@tauri-apps/plugin-nfc"
+              bun="bun add @tauri-apps/plugin-nfc"
+          />
+
+    </Steps>
+
+  </TabItem>
+</Tabs>
+
+## 配置
+
+NFC 插件需要 iOS 的原生配置。
+
+### iOS
+
+要在 iOS 上访问 NFC API，你必须调整目标 iOS 版本，在 Info.plist 文件中配置使用描述，并将 NFC 功能添加到你的应用程序中。
+
+#### 目标 iOS 版本
+
+NFC 插件需要 iOS 14 及以上版本。这是使用 Tauri CLI v2.8 及以上版本创建的 Tauri 应用程序的默认设置，但你可以编辑你的 Xcode 项目来配置它。
+
+在 `src-tauri/gen/apple/<project-name>.xcodeproj/project.pbxproj` 文件中，将所有`IPHONEOS_DEPLOYMENT_TARGET` 属性设置为 `14.0`：
+
+```title="src-tauri/gen/apple/<project-name>.xcodeproj/project.pbxproj"
+/* Begin XCBuildConfiguration section */
+		<random-id> /* release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				...
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+			};
+			name = release;
+		};
+		<random-id> /* debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+        ...
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+			};
+			name = debug;
+		};
+```
+
+或者您可以在 Xcode 的  `General > Minimum Deployments > iOS` 配置中设置部署目标。
+
+#### Info.plist
+
+在 iOS 上，NFC 插件需要 `NFCReaderUsageDescription` 信息属性列表值，该值应描述您的应用为何需要扫描或写入 NFC 标签。
+
+在 `src-tauri/Info.ios.plist` 文件中，添加以下代码片段：
+
+```xml title=src-tauri/Info.ios.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>NFCReaderUsageDescription</key>
+		<string>Read and write various NFC tags</string>
+	</dict>
+</plist>
+```
+
+#### NFC 功能
+
+此外，iOS 需要将 NFC 功能与你的应用程序关联。
+
+该功能可以通过在 Xcode 的项目配置的 “Signing & Capabilities” 选项卡中点击“+ Capability”按钮并选择“Near Field Communication Tag Reading”来添加（更多信息请参阅[为目标添加功能]），或者通过向 `gen/apple/<app-name>_iOS/<app-name>_iOS.entitlements` 文件添加以下配置来添加：
+
+```xml title="gen/apple/<app-name>_iOS/<app-name>_iOS.entitlements"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
+</dict>
+</plist>
+```
+
+## 使用
+
+NFC 插件可在 JavaScript 和 Rust 中使用，允许你扫描和写入 NFC 标签。
+
+### 检查是否支持 NFC
+
+并非每部移动设备都具备扫描 NFC 标签的功能，因此在使用扫描和写入 API 之前，你应该检查其可用性。
+
+<Tabs syncKey="lang">
+
+<TabItem label="JavaScript">
+
+```javascript
+import { isAvailable } from '@tauri-apps/plugin-nfc';
+
+const canScanNfc = await isAvailable();
+```
+
+</TabItem>
+<TabItem label="Rust">
+
+```rust
+tauri::Builder::default()
+  .setup(|app| {
+    #[cfg(mobile)]
+    {
+      use tauri_plugin_nfc::NfcExt;
+
+      app.handle().plugin(tauri_plugin_nfc::init());
+
+      let can_scan_nfc = app.nfc().is_available()?;
+    }
+    Ok(())
+  })
+```
+
+</TabItem>
+</Tabs>
+
+### 扫描 NFC 标签
+
+该插件可以扫描通用 NFC 标签或带有 NDEF（NFC 数据交换格式）消息的 NFC 标签，NDEF 是一种在 NFC 标签中封装类型数据的标准格式。
+
+<Tabs syncKey="lang">
+
+<TabItem label="JavaScript">
+
+```javascript
+import { scan } from '@tauri-apps/plugin-nfc';
+
+const scanType = {
+  type: 'ndef', // or 'tag',
+};
+
+const options = {
+  keepSessionAlive: false,
+  // configure the messages displayed in the "Scan NFC" dialog on iOS
+  message: 'Scan a NFC tag',
+  successMessage: 'NFC tag successfully scanned',
+};
+
+const tag = await scan(scanType, options);
+```
+
+</TabItem>
+
+<TabItem label="Rust">
+
+```rust
+tauri::Builder::default()
+  .setup(|app| {
+    #[cfg(mobile)]
+    {
+      use tauri_plugin_nfc::NfcExt;
+
+      app.handle().plugin(tauri_plugin_nfc::init());
+
+      let tag = app
+        .nfc()
+        .scan(tauri_plugin_nfc::ScanRequest {
+            kind: tauri_plugin_nfc::ScanKind::Ndef {
+                mime_type: None,
+                uri: None,
+                tech_list: None,
+            },
+            keep_session_alive: false,
+        })?
+        .tag;
+    }
+    Ok(())
+  })
+```
+
+</TabItem>
+
+</Tabs>
+
+:::note
+`keepSessionAlive` 选项可用于稍后直接写入扫描的 NFC 标签。
+
+如果你不提供该选项，会在下次 `write()` 调用时重新创建会话，这意味着应用程序将尝试重新扫描标签。
+:::
+
+#### 过滤器
+
+NFC 扫描器还可以根据特定的 URI 格式、MIME 类型或 NFC 标签技术来过滤标签。在这种情况下，扫描将仅检测符合所提供过滤器的标签。
+
+:::note
+过滤功能仅在 Android 上可用，因此你应该始终检查扫描的 NFC 标签内容。
+
+MIME 类型区分大小写，必须使用小写字母提供。
+:::
+
+<Tabs syncKey="lang">
+
+<TabItem label="JavaScript">
+
+```javascript
+import { scan, TechKind } from '@tauri-apps/plugin-nfc';
+
+const techLists = [
+  // capture anything using NfcF
+  [TechKind.NfcF],
+  // capture all MIFARE Classics with NDEF payloads
+  [TechKind.NfcA, TechKind.MifareClassic, TechKind.Ndef],
+];
+
+const tag = await scan({
+  type: 'ndef', // or 'tag'
+  mimeType: 'text/plain',
+  uri: {
+    scheme: 'https',
+    host: 'my.domain.com',
+    pathPrefix: '/app',
+  },
+  techLists,
+});
+```
+
+</TabItem>
+
+<TabItem label="Rust">
+
+```rust
+tauri::Builder::default()
+  .setup(|app| {
+    #[cfg(mobile)]
+    {
+      use tauri_plugin_nfc::NfcExt;
+
+      app.handle().plugin(tauri_plugin_nfc::init());
+
+      let tag = app
+        .nfc()
+        .scan(tauri_plugin_nfc::ScanRequest {
+            kind: tauri_plugin_nfc::ScanKind::Ndef {
+                mime_type: Some("text/plain".to_string()),
+                uri: Some(tauri_plugin_nfc::UriFilter {
+                  scheme: Some("https".to_string()),
+                  host: Some("my.domain.com".to_string()),
+                  path_prefix: Some("/app".to_string()),
+                }),
+                tech_list: Some(vec![
+                  vec![tauri_plugin_nfc::TechKind::Ndef],
+                ]),
+            },
+        })?
+        .tag;
+    }
+    Ok(())
+  })
+```
+
+</TabItem>
+
+</Tabs>
+
+### 写入 NFC 标签
+
+`write` API 可用于将有效负载写入 NFC 标签。如果未扫描到标签且 `keepSessionAlive: true` 的NFC标签，应用将首先扫描 NFC 标签。
+
+<Tabs syncKey="lang">
+
+<TabItem label="JavaScript">
+
+```javascript
+import { write, textRecord, uriRecord } from '@tauri-apps/plugin-nfc';
+
+const payload = [uriRecord('https://tauri.app'), textRecord('some payload')];
+
+const options = {
+  // the kind is only required if you do not have a scanned tag session alive
+  // its format is the same as the argument provided to scan()
+  kind: {
+    type: 'ndef',
+  },
+  // configure the messages displayed in the "Scan NFC" dialog on iOS
+  message: 'Scan a NFC tag',
+  successfulReadMessage: 'NFC tag successfully scanned',
+  successMessage: 'NFC tag successfully written',
+};
+
+await write(payload, options);
+```
+
+</TabItem>
+
+<TabItem label="Rust">
+:::caution
+The Rust API currently only provides a low level interface for writing NFC payloads.
+
+The API will be enhanced soon.
+:::
+
+```rust
+tauri::Builder::default()
+  .setup(|app| {
+    #[cfg(mobile)]
+    {
+      use tauri_plugin_nfc::NfcExt;
+
+      app.handle().plugin(tauri_plugin_nfc::init());
+
+      app
+        .nfc()
+        .write(vec![
+          tauri_plugin_nfc::NfcRecord {
+            format: tauri_plugin_nfc::NFCTypeNameFormat::NfcWellKnown,
+            kind: vec![0x55], // URI record
+            id: vec![],
+            payload: vec![], // insert payload here
+          }
+        ])?;
+    }
+    Ok(())
+  })
+```
+
+</TabItem>
+</Tabs>
+
+## 权限
+
+默认情况下，所有潜在的危险插件命令和作用域均被阻止，无法访问。你必须修改 `capabilities` 配置中的权限才能启用这些功能。
+
+有关更多信息，请参阅 [功能概述](/zh-cn/security/capabilities/)， 关于如何使用插件权限，请参阅 [分步指南](/zh-cn/learn/security/using-plugin-permissions/)。
+
+```json title="src-tauri/capabilities/default.json" ins={4}
+{
+  "permissions": [
+    ...,
+    "nfc:default",
+  ]
+}
+```
+
+<PluginPermissions plugin={frontmatter.plugin} />
+
+[为目标添加功能]: https://help.apple.com/xcode/mac/current/#/dev88ff319e7


### PR DESCRIPTION
#### Description
- src/content/docs/zh-cn/plugin/biometric.mdx
- src/content/docs/zh-cn/plugin/index.mdx
- src/content/docs/zh-cn/plugin/nfc.mdx
- src/content/docs/zh-cn/plugin/geolocation.mdx
- src/content/docs/zh-cn/plugin/haptics.mdx