### PR TITLE
Tweak accent color for light theme

### DIFF
--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -28,4 +28,12 @@ const year = new Date().getFullYear();
     margin-inline: auto;
     margin-block: 1rem;
   }
+
+  a {
+    color: var(--sl-color-accent);
+  }
+
+  a:hover {
+    color: var(--sl-color-accent-high);
+  }
 </style>

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -27,6 +27,11 @@
 }
 
 :root[data-theme='light'] {
+  // --tauri-blue: oklch(76.61% 0.12577 206.774);
+  --sl-color-accent-low: oklch(30% 0.13 207);
+  --sl-color-accent: oklch(50% 0.13 207);
+  --sl-color-accent-high: oklch(70% 0.13 207);
+
   --sl-color-white: #070707;
   --sl-color-gray-1: #2f2f2f;
   --sl-color-gray-2: #353841;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -28,9 +28,11 @@
 
 :root[data-theme='light'] {
   // --tauri-blue: oklch(76.61% 0.12577 206.774);
-  --sl-color-accent-low: oklch(30% 0.13 207);
-  --sl-color-accent: oklch(50% 0.13 207);
-  --sl-color-accent-high: oklch(70% 0.13 207);
+  // Using a hue that's as close to the tauri blue as possible,
+  // while targeting a chroma of 0.15 with a 50% lightness
+  --sl-color-accent-low: oklch(40% 0.12 253);
+  --sl-color-accent: oklch(50% 0.15 253);
+  --sl-color-accent-high: oklch(70% 0.15 253);
 
   --sl-color-white: #070707;
   --sl-color-gray-1: #2f2f2f;


### PR DESCRIPTION
The starlight default accent color is a bit too high in chroma (too saturated/contrasty) and since we're already using a custom one for the dark theme, let's also do it for the light theme

Feel free to suggest other colors, I just went with a color offset from the Tauri logo blue using oklch