### PR TITLE
Fix: update window-customization guide to use objc2_app_kit over cocoa

### DIFF
--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -284,19 +284,19 @@ Create the main window and change its background color:
 
     			// set background color only when building for macOS
     			#[cfg(target_os = "macos")]
-          {
-              use objc2_app_kit::{NSColor, NSWindow};
+				{
+					use objc2_app_kit::{NSColor, NSWindow};
 
-              let ns_window_ptr = window.ns_window().unwrap() as *mut NSWindow;
-              let ns_window = unsafe { &*ns_window_ptr };
-              let bg_color = NSColor::colorWithRed_green_blue_alpha(
-                  50.0 / 255.0,
-                  158.0 / 255.0,
-                  163.5 / 255.0,
-                  1.0,
-              );
-              ns_window.setBackgroundColor(Some(&bg_color));
-          }
+					let ns_window_ptr = window.ns_window().unwrap() as *mut NSWindow;
+					let ns_window = unsafe { &*ns_window_ptr };
+					let bg_color = NSColor::colorWithRed_green_blue_alpha(
+						50.0 / 255.0,
+						158.0 / 255.0,
+						163.5 / 255.0,
+						1.0,
+					);
+					ns_window.setBackgroundColor(Some(&bg_color));
+				}
 
     			Ok(())
     		})

--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -260,7 +260,7 @@ Add `cocoa` crate to dependencies so that we can use it to call the macOS native
 
     ```toml title="src-tauri/Cargo.toml"
     [target."cfg(target_os = \"macos\")".dependencies]
-    cocoa = "0.26"
+    objc2-app-kit = { version = "0.3.2", features = ["NSColor", "NSWindow", "objc2-core-foundation"] }
     ```
 
 Create the main window and change its background color:
@@ -284,22 +284,19 @@ Create the main window and change its background color:
 
     			// set background color only when building for macOS
     			#[cfg(target_os = "macos")]
-    			{
-    				use cocoa::appkit::{NSColor, NSWindow};
-    				use cocoa::base::{id, nil};
+          {
+              use objc2_app_kit::{NSColor, NSWindow};
 
-    				let ns_window = window.ns_window().unwrap() as id;
-    				unsafe {
-    					let bg_color = NSColor::colorWithRed_green_blue_alpha_(
-    							nil,
-    							50.0 / 255.0,
-    							158.0 / 255.0,
-    							163.5 / 255.0,
-    							1.0,
-    					);
-    					ns_window.setBackgroundColor_(bg_color);
-    				}
-    			}
+              let ns_window_ptr = window.ns_window().unwrap() as *mut NSWindow;
+              let ns_window = unsafe { &*ns_window_ptr };
+              let bg_color = NSColor::colorWithRed_green_blue_alpha(
+                  50.0 / 255.0,
+                  158.0 / 255.0,
+                  163.5 / 255.0,
+                  1.0,
+              );
+              ns_window.setBackgroundColor(Some(&bg_color));
+          }
 
     			Ok(())
     		})

--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -284,19 +284,19 @@ Create the main window and change its background color:
 
     			// set background color only when building for macOS
     			#[cfg(target_os = "macos")]
-				{
-					use objc2_app_kit::{NSColor, NSWindow};
+    			{
+    				use objc2_app_kit::{NSColor, NSWindow};
 
-					let ns_window_ptr = window.ns_window().unwrap() as *mut NSWindow;
-					let ns_window = unsafe { &*ns_window_ptr };
-					let bg_color = NSColor::colorWithRed_green_blue_alpha(
-						50.0 / 255.0,
-						158.0 / 255.0,
-						163.5 / 255.0,
-						1.0,
-					);
-					ns_window.setBackgroundColor(Some(&bg_color));
-				}
+    				let ns_window_ptr = window.ns_window().unwrap() as *mut NSWindow;
+    				let ns_window = unsafe { &*ns_window_ptr };
+    				let bg_color = NSColor::colorWithRed_green_blue_alpha(
+    					50.0 / 255.0,
+    					158.0 / 255.0,
+    					163.5 / 255.0,
+    					1.0,
+    				);
+    				ns_window.setBackgroundColor(Some(&bg_color));
+    			}
 
     			Ok(())
     		})


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
cocoa crate is deprecated in favour of objc2 crate, and specifically the objc2_app_kit crate for this example. This PR updates the example to use objc2_app_kit.

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
