### PR TITLE
docs: replace deprecated menu_on_left_click with show_menu_on_left_click

### DIFF
--- a/src/content/docs/learn/system-tray.mdx
+++ b/src/content/docs/learn/system-tray.mdx
@@ -101,7 +101,7 @@ To attach a menu that is displayed when the tray is clicked, you can use the `me
 :::note
 By default the menu is displayed on both left and right clicks.
 
-To prevent the menu from popping up on left click, call the [`menu_on_left_click(false)`][TrayIconBuilder::menu_on_left_click] Rust function
+To prevent the menu from popping up on left click, call the [`show_menu_on_left_click(false)`][TrayIconBuilder::show_menu_on_left_click] Rust function
 or set the [`menuOnLeftClick`] JavaScript option to `false`.
 :::
 
@@ -146,7 +146,7 @@ let menu = Menu::with_items(app, &[&quit_i])?;
 
 let tray = TrayIconBuilder::new()
   .menu(&menu)
-  .menu_on_left_click(true)
+  .show_menu_on_left_click(true)
   .build(app)?;
 ```
 
@@ -317,7 +317,7 @@ For detailed information about creating menus, including menu items, submenus, a
 [`TrayIcon.new`]: /reference/javascript/api/namespacetray/#new
 [`TrayIconOptions`]: /reference/javascript/api/namespacetray/#trayiconoptions
 [`TrayIconBuilder`]: https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html
-[TrayIconBuilder::menu_on_left_click]: https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html#method.menu_on_left_click
+[TrayIconBuilder::show_menu_on_left_click]: https://docs.rs/tauri/latest/tauri/tray/struct.TrayIconBuilder.html#method.show_menu_on_left_click
 [`menuOnLeftClick`]: /reference/javascript/api/namespacetray/#properties-1
 [`TrayIconBuilder::on_menu_event`]: https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html#method.on_menu_event
 [js TrayIconEvent]: /reference/javascript/api/namespacetray/#trayiconevent


### PR DESCRIPTION
- Replaces deprecated `menu_on_left_click` with `show_menu_on_left_click` in the System Tray documentation. The old method was deprecated since Tauri 2.2.0 and produces a compiler warning when used.
- Closes #