### PR TITLE
docs: mention ad-hoc signing in GitHub workflows

### DIFF
--- a/src/content/docs/distribute/Pipelines/github.mdx
+++ b/src/content/docs/distribute/Pipelines/github.mdx
@@ -14,6 +14,10 @@ To set up code signing for Windows and macOS in your workflow, follow the specif
 - [Windows Code Signing](/distribute/sign/windows/)
 - [macOS Code Signing](/distribute/sign/macos/)
 
+If you build a macOS app without an Apple signing certificate, configure an
+[ad-hoc signing identity](/distribute/sign/macos/#ad-hoc-signing). This can avoid
+macOS treating Apple Silicon builds downloaded from GitHub releases as damaged.
+
 :::
 
 ## Getting Started


### PR DESCRIPTION
## Summary

- add a note to the GitHub Actions pipeline guide for macOS builds without an Apple signing certificate
- link to the existing ad-hoc signing section so users can configure `signingIdentity: "-"`
- mention the Apple Silicon "damaged" app symptom described in tauri-apps/tauri#8763

## Validation

- `git diff --check`
- confirmed the target anchor exists in `src/content/docs/distribute/Sign/macos.mdx`
- checked no open tauri-docs PR mentions this issue/ad-hoc signing guidance

Refs tauri-apps/tauri#8763
