### PR TITLE
Change 'type' to 'item' for menu separator

### DIFF
--- a/src/content/docs/learn/window-menu.mdx
+++ b/src/content/docs/learn/window-menu.mdx
@@ -36,7 +36,7 @@ const menu = await Menu.new({
       checked: true,
     },
     {
-      type: 'Separator',
+      item: 'Separator',
     },
     {
       id: 'disabled_item',


### PR DESCRIPTION
#### Description
- Parameters for [PredefinedMenuItemOptions](https://tauri.app/reference/javascript/api/namespacemenu/#predefinedmenuitemoptions) use `item` instead of `type`