### PR TITLE
docs(plugins): document permission requirement for mobile plugin events

### DIFF
--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -660,9 +660,7 @@ Listening to plugin events from JavaScript is gated by the same [capability](/se
 {
   "identifier": "default",
   "windows": ["main"],
-  "permissions": [
-    "<plugin-name>:default"
-  ]
+  "permissions": ["<plugin-name>:default"]
 }
 ```
 

--- a/src/content/docs/develop/Plugins/develop-mobile.mdx
+++ b/src/content/docs/develop/Plugins/develop-mobile.mdx
@@ -650,3 +650,22 @@ export async function onRequest(
 	);
 }
 ```
+
+:::note[Capability Required]
+
+Listening to plugin events from JavaScript is gated by the same [capability](/security/capabilities/) and [permission](/security/permissions/) system that gates plugin commands. Add the plugin's permission (commonly `<plugin-name>:default`, or a specific `allow-listen-*` permission if the plugin defines one) to the `permissions` array of a capability under `src-tauri/capabilities/`:
+
+```json
+// src-tauri/capabilities/default.json
+{
+  "identifier": "default",
+  "windows": ["main"],
+  "permissions": [
+    "<plugin-name>:default"
+  ]
+}
+```
+
+Refer to the plugin's own documentation for the exact permission identifiers it exposes.
+
+:::


### PR DESCRIPTION
  #### Description

  - Adds a note to the Plugin Events section of the mobile plugin development
  guide explaining that listening to plugin events from JavaScript is gated by
  the same capability and permission system that gates plugin commands.  The
  note includes a capability JSON example and links to `/security/capabilities/`
   and `/security/permissions/` for the full configuration model.
   
  Closes: tauri-apps/tauri#13100