### PR TITLE
ci: enable sign commits for create-pull-request

### DIFF
--- a/.github/workflows/syncSponsorsData.yml
+++ b/.github/workflows/syncSponsorsData.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create pull request for updated docs
         id: cpr
-        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 7.0.6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}

--- a/.github/workflows/syncSponsorsData.yml
+++ b/.github/workflows/syncSponsorsData.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
 
@@ -39,8 +39,7 @@ jobs:
 
       - name: Create pull request for updated docs
         id: cpr
-        # soft fork of https://github.com/peter-evans/create-pull-request for security purposes
-        uses: tauri-apps/create-pull-request@v3.4.1
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 7.0.6
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
@@ -48,6 +47,7 @@ jobs:
           branch: ci/v2/update-sponsors
           title: Update Sponsors Data
           labels: 'bot'
+          sign-commits: true
 
       - name: Automerge
         run: gh pr merge --squash --auto ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Same as https://github.com/tauri-apps/tauri/pull/13668, but uses the latest version v8.1.1 for `actions/checkout@v6`

Reference: https://github.com/tauri-apps/tauri-docs/pull/3772#issuecomment-4191529462
Run: https://github.com/tauri-apps/tauri-docs/actions/runs/24816287190/job/72631285717