### PR TITLE
Fix window-customization guide permissions

### DIFF
--- a/src/content/docs/ja/learn/window-customization.mdx
+++ b/src/content/docs/ja/learn/window-customization.mdx
@@ -75,14 +75,14 @@ macOS では、カスタム・タイトルバーを使用すると、[ウィン�
 }
 ```
 
-| Permission                                   | Description                                                                |
-| -------------------------------------------- | -------------------------------------------------------------------------- |
-| `core:window:default`                        | plugin 用デフォルト・アクセス権。                                          |
-| `core:window:allow-close`                    | スコープ（適用範囲）の事前設定なしで close コマンドを有効にします。        |
-| `core:window:allow-minimize`                 | スコープの事前設定なしで minimize コマンドを有効にします。                 |
-| `core:window:allow-start-dragging`           | スコープの事前設定なしで start_dragging コマンドを有効にします。           |
-| `core:window:allow-toggle-maximize`          | スコープの事前設定なしで toggle_maximize コマンドを有効にします。          |
-| `core:window:allow-internal-toggle-maximize` | スコープの事前設定なしで internal_toggle_maximize コマンドを有効にします。 |
+| Permission                                   | Description                                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `core:window:default`                        | plugin 用デフォルト・アクセス権。This includes `core:window:allow-internal-toggle-maximize`. |
+| `core:window:allow-close`                    | スコープ（適用範囲）の事前設定なしで close コマンドを有効にします。                          |
+| `core:window:allow-minimize`                 | スコープの事前設定なしで minimize コマンドを有効にします。                                   |
+| `core:window:allow-start-dragging`           | スコープの事前設定なしで start_dragging コマンドを有効にします。                             |
+| `core:window:allow-toggle-maximize`          | スコープの事前設定なしで toggle_maximize コマンドを有効にします。                            |
+| `core:window:allow-internal-toggle-maximize` | スコープの事前設定なしで internal_toggle_maximize コマンドを有効にします。                   |
 
 #### CSS
 

--- a/src/content/docs/ja/learn/window-customization.mdx
+++ b/src/content/docs/ja/learn/window-customization.mdx
@@ -59,24 +59,30 @@ macOS では、カスタム・タイトルバーを使用すると、[ウィン�
 
 詳細については「[セキュリティ・レベルの概要](/ja/security/capabilities/)」の章を参照してください。また、プラグイン権限を使用するには「[プラグイン・アクセス権の使用](/ja/learn/security/using-plugin-permissions/)」の章を参照してください。
 
-```json title="src-tauri/capabilities/default.json" ins={6}
+```json title="src-tauri/capabilities/default.json" ins={7,11}
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:window:default", "core:window:allow-start-dragging"]
+  "permissions": [
+    "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging"
+  ]
 }
 ```
 
-| Permission                                   | Description                                                                      |
-| -------------------------------------------- | -------------------------------------------------------------------------------- |
-| `core:window:default`                        | plugin 用デフォルト・アクセス権。ただし、 `window:allow-start-dragging` を除く。 |
-| `core:window:allow-close`                    | スコープ（適用範囲）の事前設定なしで close コマンドを有効にします。              |
-| `core:window:allow-minimize`                 | スコープの事前設定なしで minimize コマンドを有効にします。                       |
-| `core:window:allow-start-dragging`           | スコープの事前設定なしで start_dragging コマンドを有効にします。                 |
-| `core:window:allow-toggle-maximize`          | スコープの事前設定なしで toggle_maximize コマンドを有効にします。                |
-| `core:window:allow-internal-toggle-maximize` | スコープの事前設定なしで internal_toggle_maximize コマンドを有効にします。       |
+| Permission                                   | Description                                                                |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `core:window:default`                        | plugin 用デフォルト・アクセス権。                                          |
+| `core:window:allow-close`                    | スコープ（適用範囲）の事前設定なしで close コマンドを有効にします。        |
+| `core:window:allow-minimize`                 | スコープの事前設定なしで minimize コマンドを有効にします。                 |
+| `core:window:allow-start-dragging`           | スコープの事前設定なしで start_dragging コマンドを有効にします。           |
+| `core:window:allow-toggle-maximize`          | スコープの事前設定なしで toggle_maximize コマンドを有効にします。          |
+| `core:window:allow-internal-toggle-maximize` | スコープの事前設定なしで internal_toggle_maximize コマンドを有効にします。 |
 
 #### CSS
 

--- a/src/content/docs/learn/window-customization.mdx
+++ b/src/content/docs/learn/window-customization.mdx
@@ -57,24 +57,30 @@ By default, all plugin commands are blocked and cannot be accessed. You must def
 
 See the [Capabilities Overview](/security/capabilities/) for more information and the [step by step guide](/learn/security/using-plugin-permissions/) to use plugin permissions.
 
-```json title="src-tauri/capabilities/default.json" ins={6}
+```json title="src-tauri/capabilities/default.json" ins={7,11}
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:window:default", "core:window:allow-start-dragging"]
+  "permissions": [
+    "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging"
+  ]
 }
 ```
 
-| Permission                                   | Description                                                                    |
-| -------------------------------------------- | ------------------------------------------------------------------------------ |
-| `core:window:default`                        | Default permissions for the plugin. Except `window:allow-start-dragging`.      |
-| `core:window:allow-close`                    | Enables the close command without any pre-configured scope.                    |
-| `core:window:allow-minimize`                 | Enables the minimize command without any pre-configured scope.                 |
-| `core:window:allow-start-dragging`           | Enables the start_dragging command without any pre-configured scope.           |
-| `core:window:allow-toggle-maximize`          | Enables the toggle_maximize command without any pre-configured scope.          |
-| `core:window:allow-internal-toggle-maximize` | Enables the internal_toggle_maximize command without any pre-configured scope. |
+| Permission                                   | Description                                                                                     |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `core:window:default`                        | Default permissions for the plugin. This includes `core:window:allow-internal-toggle-maximize`. |
+| `core:window:allow-close`                    | Enables the close command without any pre-configured scope.                                     |
+| `core:window:allow-minimize`                 | Enables the minimize command without any pre-configured scope.                                  |
+| `core:window:allow-start-dragging`           | Enables the start_dragging command without any pre-configured scope.                            |
+| `core:window:allow-toggle-maximize`          | Enables the toggle_maximize command without any pre-configured scope.                           |
+| `core:window:allow-internal-toggle-maximize` | Enables the internal_toggle_maximize command without any pre-configured scope.                  |
 
 #### CSS
 

--- a/src/content/docs/zh-cn/learn/window-customization.mdx
+++ b/src/content/docs/zh-cn/learn/window-customization.mdx
@@ -55,19 +55,25 @@ Tauri 提供了许多自定义应用程序窗口外观的选项。您可以创�
 
 更多信息请参见[访问控制列表](/zh-cn/reference/acl/)。
 
-```json title="src-tauri/capabilities/default.json" ins={6}
+```json title="src-tauri/capabilities/default.json" ins={7,11}
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:window:default", "core:window:allow-start-dragging"]
+  "permissions": [
+    "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging"
+  ]
 }
 ```
 
 | 权限                                    | 描述                                                               |
 | --------------------------------------- | ------------------------------------------------------------------ |
-| `window:default`                        | 插件的默认权限。除了 `window:allow-start-dragging`。               |
+| `window:default`                        | 插件的默认权限。包含 `window:allow-internal-toggle-maximize`。     |
 | `window:allow-close`                    | 在没有预先配置作用域的情况下，启用 close 命令。                    |
 | `window:allow-minimize`                 | 在没有预先配置作用域的情况下，启用 minimize 命令。                 |
 | `window:allow-start-dragging`           | 在没有预先配置作用域的情况下，启用 start_dragging 命令。           |


### PR DESCRIPTION
`core:window:default` does not include `core:window:allow-close` and the a few other permissions, maybe it's just outdated or maybe it has always been wrong