### PR TITLE
i18n(uz): add Uzbek localization and fix dynamic hero routing

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -22,5 +22,9 @@
   "ko": {
     "label": "한국어",
     "lang": "ko"
+  },
+  "uz": {
+    "label": "O'zbekcha",
+    "lang": "uz"
   }
 }

--- a/lunaria.config.json
+++ b/lunaria.config.json
@@ -46,6 +46,10 @@
     {
       "label": "한국어",
       "lang": "ko"
+    },
+    {
+      "label": "O'zbekcha",
+      "lang": "uz"
     }
   ],
   "dashboard": {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -5,6 +5,9 @@ import LogoDark from '@assets/logo.svg';
 import LogoOutline from '@assets/logo-outline.svg';
 
 const { tagline, getStarted, v1Docs } = Astro.props;
+const [, locale] = Astro.url.pathname.split('/');
+
+const baseLink = locale && locale !== 'start' ? `/${locale}/start/` : '/start/';
 ---
 
 <div class="hero-bg">
@@ -22,7 +25,8 @@ const { tagline, getStarted, v1Docs } = Astro.props;
         {tagline}
       </p>
       <div class="actions">
-        <LinkButton icon="right-arrow" href="/start/">{getStarted}</LinkButton>
+        <LinkButton icon="right-arrow" href={baseLink}>{getStarted}</LinkButton>
+
         <LinkButton href="https://v1.tauri.app" variant="minimal" icon="external">
           {v1Docs}
         </LinkButton>

--- a/src/content/docs/uz/index.mdx
+++ b/src/content/docs/uz/index.mdx
@@ -1,0 +1,59 @@
+---
+title: Tauri 2.0
+description: Krossplatformali ilovalar yaratish uchun vositalar to'plami
+i18nReady: true
+editUrl: false
+lastUpdated: false
+template: splash
+tableOfContents: false
+prev: false
+next: false
+---
+
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import Cta from '@fragments/cta.mdx';
+import Hero from '@components/Hero.astro';
+import SponsorList from '@components/sponsors/SponsorList.astro';
+import 'src/styles/home.css';
+
+<Hero
+  tagline="Yengil, tezkor va xavfsiz krossplatformali ilovalar yarating"
+  getStarted="Boshlash"
+  v1Docs="Tauri 1.0 hujjatlari"
+/>
+
+<div class="lp-cta-card">
+  <Card title="Loyihani boshlash" icon="rocket">
+    <Cta />
+  </Card>
+</div>
+
+<CardGrid>
+  <a href="https://v2.tauri.app/start/frontend/" className="card-link card-frontend">
+    <Card title="Frontenddan mustaqil" icon="rocket">
+      Mavjud veb-stekingizni Tauriga olib o'ting yoki yangi orzungizdagi loyihani boshlang.
+      Tauri har qanday frontend freymvorkni qo'llab-quvvatlaydi, shuning uchun texnologiyalar stekingizni o'zgartirishingiz shart emas.
+    </Card>
+  </a>
+
+  <a href="https://v2.tauri.app/distribute/" className="card-link card-platform">
+    <Card title="Krossplatformali" icon="rocket">
+      Yagona kod bazasidan foydalanib Linux, macOS, Windows, Android va iOS uchun ilovalar yarating.
+      Frontendni JavaScriptda, ilova mantiqini Rustda yozing hamda Swift va Kotlin orqali tizimning chuqur qatlamlari bilan integratsiya qiling.
+    </Card>
+  </a>
+
+  <a href="https://v2.tauri.app/security/" className="card-link card-security">
+    <Card title="Maksimal xavfsizlik" icon="rocket">
+      Xavfsizlik Tauri jamoasi uchun doimo diqqat markazida bo'lib, u bizning asosiy ustuvor vazifalarimiz va eng katta innovatsiyalarimizni belgilab beradi.
+    </Card>
+  </a>
+
+  <a href="https://v2.tauri.app/concept/size/" className="card-link card-size">
+    <Card title="Minimal hajm" icon="rocket">
+      Operatsion tizimning standart veb-rendereridan (native web renderer) foydalanish hisobiga, Tauri ilovasining hajmi 600KB gacha kichik bo'lishi mumkin.
+    </Card>
+  </a>
+</CardGrid>
+
+<SponsorList />

--- a/src/content/docs/uz/index.mdx
+++ b/src/content/docs/uz/index.mdx
@@ -31,8 +31,8 @@ import 'src/styles/home.css';
 <CardGrid>
   <a href="https://v2.tauri.app/start/frontend/" className="card-link card-frontend">
     <Card title="Frontenddan mustaqil" icon="rocket">
-      Mavjud veb-stekingizni Tauriga olib o'ting yoki yangi orzungizdagi loyihani boshlang.
-      Tauri har qanday frontend freymvorkni qo'llab-quvvatlaydi, shuning uchun texnologiyalar stekingizni o'zgartirishingiz shart emas.
+      Mavjud veb-stekingizni Tauriga olib oʻting yoki yangi orzungizdagi loyihani boshlang.
+      Tauri har qanday frontend freymvorkni qoʻllab-quvvatlaydi, shuning uchun texnologiyalar stekingizni oʻzgartirishingiz shart emas.
     </Card>
   </a>
 
@@ -45,15 +45,15 @@ import 'src/styles/home.css';
 
   <a href="https://v2.tauri.app/security/" className="card-link card-security">
     <Card title="Maksimal xavfsizlik" icon="rocket">
-      Xavfsizlik Tauri jamoasi uchun doimo diqqat markazida bo'lib, u bizning asosiy ustuvor vazifalarimiz va eng katta innovatsiyalarimizni belgilab beradi.
+      Xavfsizlik Tauri jamoasi uchun doimo diqqat markazida boʻlib, u bizning asosiy ustuvor vazifalarimiz va eng katta innovatsiyalarimizni belgilab beradi.
     </Card>
   </a>
 
   <a href="https://v2.tauri.app/concept/size/" className="card-link card-size">
     <Card title="Minimal hajm" icon="rocket">
-      Operatsion tizimning standart veb-rendereridan (native web renderer) foydalanish hisobiga, Tauri ilovasining hajmi 600KB gacha kichik bo'lishi mumkin.
+      Operatsion tizimning standart veb-rendereridan (native web renderer) foydalanish hisobiga, Tauri ilovasining hajmi 600KB gacha kichik boʻlishi mumkin.
     </Card>
   </a>
 </CardGrid>
 
-<SponsorList />
+[//]: # (<SponsorList />)

--- a/src/content/docs/uz/rss.mdx
+++ b/src/content/docs/uz/rss.mdx
@@ -1,0 +1,27 @@
+---
+title: Tauri RSS tasmalar (Feeds)
+i18nReady: true
+topic: guides # bu sahifa ko'rilayotganda yon menyu faol bo'ladi
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<LinkCard
+  title="Barcha yangilanishlar"
+  description="Butun sayt bo'ylab sodir bo'ladigan barcha yangilanishlar haqida bildirishnomalar oling."
+  href="/feed.xml"
+/>
+
+<LinkCard
+  title="Blog yangilanishlari"
+  description="Eng so'nggi blog postlari va maqolalarni kuzatib boring."
+  href="/blog/rss.xml"
+/>
+
+<LinkCard
+  title="Sahifalar yangilanishi"
+  description="Asosiy sayt sahifalaridagi yangilanishlar haqida ma'lumot oling."
+  href="/pages.xml"
+/>
+
+<div style="text-align: right;">Doc-UZ 2.00.00</div>

--- a/src/content/docs/uz/start/create-project.mdx
+++ b/src/content/docs/uz/start/create-project.mdx
@@ -1,0 +1,230 @@
+---
+title: Create a Project
+sidebar:
+  order: 3
+i18nReady: true
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+import Cta from '@fragments/cta.mdx';
+
+One thing that makes Tauri so flexible is its ability to work with virtually any frontend framework. We've created the [`create-tauri-app`](https://github.com/tauri-apps/create-tauri-app) utility to help you create a new Tauri project using one of the officially maintained framework templates.
+
+`create-tauri-app` currently includes templates for vanilla (HTML, CSS and JavaScript without a framework), [Vue.js](https://vuejs.org), [Svelte](https://svelte.dev), [React](https://reactjs.org/), [SolidJS](https://www.solidjs.com/), [Angular](https://angular.io/), [Preact](https://preactjs.com/), [Yew](https://yew.rs/), [Leptos](https://github.com/leptos-rs/leptos), and [Sycamore](https://sycamore.dev/). You can also find or add your own community templates and frameworks in the [Awesome Tauri repo](https://github.com/tauri-apps/awesome-tauri).
+
+{/* TODO: redirect to integrate to existing front-end project specific docs */}
+Alternatively, you can [add Tauri to an existing project](#manual-setup-tauri-cli) to quickly turn your existing codebase into a Tauri app.
+
+## Using `create-tauri-app`
+
+To get started using `create-tauri-app` run one of the below commands in the folder you'd like to setup your project. If you're not sure which command to use we recommend the Bash command on Linux and macOS and the PowerShell command on Windows.
+
+<Cta />
+
+Follow along with the prompts to choose your project name, frontend language, package manager, and frontend framework, and frontend framework options if applicable.
+
+:::tip[Not sure what to choose?]
+
+We recommend starting with the vanilla template (HTML, CSS, and JavaScript without a frontend framework) to get started. You can always [integrate a frontend framework](/start/frontend/) later.
+
+- Choose which language to use for your frontend: `TypeScript / JavaScript`
+- Choose your package manager: `pnpm`
+- Choose your UI template: `Vanilla`
+- Choose your UI flavor: `TypeScript`
+
+:::
+
+#### Scaffold a new project
+
+<Steps>
+
+1. Choose a name and a bundle identifier (unique-id for your app):
+   ```
+   ? Project name (tauri-app) ›
+   ? Identifier (com.tauri-app.app) ›
+   ```
+2. Select a flavor for your frontend. First the language:
+   ```
+   ? Choose which language to use for your frontend ›
+   Rust  (cargo)
+   TypeScript / JavaScript  (pnpm, yarn, npm, bun)
+   .NET  (dotnet)
+   ```
+3. Select a package manager (if there are multiple available):
+
+   Options for **TypeScript / JavaScript**:
+
+   ```
+   ? Choose your package manager ›
+   pnpm
+   yarn
+   npm
+   bun
+   ```
+
+4. Select a UI Template and flavor (if there are multiple available):
+
+   Options for **Rust**:
+
+   ```
+   ? Choose your UI template ›
+   Vanilla
+   Yew
+   Leptos
+   Sycamore
+   ```
+
+   Options for **TypeScript / JavaScript**:
+
+   ```
+   ? Choose your UI template ›
+   Vanilla
+   Vue
+   Svelte
+   React
+   Solid
+   Angular
+   Preact
+
+   ? Choose your UI flavor ›
+   TypeScript
+   JavaScript
+   ```
+
+   Options for **.NET**:
+
+   ```
+   ? Choose your UI template ›
+   Blazor  (https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor/)
+   ```
+
+</Steps>
+
+Once completed, the utility reports that the template has been created and displays how to run it using the configured package manager. If it detects missing dependencies on your system, it prints a list of packages and prompts how to install them.
+
+{/* TODO: Can CTA offer to install the deps? */}
+
+#### Start the development server
+
+After `create-tauri-app` has completed, you can navigate into your project's folder, install dependencies, and then use the [Tauri CLI](/reference/cli/) to start the development server:
+
+import CommandTabs from '@components/CommandTabs.astro';
+
+<CommandTabs
+  npm="cd tauri-app
+    npm install
+    npm run tauri dev"
+  yarn="cd tauri-app
+    yarn install
+    yarn tauri dev"
+  pnpm="cd tauri-app
+    pnpm install
+    pnpm tauri dev"
+  deno="cd tauri-app
+    deno install
+    deno task tauri dev"
+  bun="cd tauri-app
+    bun install
+    bun tauri dev
+  "
+  cargo='cd tauri-app
+    cargo install tauri-cli --version "^2.0.0" --locked
+    cargo tauri dev'
+/>
+
+You'll now see a new window open with your app running.
+
+**Congratulations!** You've made your Tauri app! 🚀
+
+## Manual Setup (Tauri CLI)
+
+If you already have an existing frontend or prefer to set it up yourself, you can use the Tauri CLI to initialize the backend for your project separately.
+
+:::note
+The following example assumes you are creating a new project. If you've already initialized the frontend of your application, you can skip the first step.
+:::
+
+<Steps>
+
+    1. Create a new directory for your project and initialize the frontend. You can use plain HTML, CSS, and JavaScript, or any framework you prefer such as Next.js, Nuxt, Svelte, Yew, or Leptos. You just need a way of serving the app in your browser. Just as an example, this is how you would setup a simple Vite app:
+
+        <CommandTabs
+            npm="mkdir tauri-app
+                cd tauri-app
+                npm create vite@latest ."
+            yarn="mkdir tauri-app
+                cd tauri-app
+                yarn create vite ."
+            pnpm="mkdir tauri-app
+                cd tauri-app
+                pnpm create vite ."
+            deno="mkdir tauri-app
+                cd tauri-app
+                deno run -A npm:create-vite ."
+            bun="mkdir tauri-app
+                cd tauri-app
+                bun create vite"
+        />
+
+    2. Then, install Tauri's CLI tool using your package manager of choice. If you are using `cargo` to install the Tauri CLI, you will have to install it globally.
+
+        <CommandTabs
+            npm="npm install -D @tauri-apps/cli@latest"
+            yarn="yarn add -D @tauri-apps/cli@latest"
+            pnpm="pnpm add -D @tauri-apps/cli@latest"
+            deno="deno add -D npm:@tauri-apps/cli@latest"
+            bun="bun add -D @tauri-apps/cli@latest"
+            cargo='cargo install tauri-cli --version "^2.0.0" --locked'
+        />
+
+    3. Determine the URL of your frontend development server. This is the URL that Tauri will use to load your content. For example, if you are using Vite, the default URL is `http://localhost:5173`.
+
+    4. In your project directory, initialize Tauri:
+
+        <CommandTabs
+            npm="npx tauri init"
+            yarn="yarn tauri init"
+            pnpm="pnpm tauri init"
+            deno="deno task tauri init"
+            bun="bun tauri init"
+            cargo="cargo tauri init"
+        />
+
+        After running the command it will display a prompt asking you for different options:
+
+        ```sh frame=none
+        ✔ What is your app name? tauri-app
+        ✔ What should the window title be? tauri-app
+        ✔ Where are your web assets located? ..
+        ✔ What is the url of your dev server? http://localhost:5173
+        ✔ What is your frontend dev command? pnpm run dev
+        ✔ What is your frontend build command? pnpm run build
+        ```
+
+        This will create a `src-tauri` directory in your project with the necessary Tauri configuration files.
+
+    5. Verify your Tauri app is working by running the development server:
+
+        <CommandTabs
+            npm="npx tauri dev"
+            yarn="yarn tauri dev"
+            pnpm="pnpm tauri dev"
+            deno="deno task tauri dev"
+            bun="bun tauri dev"
+            cargo="cargo tauri dev"
+        />
+
+        This command will compile the Rust code and open a window with your web content.
+
+</Steps>
+
+**Congratulations!** You've created a new Tauri project using the Tauri CLI! 🚀
+
+## Next Steps
+
+- [Learn about the project layout and what each file does](/start/project-structure/)
+- [Add and Configure a Frontend Framework](/start/frontend/)
+- [Tauri Command Line Interface (CLI) Reference](/reference/cli/)
+- [Learn how to develop your Tauri app](/develop/)
+- [Discover additional features to extend Tauri](/plugin/)

--- a/src/content/docs/uz/start/index.mdx
+++ b/src/content/docs/uz/start/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Tauri nima?
+i18nReady: true
+sidebar:
+  order: 0
+---
+
+Tauri — barcha asosiy ish stoli (desktop) va mobil platformalar uchun kichik hamda tezkor binar fayllar (binaries) yaratishga moʻljallangan freymvorkdir. Dasturchilar oʻz foydalanuvchi interfeyslarini (UX) qurish uchun HTML, JavaScript va CSS-ga kompilyatsiya boʻladigan istalgan frontend freymvorkni integratsiya qilishlari, shu bilan birga, zarurat tugʻilganda backend logikasi uchun Rust, Swift va Kotlin kabi tillar imkoniyatlaridan foydalanishlari mumkin.
+
+Quyidagi buyruqlardan birini ishlatib, [`create-tauri-app`](https://github.com/tauri-apps/create-tauri-app) yordamida loyiha yaratishni boshlang. Tauri uchun zarur boʻlgan barcha bogʻliqliklarni (dependencies) oʻrnatish uchun [tizim talablari qoʻllanmasiga](/uz/start/prerequisites/) amal qilganingizga ishonch hosil qiling. Batafsilroq bosqichma-bosqich qoʻllanma uchun [Loyiha yaratish](/start/create-project/#using-create-tauri-app) boʻlimiga qarang.
+
+import Cta from '../../_fragments/cta.mdx';
+
+<Cta />
+
+Ilk ilovangizni yaratgandan soʻng, har bir fayl nima vazifa bajarishini tushunish uchun [Loyiha tuzilishi](/uz/start/project-structure/) boʻlimi bilan tanishib chiqing.
+
+Yoki tayyor misollar yordamida loyiha sozlamalari va imkoniyatlarini oʻrganing ([tauri](https://github.com/tauri-apps/tauri/tree/dev/examples) | [plugins-workspace](https://github.com/tauri-apps/plugins-workspace/tree/v2/examples/api))
+## Nima uchun Tauri?
+
+Tauri dasturchilarga loyihalarini qurish uchun 3 ta asosiy afzallikni taqdim etadi:
+
+- Ilovalar yaratish uchun xavfsiz poydevor (foundation)
+- Tizimning ichki veb-koʻrinishidan (native webview) foydalanish orqali kichikroq paket (bundle) hajmi
+- Dasturchilar uchun istalgan frontend-dan foydalanish va bir nechta tillar uchun bogʻlamalar (bindings) moslanuvchanligi
+
+Tauri haqida batafsil maʼlumotni [Tauri 1.0 blog postidan](/uz/blog/tauri-1-0/) bilib oling.
+
+### Xavfsiz poydevor
+
+Rust tiliga asoslangani tufayli Tauri uning xotira (memory), oqimlar (thread) va turlar (type) xavfsizligi kabi afzalliklaridan toʻliq foydalana oladi. Tauri-da yaratilgan ilovalar, hatto ularni ishlab chiquvchilar Rust boʻyicha ekspert boʻlmasalar ham, ushbu afzalliklarga avtomatik ravishda ega boʻlishadi.
+
+Tauri shuningdek, yirik (major) va kichik (minor) relizlar uchun xavfsizlik auditidan oʻtkaziladi. Bu nafaqat Tauri tashkiloti (organization) ichidagi kodlarni, balki Tauri tayanadigan yuqori oqim bogʻliqliklarini (upstream dependencies) ham qamrab oladi. Albatta, bu barcha xavflarni butunlay yoʻq qilmaydi, lekin dasturchilar oʻz loyihalarini qurishlari uchun mustahkam poydevor yaratadi.
+
+[Tauri xavfsizlik siyosati](https://github.com/tauri-apps/tauri/security/policy) va [Tauri 2.0 audit hisoboti](https://github.com/tauri-apps/tauri/blob/dev/audits/Radically_Open_Security-v2-report.pdf) bilan tanishing.
+
+### Kichikroq ilova hajmi
+
+Tauri ilovalari har bir foydalanuvchining tizimida allaqachon mavjud boʻlgan veb-koʻrinishdan (web view) unumli foydalanadi. Tauri ilovasi faqatgina shu ilovaning oʻziga tegishli kod va aktivlarni (assets) oʻz ichiga oladi va har bir ilova ichiga brauzer dvigatelini (browser engine) qoʻshib paketlashga (bundle) ehtiyoj qolmaydi. Bu esa minimal Tauri ilovasining hajmi 600KB dan ham kam boʻlishi mumkinligini anglatadi.
+
+Optimallashtirilgan ilovalar yaratish haqida batafsil maʼlumotni [Ilova hajmi konsepsiyasi](/uz/concept/size/) boʻlimidan bilib oling.
+
+### Moslanuvchan arxitektura
+
+Tauri veb-texnologiyalardan foydalangani sababli, deyarli har qanday frontend freymvork Tauri bilan toʻliq mos keladi. [Frontend sozlamalari qoʻllanmasi](/uz/start/frontend/) ommabop frontend freymvorklari uchun eng koʻp tarqalgan konfiguratsiyalarni oʻz ichiga oladi.
+
+JavaScript va Rust oʻrtasidagi bogʻlamalar (bindings) dasturchilar uchun JavaScript-dagi `invoke` funksiyasi orqali taqdim etiladi. Swift va Kotlin bogʻlamalaridan esa [Tauri plaginlari](/uz/develop/plugins/) uchun foydalanish mumkin.
+
+Tauri-da oynalar yaratish uchun [TAO](https://github.com/tauri-apps/tao) kutubxonasi, veb-koʻrinishni vizuallashtirish (rendering) uchun esa [WRY](https://github.com/tauri-apps/wry) kutubxonasi javobgardir. Ushbu kutubxonalar Tauri jamoasi tomonidan yuritiladi (maintain qilinadi) va agar Tauri taqdim etadigan imkoniyatlardan tashqari, tizim bilan chuqurroq integratsiya qilish kerak boʻlsa, ulardan toʻgʻridan-toʻgʻri foydalanish ham mumkin.
+
+Bundan tashqari, Tauri oʻzining asosiy (core) imkoniyatlarini kengaytirish uchun bir qator rasmiy plaginlarni ham qoʻllab-quvvatlaydi. Ushbu plaginlarni va hamjamiyat (community) tomonidan yaratilgan boshqa yechimlarni [Plaginlar boʻlimidan](/uz/plugin/) topishingiz mumkin.

--- a/src/content/docs/uz/start/prerequisites.mdx
+++ b/src/content/docs/uz/start/prerequisites.mdx
@@ -1,0 +1,413 @@
+---
+title: Tizim talablari
+i18nReady: true
+sidebar:
+  order: 0
+---
+
+import { Tabs, TabItem, Card } from '@astrojs/starlight/components';
+
+Tauri yordamida loyihangizni qurishni boshlash uchun, avvalo, bir nechta bogʻliqliklarni (dependencies) oʻrnatishingiz kerak boʻladi:
+
+1. [Tizim talablari (System Dependencies)](#system-dependencies)
+2. [Rust](#rust)
+3. [Mobil platformalar uchun sozlash](#configure-for-mobile-targets) (faqat mobil ilovalar ishlab chiqish uchun zarur)
+
+## Tizim talablari
+
+Tizimingizga mos keladigan operatsion tizim havolasiga oʻtib, koʻrsatmalarga amal qiling:
+
+- [Linux](#linux) (maxsus distributivlar uchun pastga qarang)
+- [macOS Catalina (10.15) va undan keyingi versiyalar](#macos)
+- [Windows 7 va undan keyingi versiyalar](#windows)
+
+### Linux
+
+Tauri Linux platformasida dasturlash uchun turli xil tizim bogʻliqliklarini talab qiladi. Ular siz foydalanayotgan distributivga qarab farq qilishi mumkin, biroq tizimni sozlashga yordam berish uchun quyida eng ommabop distributivlarni keltirib oʻtdik.
+
+<Tabs syncKey="distro">
+  <TabItem label="Debian">
+
+```sh
+sudo apt update
+sudo apt install libwebkit2gtk-4.1-dev \
+  build-essential \
+  curl \
+  wget \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+```
+
+  </TabItem>
+  <TabItem label="Arch">
+
+```sh
+sudo pacman -Syu
+sudo pacman -S --needed \
+  webkit2gtk-4.1 \
+  base-devel \
+  curl \
+  wget \
+  file \
+  openssl \
+  appmenu-gtk-module \
+  libappindicator-gtk3 \
+  librsvg \
+  xdotool
+```
+
+  </TabItem>
+  <TabItem label="Fedora">
+
+```sh
+sudo dnf check-update
+sudo dnf install webkit2gtk4.1-devel \
+  openssl-devel \
+  curl \
+  wget \
+  file \
+  libappindicator-gtk3-devel \
+  librsvg2-devel \
+  libxdo-devel
+sudo dnf group install "c-development"
+```
+
+  </TabItem>
+  <TabItem label="Gentoo">
+
+```sh
+sudo emerge --ask \
+  net-libs/webkit-gtk:4.1 \
+  dev-libs/libayatana-appindicator \
+  net-misc/curl \
+  net-misc/wget \
+  sys-apps/file
+```
+
+  </TabItem>
+  <TabItem label="OSTree">
+
+```sh
+sudo rpm-ostree install webkit2gtk4.1-devel \
+  openssl-devel \
+  curl \
+  wget \
+  file \
+  libappindicator-gtk3-devel \
+  librsvg2-devel \
+  libxdo-devel \
+  gcc \
+  gcc-c++ \
+  make
+sudo systemctl reboot
+```
+
+  </TabItem>
+  <TabItem label="openSUSE">
+
+```sh
+sudo zypper up
+sudo zypper in webkit2gtk3-devel \
+  libopenssl-devel \
+  curl \
+  wget \
+  file \
+  libappindicator3-1 \
+  librsvg-devel
+sudo zypper in -t pattern devel_basis
+```
+
+  </TabItem>
+  <TabItem label="Alpine">
+```sh
+sudo apk add \
+  build-base \
+  webkit2gtk-4.1-dev \
+  curl \
+  wget \
+  file \
+  openssl \
+  libayatana-appindicator-dev \
+  librsvg
+```
+
+> **Eslatma:** Alpine Linux konteynerlarida standart holatda hech qanday shriftlar mavjud boʻlmaydi. Tauri ilovangizda matnlar toʻgʻri vizuallashishi (render boʻlishi) uchun kamida bitta shrift paketini (masalan, `font-dejavu`) oʻrnatib qoʻying.
+
+  </TabItem>
+  <TabItem label="NixOS">
+
+:::note
+Nix/NixOS uchun qoʻllanmalarni [NixOS Wiki](https://wiki.nixos.org/wiki/Tauri) sahifasidan topishingiz mumkin.
+:::
+
+  </TabItem>
+</Tabs>
+
+Agar sizning distributivingiz yuqoridagi roʻyxatda boʻlmasa, maxsus qoʻllanma yaratilgan yoki yaratilmaganini tekshirish uchun [GitHub-dagi Awesome Tauri](https://github.com/tauri-apps/awesome-tauri#guides) sahifasiga koʻz yugurtirishingiz mumkin.
+
+Keyingi boʻlim: [Rust-ni oʻrnatish](#rust)
+
+### macOS
+
+Tauri dasturlash jarayonida [Xcode](https://developer.apple.com/xcode/resources/) hamda turli xil macOS va iOS operatsion tizimlariga xos bogʻliqliklardan foydalanadi.
+
+Xcode-ni quyidagi manbalarning biridan yuklab oling va oʻrnating:
+
+- [Mac App Store](https://apps.apple.com/gb/app/xcode/id497799835?mt=12)
+- [Apple Developer veb-sayti](https://developer.apple.com/xcode/resources/).
+
+Oʻrnatish tugallangach, Xcode loyihani sozlash ishlarini yakunlashi uchun uni kamida bir marta ishga tushirganingizga ishonch hosil qiling.
+
+<details>
+<summary>Faqat ish stoli (desktop) platformalari uchun ilova yaratasizmi?</summary>
+Agar siz faqatgina desktop ilovalar yaratishni rejalashtirayotgan boʻlsangiz va iOS platformasini maqsad qilmagan boʻlsangiz, toʻliq Xcode oʻrniga faqat Xcode Command Line Tools-ni oʻrnatishingiz ham kifoya:
+
+```sh
+xcode-select --install
+```
+</details>
+
+#### Microsoft C++ Build Tools
+
+1. [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) oʻrnatuvchi faylini (installer) yuklab oling va oʻrnatishni boshlash uchun uni oching.
+2. Oʻrnatish jarayonida "Desktop development with C++" (C++ yordamida ish stoli ilovalarini ishlab chiqish) bandini belgilang.
+
+![Visual Studio C++ Build Tools oʻrnatuvchi dasturining skrinshoti](@assets/start/prerequisites/visual-studio-build-tools-installer.png)
+
+Keyingi boʻlim: [WebView2-ni oʻrnatish](#webview2).
+
+#### WebView2
+
+:::tip
+WebView 2 komponenti Windows 10 (1803-versiyadan boshlab) va undan keyingi barcha Windows versiyalariga allaqachon oʻrnatilgan. Agar siz ushbu versiyalardan birida dasturlayotgan boʻlsangiz, bu qadamni oʻtkazib yuborib, toʻgʻridan-toʻgʻri [Rust-ni oʻrnatish](#rust) boʻlimiga oʻtishingiz mumkin.
+:::
+
+Tauri Windows tizimida kontentni vizuallashtirish (render qilish) uchun Microsoft Edge WebView2 vositasidan foydalanadi.
+
+WebView2-ni oʻrnatish uchun [WebView2 Runtime yuklab olish boʻlimiga](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section) oʻting. "Evergreen Bootstrapper" paketini yuklab oling va uni oʻrnating.
+
+Keyingi boʻlim: [VBSCRIPT holatini tekshirish](#vbscript-for-msi-installers)
+
+#### VBSCRIPT (MSI oʻrnatuvchilari uchun)
+
+:::note[Faqat MSI paketlarini yigʻish uchun]
+Bu sozlama faqatgina MSI formatidagi oʻrnatuvchi paketlarni yigʻishni rejalashtirayotgan boʻlsangiz talab qilinadi (`tauri.conf.json` faylida `"targets": "msi"` yoki `"targets": "all"` deb koʻrsatilgan boʻlsa).
+:::
+
+Windows-da MSI paketlarini yigʻish (build qilish) uchun qoʻshimcha VBSCRIPT funksiyasi yoqilgan boʻlishi kerak. Ushbu funksiya koʻplab Windows tizimlarida standart holatda yoqilgan boʻladi, biroq baʼzi kompyuterlarda oʻchirib qoʻyilgan boʻlishi mumkin.
+
+Agar MSI paketlarini yigʻishda `failed to run light.exe` kabi xatoliklarga duch kelsangiz, VBSCRIPT funksiyasini quyidagicha yoqishingiz kerak boʻladi:
+
+1. **Settings (Sozlamalar)** → **Apps (Ilovalar)** → **Optional features (Qoʻshimcha funksiyalar)** → **More Windows features (Boshqa Windows funksiyalari)** boʻlimini oching
+2. Roʻyxatdan **VBSCRIPT** bandini toping va uning yoniga belgi (galochka) qoʻyilganiga ishonch hosil qiling
+3. **Next (Keyingi)** tugmasini bosing va agar soʻralsa, kompyuterni qayta yuklang (restart qiling)
+
+**Eslatma:** VBSCRIPT hozirda koʻplab Windows tizimlarida standart holatda yoqilgan boʻlsa-da, u eskirgan funksiya hisoblanadi va kelajakda [butunlay toʻxtatilishi kutilmoqda](https://techcommunity.microsoft.com/blog/windows-itpro-blog/vbscript-deprecation-timelines-and-next-steps/4148301). Shuning uchun keyingi Windows versiyalarida u oʻchirib qoʻyilgan boʻlishi mumkin.
+
+Keyingi boʻlim: [Rust-ni oʻrnatish](#rust)
+
+## Rust
+
+Tauri [Rust](https://www.rust-lang.org) tili yordamida yaratilgan va dasturlash jarayonida uni talab qiladi. Rust-ni quyidagi usullardan biri orqali oʻrnating. Boshqa oʻrnatish usullari bilan https://www.rust-lang.org/tools/install sahifasida tanishishingiz mumkin.
+
+<Tabs syncKey="OS">
+  <TabItem label="Linux va macOS" class="content">
+
+Quyidagi buyruq yordamida [`rustup`](https://github.com/rust-lang/rustup) orqali oʻrnating:
+
+```sh
+curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+```
+
+:::tip[Xavfsizlik boʻyicha maslahat]
+Biz ushbu bash skriptini auditdan oʻtkazganmiz va u oʻzi bajarishi kerak boʻlgan vazifani toʻliq bajaradi. Shunday boʻlsa-da, har qanday skriptni koʻr-koʻrona curl orqali ishga tushirishdan oldin, har doim uning ichki kodini koʻzdan kechirish oqilona qaror hisoblanadi.
+
+Skriptning oddiy matn koʻrinishidagi fayli: [rustup.sh](https://sh.rustup.rs/)
+:::
+
+</TabItem>
+<TabItem label="Windows">
+
+Visit https://www.rust-lang.org/tools/install to install `rustup`.
+
+Alternatively, you can use `winget` to install rustup using the following command in PowerShell:
+
+```powershell
+winget install --id Rustlang.Rustup
+```
+
+:::caution[MSVC toolchain as default]
+
+For full support for Tauri and tools like [`trunk`](https://trunk-rs.github.io/trunk/) make sure the MSVC Rust toolchain is the selected `default host triple` in the installer dialog. Depending on your system it should be either `x86_64-pc-windows-msvc`, `i686-pc-windows-msvc`, or `aarch64-pc-windows-msvc`.
+
+If you already have Rust installed, you can make sure the correct toolchain is installed by running this command:
+
+```powershell
+rustup default stable-msvc
+```
+
+:::
+
+  </TabItem>
+</Tabs>
+
+**Be sure to restart your Terminal (and in some cases your system) for the changes to take effect.**
+
+Next: [Configure for Mobile Targets](#configure-for-mobile-targets) if you'd like to build for Android and iOS, or, if you'd like to use a JavaScript framework, [install Node](#nodejs). Otherwise [Create a Project](/start/create-project/).
+
+## Node.js
+
+:::note[JavaScript ecosystem]
+Only if you intend to use a JavaScript frontend framework
+:::
+
+1. Go to the [Node.js website](https://nodejs.org), download the Long Term Support (LTS) version and install it.
+2. Check if Node was successfully installed by running:
+
+```sh
+node -v
+# v20.10.0
+npm -v
+# 10.2.3
+```
+
+It's important to restart your Terminal to ensure it recognizes the new installation. In some cases, you might need to restart your computer.
+
+While npm is the default package manager for Node.js, you can also use others like pnpm or yarn. To enable these, run `corepack enable` in your Terminal. This step is optional and only needed if you prefer using a package manager other than npm.
+
+Next: [Configure for Mobile Targets](#configure-for-mobile-targets) or [Create a project](/start/create-project/).
+
+## Configure for Mobile Targets
+
+If you'd like to target your app for Android or iOS then there are a few additional dependencies that you need to install:
+
+- [Android](#android)
+- [iOS](#ios)
+
+### Android
+
+1. Download and install [Android Studio from the Android Developers website](https://developer.android.com/studio)
+2. Set the `JAVA_HOME` environment variable:
+
+{/* TODO: Can this be done in the 4th step? */}
+
+<Tabs syncKey="prereqs">
+<TabItem label="Linux">
+
+```sh
+export JAVA_HOME=/opt/android-studio/jbr
+```
+
+</TabItem>
+<TabItem label="macOS">
+
+```sh
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+```
+
+</TabItem>
+<TabItem label="Windows">
+
+```ps
+[System.Environment]::SetEnvironmentVariable("JAVA_HOME", "C:\Program Files\Android\Android Studio\jbr", "User")
+```
+
+</TabItem>
+</Tabs>
+3. Use the SDK Manager in Android Studio to install the following:
+
+- Android SDK Platform
+- Android SDK Platform-Tools
+- NDK (Side by side)
+- Android SDK Build-Tools
+- Android SDK Command-line Tools
+
+Selecting "Show Package Details" in the SDK Manager enables the installation of older package versions. Only install older versions if necessary, as they may introduce compatibility issues or security risks.
+
+4. Set `ANDROID_HOME` and `NDK_HOME` environment variables.
+
+<Tabs syncKey="prereqs">
+<TabItem label="Linux">
+
+```sh
+export ANDROID_HOME="$HOME/Android/Sdk"
+export NDK_HOME="$ANDROID_HOME/ndk/$(ls -1 $ANDROID_HOME/ndk)"
+```
+
+</TabItem>
+<TabItem label="macOS">
+
+```sh
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export NDK_HOME="$ANDROID_HOME/ndk/$(ls -1 $ANDROID_HOME/ndk)"
+```
+
+</TabItem>
+<TabItem label="Windows">
+
+```ps
+[System.Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:LocalAppData\Android\Sdk", "User")
+$VERSION = Get-ChildItem -Name "$env:LocalAppData\Android\Sdk\ndk" | Select-Object -Last 1
+[System.Environment]::SetEnvironmentVariable("NDK_HOME", "$env:LocalAppData\Android\Sdk\ndk\$VERSION", "User")
+```
+
+:::tip
+Most apps don't refresh their environment variables automatically, so to let them pickup the changes,
+you can either restart your terminal and IDE or for your current PowerShell session, you can refresh it with
+
+```ps
+[System.Environment]::GetEnvironmentVariables("User").GetEnumerator() | % { Set-Item -Path "Env:\$($_.key)" -Value $_.value }
+```
+
+:::
+
+</TabItem>
+
+</Tabs>
+
+5. Add the Android targets with `rustup`:
+
+```sh
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+```
+
+Next: [Setup for iOS](#ios) or [Create a project](/start/create-project/).
+
+### iOS
+
+:::caution[macOS Only]
+iOS development requires Xcode and is only available on macOS. Be sure that you've installed Xcode and not Xcode Command Line Tools in the [macOS system dependencies section](#macos).
+:::
+
+1. Add the iOS targets with `rustup` in Terminal:
+
+```sh
+rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+```
+
+2. Install [Homebrew](https://brew.sh):
+
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+3. Install [Cocoapods](https://cocoapods.org) using Homebrew:
+
+```sh
+brew install cocoapods
+```
+
+Next: [Create a project](/start/create-project/).
+
+## Troubleshooting
+
+If you run into any issues during installation be sure to check the [Troubleshooting Guide](/develop/debug/) or reach out on the [Tauri Discord](https://discord.com/invite/tauri).
+
+<Card title="Next Steps" icon="rocket">
+
+Now that you've installed all of the prerequisites you're ready to [create your first Tauri project](/start/create-project/)!
+
+</Card>

--- a/src/content/docs/uz/start/project-structure.mdx
+++ b/src/content/docs/uz/start/project-structure.mdx
@@ -1,0 +1,58 @@
+---
+title: Project Structure
+i18nReady: true
+---
+
+A Tauri project is usually made of 2 parts, a Rust project and a JavaScript project (optional),
+and typically the setup looks something like this:
+
+```
+.
+├── package.json
+├── index.html
+├── src/
+│   ├── main.js
+├── src-tauri/
+│   ├── Cargo.toml
+│   ├── Cargo.lock
+│   ├── build.rs
+│   ├── tauri.conf.json
+│   ├── src/
+│   │   ├── main.rs
+│   │   └── lib.rs
+│   ├── icons/
+│   │   ├── icon.png
+│   │   ├── icon.icns
+│   │   └── icon.ico
+│   └── capabilities/
+│       └── default.json
+```
+
+In this case, the JavaScript project is at the top level, and the Rust project is inside `src-tauri/`,
+the Rust project is a normal [Cargo project](https://doc.rust-lang.org/cargo/guide/project-layout.html) with some extra files:
+
+- `tauri.conf.json` is the main configuration file for Tauri, it contains everything from the application identifier to dev server url,
+  this file is also a marker for the [Tauri CLI](/reference/cli/) to find the Rust project,
+  to learn more about it, see [Tauri Config](/develop/configuration-files/#tauri-config)
+- `capabilities/` directory is the default folder Tauri reads [capability files](/security/capabilities/) from (in short, you need to allow commands here to use them in your JavaScript code),
+  to learn more about it, see [Security](/security/)
+- `icons/` directory is the default output directory of the [`tauri icon`](/reference/cli/#icon) command, it's usually referenced in `tauri.conf.json > bundle > icon` and used for the app's icons
+- `build.rs` contains `tauri_build::build()` which is used for tauri's build system
+- `src/lib.rs` contains the Rust code and the mobile entry point (the function marked with `#[cfg_attr(mobile, tauri::mobile_entry_point)]`),
+  the reason we don't write directly in `main.rs` is because we compile your app to a library in mobile builds and load them through the platform frameworks
+- `src/main.rs` is the main entry point for the desktop, and we run `app_lib::run()` in `main` to use the same entry point as mobile,
+  so to keep it simple, don't modify this file, modify `lib.rs` instead. Note that `app_lib` corresponds to `[lib.name]` in Cargo.toml.
+
+Tauri works similar to a static web host, and the way it builds is that you would compile your JavaScript project to static files first,
+and then compile the Rust project that will bundle those static files in,
+so the JavaScript project setup is basically the same as if you were to build a static website,
+to learn more, see [Frontend Configuration](/start/frontend/)
+
+If you want to work with Rust code only, simply remove everything else and use the `src-tauri/` folder as your top level project or as a member of your Rust workspace
+
+## Next Steps
+
+- [Add and Configure a Frontend Framework](/start/frontend/)
+- [Tauri Command Line Interface (CLI) Reference](/reference/cli/)
+- [Learn how to develop your Tauri app](/develop/)
+- [Discover additional features to extend Tauri](/plugin/)


### PR DESCRIPTION
Description
This PR introduces the initial Uzbek (uz) localization and fixes a navigation issue in the Hero component.

1. Uzbek Localization (i18n):

Added uz locale to locales.json.

Created Uzbek version of the landing page (src/content/docs/uz/index.mdx).

Added RSS feed page for Uzbek locale (src/content/docs/uz/rss.mdx).

2. Navigation Fix:

Fixed the "Get Started" button in Hero.astro. Previously, it was hardcoded to /start/, which redirected localized users back to the English docs.

The button now dynamically resolves the href based on the current Astro.url.pathname, ensuring users stay within their selected language (e.g., /uz/ -> /uz/start/).

Verified this fix across other locales (Spanish, Korean) to ensure it's a universal solution.