### PR TITLE
fix(docs): correct stale config paths and commands

### DIFF
--- a/src/content/docs/develop/configuration-files.mdx
+++ b/src/content/docs/develop/configuration-files.mdx
@@ -203,7 +203,7 @@ tauri = { version = "2.0.0", features = [ ] }
 
 The most important parts to take note of are the `tauri-build` and `tauri` dependencies. Generally, they must both be on the same latest minor versions as the Tauri CLI, but this is not strictly required. If you encounter issues while trying to run your app you should check that any Tauri versions (`tauri` and `tauri-cli`) are on the latest versions for their respective minor releases.
 
-Cargo version numbers use [Semantic Versioning]. Running `cargo update` in the `src-tauri` folder will pull the latest available Semver-compatible versions of all dependencies. For example, if you specify `2.0.0` as the version for `tauri-build`, Cargo will detect and download version `2.0.0.0` because it is the latest Semver-compatible version available. Tauri will update the major version number whenever a breaking change is introduced, meaning you should always be capable of safely upgrading to the latest minor and patch versions without fear of your code breaking.
+Cargo version numbers use [Semantic Versioning]. Running `cargo update` in the `src-tauri` folder will pull the latest available Semver-compatible versions of all dependencies. For example, if you specify `2.0.0` as the version for `tauri-build`, Cargo will detect and download version `2.0.1` because it is the latest Semver-compatible version available. Tauri will update the major version number whenever a breaking change is introduced, meaning you should always be capable of safely upgrading to the latest minor and patch versions without fear of your code breaking.
 
 If you want to use a specific crate version you can use exact versions instead by prepending `=` to the version number of the dependency:
 
@@ -231,8 +231,8 @@ An example of a barebones `package.json` file for a Tauri project might look a l
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.0.0.0",
-    "@tauri-apps/cli": "^2.0.0.0"
+    "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/cli": "^2.0.0"
   }
 }
 ```

--- a/src/content/docs/develop/sidecar.mdx
+++ b/src/content/docs/develop/sidecar.mdx
@@ -7,7 +7,7 @@ You may need to embed external binaries to add additional functionality to your 
 
 Binaries are executables written in any programming language. Common use cases are Python CLI applications or API servers bundled using `pyinstaller`.
 
-To bundle the binaries of your choice, you can add the `externalBin` property to the `tauri > bundle` object in your `tauri.conf.json`.
+To bundle the binaries of your choice, you can add the `externalBin` property to the `bundle` object in your `tauri.conf.json`.
 The `externalBin` configuration expects a list of strings targeting binaries either with absolute or relative paths.
 
 Here is a Tauri configuration snippet to illustrate a sidecar configuration:

--- a/src/content/docs/plugin/deep-linking.mdx
+++ b/src/content/docs/plugin/deep-linking.mdx
@@ -142,7 +142,7 @@ The `.well-known/apple-app-site-association` endpoint must be served over HTTPS.
 To test localhost you can either use a self-signed TLS certificate and install it on the iOS simulator or use services like [ngrok].
 :::
 
-Where `$DEVELOPMENT_TEAM_ID` is the value defined on `tauri.conf.json > tauri > bundle > iOS > developmentTeam` or the
+Where `$DEVELOPMENT_TEAM_ID` is the value defined on `tauri.conf.json > bundle > iOS > developmentTeam` or the
 `TAURI_APPLE_DEVELOPMENT_TEAM` environment variable and `$APP_BUNDLE_ID` is the value defined on [`tauri.conf.json > identifier`].
 
 To verify if your domain has been properly configured to expose the app associations, you can run the following command,

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -65,7 +65,7 @@ Install the notifications plugin to get started.
                 npm="npm install @tauri-apps/plugin-notification"
                 yarn="yarn add @tauri-apps/plugin-notification"
                 pnpm="pnpm add @tauri-apps/plugin-notification"
-                deno="bun add npm:@tauri-apps/plugin-notification"
+                deno="deno add npm:@tauri-apps/plugin-notification"
                 bun="bun add @tauri-apps/plugin-notification"
             />
 

--- a/src/content/docs/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/start/migrate/from-tauri-1.mdx
@@ -52,7 +52,7 @@ fn main() {
 
 :::danger
 
-This command is not a substitude for this guide! Please read the _whole_ page regardless of whether you chose to use the command.
+This command is not a substitute for this guide! Please read the _whole_ page regardless of whether you chose to use the command.
 
 :::
 
@@ -400,7 +400,7 @@ tauri::Builder::default()
 
 ### Migrate to File System Plugin
 
-The Rust `App::get_cli_matches` JavaScript `@tauri-apps/api/fs` APIs have been removed. Use the [`std::fs`](https://doc.rust-lang.org/std/fs/) for Rust and `@tauri-apps/plugin-fs` plugin for JavaScript instead:
+The Rust `tauri::api::file` and JavaScript `@tauri-apps/api/fs` APIs have been removed. Use [`std::fs`](https://doc.rust-lang.org/std/fs/) for Rust and the `@tauri-apps/plugin-fs` plugin for JavaScript instead:
 
 1. Add to cargo dependencies:
 


### PR DESCRIPTION
Fixes #3875

## Summary
- fix the notification plugin Deno install command
- correct invalid `2.0.0.0` package examples to valid semver examples
- update stale v1 `tauri > bundle` config path references to the v2 top-level `bundle` path
- correct the file-system migration API name
- fix a small `substitude` typo

## Checks
- `git diff --check`
- `pnpm exec prettier -c --plugin prettier-plugin-astro src/content/docs/develop/configuration-files.mdx src/content/docs/develop/sidecar.mdx src/content/docs/plugin/deep-linking.mdx src/content/docs/plugin/notification.mdx src/content/docs/start/migrate/from-tauri-1.mdx`
- `pnpm dev:setup`
- `pnpm build:astro` was attempted; static page generation completed, then the final link validator failed on existing unrelated invalid links in the current docs tree
