### PR TITLE
Make theme select icon slightly bigger

### DIFF
--- a/src/components/overrides/ThemeSelect.astro
+++ b/src/components/overrides/ThemeSelect.astro
@@ -30,8 +30,8 @@ import { Icon } from '@astrojs/starlight/components';
 </script>
 
 <theme-switcher class="sl-flex">
-  <Icon name="sun" class="theme-selector-light" />
-  <Icon name="moon" class="theme-selector-dark" />
+  <Icon name="sun" class="theme-selector-light" size="1.2em" />
+  <Icon name="moon" class="theme-selector-dark" size="1.2em" />
 </theme-switcher>
 
 <style>


### PR DESCRIPTION
This makes it visually the same as the rest of icons