### PR TITLE
fix(docs): correct Next.js config filename (next.conf.mjs → next.config.mjs)

### DIFF
--- a/src/content/docs/es/start/frontend/nextjs.mdx
+++ b/src/content/docs/es/start/frontend/nextjs.mdx
@@ -94,7 +94,7 @@ Next.js es un meta framework para React. Aprende más sobre Next.js en https://n
 2.  ##### Actualiza la configuración de Next.js
 
     ```ts
-    // next.conf.mjs
+    // next.config.mjs
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';

--- a/src/content/docs/ja/start/frontend/nextjs.mdx
+++ b/src/content/docs/ja/start/frontend/nextjs.mdx
@@ -94,7 +94,7 @@ Next.js（ネクスト・ジェイエス）は React 用のメタ・フレーム
 2.  ##### Next.js の設定をアップデート
 
     ```ts
-    // next.conf.mjs
+    // next.config.mjs
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';

--- a/src/content/docs/ko/start/frontend/nextjs.mdx
+++ b/src/content/docs/ko/start/frontend/nextjs.mdx
@@ -94,7 +94,7 @@ Next.js(넥스트.js)는 React용 메타 프레임워크입니다. Next.js에 �
 2.  ##### Next.js 설정 업데이트
 
     ```ts
-    // next.conf.mjs
+    // next.config.mjs
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';

--- a/src/content/docs/start/frontend/nextjs.mdx
+++ b/src/content/docs/start/frontend/nextjs.mdx
@@ -94,7 +94,7 @@ Next.js is a meta framework for React. Learn more about Next.js at https://nextj
 2.  ##### Update Next.js configuration
 
     ```ts
-    // next.conf.mjs
+    // next.config.mjs
     const isProd = process.env.NODE_ENV === 'production';
 
     const internalHost = process.env.TAURI_DEV_HOST || 'localhost';

--- a/src/content/docs/zh-cn/start/frontend/nextjs.mdx
+++ b/src/content/docs/zh-cn/start/frontend/nextjs.mdx
@@ -86,7 +86,7 @@ Next.js 是一个基于 React 的元框架。要了解更多关于 Next.js 的�
     2.  ##### 更新 Next.js 配置
 
         ```ts
-        // next.conf.mjs
+        // next.config.mjs
         const isProd = process.env.NODE_ENV === 'production';
 
         const internalHost = process.env.TAURI_DEV_HOST || 'localhost';


### PR DESCRIPTION
## What

Fixes a typo in the Next.js frontend guide where the config filename is shown as `next.conf.mjs` instead of the correct `next.config.mjs`.

## Why

The Next.js configuration file is named `next.config.js` / `next.config.mjs`, not `next.conf.mjs`. This is just a comment in a code block, but readers copying the comment as a filename would create a file in the wrong location and Next.js would not pick it up.

## Files changed

- `src/content/docs/start/frontend/nextjs.mdx` (English source)
- `src/content/docs/es/start/frontend/nextjs.mdx` (Spanish)
- `src/content/docs/ja/start/frontend/nextjs.mdx` (Japanese)
- `src/content/docs/ko/start/frontend/nextjs.mdx` (Korean)
- `src/content/docs/zh-cn/start/frontend/nextjs.mdx` (Simplified Chinese)

## How verified

Checked the [Next.js official docs](https://nextjs.org/docs/app/api-reference/config/next-config-js) which confirms the file is `next.config.js` / `next.config.mjs`. Ran `grep` to confirm no remaining occurrences of `next.conf.mjs` in the repo.