### PR TITLE
add macos-only note to ios commands in cli reference

### DIFF
--- a/src/content/docs/reference/_cli_ios.mdx
+++ b/src/content/docs/reference/_cli_ios.mdx
@@ -1,4 +1,6 @@
 ### `ios`
+
+_All iOS commands are only available on macOS hosts._
   
 <CommandTabs
   npm="npm run tauri ios"
@@ -29,6 +31,8 @@ Options:
 ```
 
 #### `ios init`
+
+_All iOS commands are only available on macOS hosts._
   
 <CommandTabs
   npm="npm run tauri ios init"
@@ -77,6 +81,8 @@ Options:
 
 
 #### `ios dev`
+
+_All iOS commands are only available on macOS hosts._
   
 <CommandTabs
   npm="npm run tauri ios dev"
@@ -178,6 +184,8 @@ Options:
 
 
 #### `ios build`
+
+_All iOS commands are only available on macOS hosts._
   
 <CommandTabs
   npm="npm run tauri ios build"
@@ -254,6 +262,8 @@ Options:
 
 
 #### `ios run`
+
+_All iOS commands are only available on macOS hosts._
   
 <CommandTabs
   npm="npm run tauri ios run"


### PR DESCRIPTION
closes #3734
