### PR TITLE
fix: minor spelling mistake

### DIFF
--- a/src/content/docs/security/index.mdx
+++ b/src/content/docs/security/index.mdx
@@ -81,7 +81,7 @@ of choice, but Tauri provides generic features to control and contain the attack
 Tauri's approach is to rely on the operating system WebView and not bundling
 the WebView into the application binary.
 
-This has a multitide of reasons but from a security perspective the most
+This has a multitude of reasons but from a security perspective the most
 important reason is the average time it takes from publication of a
 security patched version of a WebView to being rolled out to the
 application end user.


### PR DESCRIPTION
#### Description

I saw a single spelling mistake as I was reading the security doc so fixed it.

`multitide -> multitude`

is what you meant i think