### PR TITLE
Update the 3 outdated JA Text files in /start/frontend/ section

### DIFF
--- a/src/content/docs/ja/start/frontend/leptos.mdx
+++ b/src/content/docs/ja/start/frontend/leptos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Leptos
+i18nReady: true
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 5
@@ -7,13 +8,14 @@ tableOfContents:
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import CommandTabs from '@components/CommandTabs.astro';
+import TranslationNote from '@components/i18n/TranslationNote.astro';
 
 Leptos（レプトス）は、Rustを基盤としたウェブ・フレームワークです。より詳しい Leptos の説明は、[公式ウェブサイト【英語版】](https://leptos.dev/) をご覧ください。以下の説明内容は、「Leptos バージョン 0.6」に準拠しています。　
 
 ## チェック項目
 
 - 「SSG（静的サイト生成）」を使用してください。Tauri は公式にはサーバー・ベースの方式には対応していません。
-- `serve.ws_protocol = "ws"` を使用してください。モバイル開発で、ホットリロード用の WebSocket が適切に接続されるようになります。
+- `serve.ws_protocol = "ws"` を使用してください。モバイル開発で、ホット・リロード用の WebSocket が適切に接続されるようになります。
 - `withGlobalTauri` を有効化してください。Tauri API が `window.__TAURI__` 変数内で利用できるようになり、`wasm-bindgen` を使用してインポート可能になります。
 
 ## 設定例
@@ -57,7 +59,5 @@ Leptos（レプトス）は、Rustを基盤としたウェブ・フレームワ�
 </Steps>
 
 <div style="text-align: right;">
-  【※ この日本語版は、「Oct 01, 2024 英語版」に基づいています】
-  <br />
-  Doc-JP 2.00.00
+  【※ この日本語版は、「Feb 22, 2025 英語版」に基づいています】
 </div>

--- a/src/content/docs/ja/start/frontend/nextjs.mdx
+++ b/src/content/docs/ja/start/frontend/nextjs.mdx
@@ -9,13 +9,14 @@ tableOfContents:
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import CommandTabs from '@components/CommandTabs.astro';
+import TranslationNote from '@components/i18n/TranslationNote.astro';
 
-Next.js（ネクスト・ジェイエス）は React 用のメタ・フレームワークです。Next.js の詳細については、https://nextjs.org ををご覧ください。以下の説明内容は、「Next.js 14.2.3 バージョン」に準拠しています。
+Next.js（ネクスト・ジェイエス）は React 用のメタ・フレームワークです。Next.js の詳細については、https://nextjs.org をご覧ください。以下の説明内容は、「Next.js 14.2.3 バージョン」に準拠しています。
 
 ## チェック項目
 
 - `output: 'export'` を設定して「静的エクスポート」を使用してください。Tauri はサーバー・ベースの方式には対応していません。
-- `tauri.conf.json` の `frontendDist` に「`out`」ディレクトリを使用してください。
+- `tauri.conf.json` では「`out`」ディレクトリを `frontendDist` として使用してください。
 
 ## 設定例
 
@@ -131,7 +132,5 @@ Next.js（ネクスト・ジェイエス）は React 用のメタ・フレーム
 </Steps>
 
 <div style="text-align: right;">
-  【※ この日本語版は、「Nov 01, 2024 英語版」に基づいています】
-  <br />
-  Doc-JP 2.00.00
+  【※ この日本語版は、「May 29, 2026 英語版」に基づいています】
 </div>

--- a/src/content/docs/ja/start/frontend/nuxt.mdx
+++ b/src/content/docs/ja/start/frontend/nuxt.mdx
@@ -7,16 +7,16 @@ tableOfContents:
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import TranslationNote from '@components/i18n/TranslationNote.astro';
 
-Nuxt（ナクスト）は Vue 用のメタ・フレームワークです。Nuxt の詳細については、https://nuxt.com をご覧ください。以下の説明内容は、「Nuxt 3.11. バージョン」に準拠しています。
+Nuxt（ナクスト）は Vue 用のメタ・フレームワークです。Nuxt の詳細については、https://nuxt.com をご覧ください。以下の説明内容は、「Nuxt 4.2 バージョン」に準拠しています。
 
 ## チェック項目
 
-- `ssr: false` を設定して SSG を使用してください。Tauri はサーバー・ベースの方式には対応していません。
-- iOS の物理デバイス上で動作するように設定されている場合、開発サーバーのホスト IP に `process.env.TAURI_DEV_HOST` を使用してください。
-- `tauri.conf.json` では `frontendDist` として `dist/` を指定します。
-- `nuxi generate` を使用してコンパイルします。
-- （任意設定項目） `nuxt.config.ts` で `telemetry: false` と設定して、テレメトリを無効にします。
+- `ssr: false` を設定（サーバー・サイド・レンダリングをオフ）して SSG（静的サイト生成）を使用してください。Tauri はサーバー・ベースの方式には対応していません。
+- `tauri.conf.json` では `dist/` を `frontendDist` として指定します。
+- `nuxi build` を使用してコンパイルします。
+- （任意設定項目） `nuxt.config.ts` 内のテレメトリ設定をオフに設定（ `telemetry: false`）して、テレメトリを無効にします。
 
 ## 設定例
 
@@ -93,12 +93,15 @@ Nuxt（ナクスト）は Vue 用のメタ・フレームワークです。Nuxt 
 
     ```ts
     export default defineNuxtConfig({
+      compatibilityDate: '2025-05-15',
       //（任意）「Nuxt devtools」を有効化します
       devtools: { enabled: true },
-      //「SSG」を有効化します
+      //「SSG（静的サイト生成）」を有効化します
       ssr: false,
-      // iOS の物理デバイス上で動作しているときに他のデバイスから開発サーバーを検出可能にします
-      devServer: { host: process.env.TAURI_DEV_HOST || 'localhost' },
+      // 開発サーバーを有効化し、iOS の物理デバイス上で動作しているときに他のデバイスから検出可能にします
+      devServer: {
+        host: '0',
+      },
       vite: {
         // Tauri CLI 出力のサポート強化
         clearScreen: false,
@@ -111,13 +114,13 @@ Nuxt（ナクスト）は Vue 用のメタ・フレームワークです。Nuxt 
           strictPort: true,
         },
       },
+      // [unhandledRejection] EMFILE エラー（開いているファイルが多すぎます）を回避し、監視します
+      ignore: ['**/src-tauri/**'],
     });
     ```
 
 </Steps>
 
 <div style="text-align: right;">
-  【※ この日本語版は、「Nov 01, 2024 英語版」に基づいています】
-  <br />
-  Doc-JP 2.00.00
+  【※ この日本語版は、「Dec 16, 2025 英語版」に基づいています】
 </div>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
"i18n(ja): Update 3 outdated files in START/FRONTEND/ section" -->
- Leptos.mdx file: Update according to PR#3177 (Addition of "i18nReady: true");
- Nextjs.mdx file: Correction on typo errors and JA text rephrasing for readability;
- Nuxt.mdx file: Update according to PR#3656;
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
