### PR TITLE
docs(tests): update docs to use @wdio/tauri-service for WebdriverIO testing

### DIFF
--- a/src/content/docs/develop/Tests/WebDriver/Example/selenium.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/Example/selenium.mdx
@@ -241,7 +241,7 @@ tests!
 With [Selenium] and some hooking up to a test suite, we just enabled e2e testing without modifying our Tauri
 application at all!
 
-[prerequisites instructions]: /develop/tests/webdriver/
+[prerequisites instructions]: /develop/tests/webdriver/manual-setup/
 [selenium]: https://selenium.dev/
 [finished example project]: https://github.com/tauri-apps/webdriver-example
 [mocha]: https://mochajs.org/

--- a/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
@@ -13,6 +13,15 @@ Make sure to go through the [prerequisites instructions] to be able to follow th
 
 :::
 
+:::tip[Recommended: the WebdriverIO Tauri service]
+
+This guide wires [WebdriverIO] up to [`tauri-driver`] by hand so you can see how the pieces fit together. For most
+projects the [`@wdio/tauri-service`] is the easier path: it manages [`tauri-driver`], detects your app binary, keeps
+the Edge WebDriver in sync on Windows, and adds macOS support, Tauri API access, mocking, and more. See the
+[WebdriverIO Tauri documentation] to get started in a couple of commands.
+
+:::
+
 This WebDriver testing example will use [WebdriverIO], and its testing suite. It is expected to have Node.js already
 installed, along with `npm` or `yarn` although the [finished example project] uses `pnpm`.
 
@@ -274,6 +283,9 @@ of configuration and a single command to run it! Even better, we didn't have to 
 
 [prerequisites instructions]: /develop/tests/webdriver/
 [webdriverio]: https://webdriver.io/
+[`tauri-driver`]: https://crates.io/crates/tauri-driver
+[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
+[webdriverio tauri documentation]: https://webdriver.io/docs/desktop-testing/tauri
 [finished example project]: https://github.com/tauri-apps/webdriver-example
 [mocha]: https://mochajs.org/
 [webdriver documentation]: https://webdriver.io/docs/configurationfile

--- a/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx
@@ -13,12 +13,11 @@ Make sure to go through the [prerequisites instructions] to be able to follow th
 
 :::
 
-:::tip[Recommended: the WebdriverIO Tauri service]
+:::tip[Using the WebdriverIO Tauri service?]
 
-This guide wires [WebdriverIO] up to [`tauri-driver`] by hand so you can see how the pieces fit together. For most
-projects the [`@wdio/tauri-service`] is the easier path: it manages [`tauri-driver`], detects your app binary, keeps
-the Edge WebDriver in sync on Windows, and adds macOS support, Tauri API access, mocking, and more. See the
-[WebdriverIO Tauri documentation] to get started in a couple of commands.
+This guide wires [WebdriverIO] up to [`tauri-driver`] by hand so you can see how the pieces fit together. Most projects
+should use the [`@wdio/tauri-service`] instead, which automates all of this and supports macOS — see the
+[WebDriver overview].
 
 :::
 
@@ -281,11 +280,11 @@ We see the Spec Reporter tell us that all 3 tests from the `test/specs/example.e
 Using the [WebdriverIO] test suite, we just easily enabled e2e testing for our Tauri application from just a few lines
 of configuration and a single command to run it! Even better, we didn't have to modify the application at all.
 
-[prerequisites instructions]: /develop/tests/webdriver/
+[prerequisites instructions]: /develop/tests/webdriver/manual-setup/
+[webdriver overview]: /develop/tests/webdriver/
 [webdriverio]: https://webdriver.io/
 [`tauri-driver`]: https://crates.io/crates/tauri-driver
 [`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
-[webdriverio tauri documentation]: https://webdriver.io/docs/desktop-testing/tauri
 [finished example project]: https://github.com/tauri-apps/webdriver-example
 [mocha]: https://mochajs.org/
 [webdriver documentation]: https://webdriver.io/docs/configurationfile

--- a/src/content/docs/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/index.mdx
@@ -9,19 +9,16 @@ i18nReady: true
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-[WebDriver] is a standardized interface to interact with web documents primarily intended for automated testing.
-Tauri supports the [WebDriver] interface by leveraging the native platform's [WebDriver] server underneath a
-cross-platform wrapper [`tauri-driver`]. When driving `tauri-driver` directly, only Windows and Linux are supported
-on desktop, as macOS has no WKWebView driver tool available. iOS and Android work through Appium 2, but the process
-is not currently streamlined.
+[WebDriver] is a standardized interface to interact with web documents, primarily intended for automated testing. The
+recommended way to use it with Tauri is [WebdriverIO] and the [`@wdio/tauri-service`], which works on **Windows, Linux,
+and macOS**. Maintained under the WebdriverIO project, it provides Tauri API access through `browser.tauri.execute()`,
+command (IPC) mocking, frontend and backend log capture, and multiremote.
 
-## Recommended: the WebdriverIO Tauri service
-
-If you are testing with [WebdriverIO], the [`@wdio/tauri-service`] is the recommended way to test Tauri apps.
-Maintained under the WebdriverIO project, it automates the setup described on this page — installing and managing
-[`tauri-driver`], detecting your application binary, and keeping the Edge WebDriver in sync on Windows — and, unlike
-driving `tauri-driver` directly, it can also test on **macOS**. It additionally provides Tauri API access through
-`browser.tauri.execute()`, command (IPC) mocking, frontend and backend log capture, and multiremote.
+By default the service runs an **embedded WebDriver server** inside your app, so no external driver is needed on any
+platform — and this is how macOS is supported. It can also drive the platform's native WebDriver through [`tauri-driver`]
+on Windows and Linux, or [CrabNebula]'s cross-platform fork of `tauri-driver` on all platforms (a paid API key is
+required for macOS). Whichever route you choose, the service detects your application binary, and on the `tauri-driver`
+route it keeps the Edge WebDriver in sync on Windows for you.
 
 The quickest way to scaffold a project is the WebdriverIO starter:
 
@@ -45,12 +42,9 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-These capabilities come from two small Tauri plugins you add to your app. `tauri-plugin-wdio` is required for backend
-access — `browser.tauri.execute()`, command mocking, and log capture — and `tauri-plugin-wdio-webdriver` is required to
-run the `embedded` driver provider, which serves WebDriver from inside your app instead of using an external driver and
-is how macOS is supported without a third-party service. Alternatively, the `crabnebula` provider drives [CrabNebula]'s
-fork of `tauri-driver`, which also covers macOS but needs a paid API key for it (Windows and Linux need none). See
-[Plugin Setup] and the [CrabNebula setup guide] for details.
+These capabilities come from two small Tauri plugins you add to your app: `tauri-plugin-wdio` for backend access
+(`browser.tauri.execute()`, command mocking, and log capture), and `tauri-plugin-wdio-webdriver` to run the embedded
+WebDriver server. See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider.
 
 For fast, renderer-only tests there is also a **browser mode** that runs your Tauri frontend in plain Chrome against a
 Vite dev server — no Tauri binary, driver, or plugin required. It intercepts `invoke()` calls so you can mock commands
@@ -62,69 +56,30 @@ and assert on their arguments with the same WDIO API. See the [browser mode guid
   href="https://webdriver.io/docs/desktop-testing/tauri"
 />
 
-The rest of this page documents the lower-level [`tauri-driver`] setup the service builds on. Reach for it directly if
-you are not using Node.js, prefer [Selenium], or are integrating WebDriver into a custom test harness.
-
-## System Dependencies
-
-Install the latest [`tauri-driver`] or update an existing installation by running:
-
-```shell
-cargo install tauri-driver --locked
-```
-
-Because we currently utilize the platform's native [WebDriver] server, there are some requirements for running
-[`tauri-driver`] on supported platforms.
-
-### Linux
-
-We use `WebKitWebDriver` on Linux platforms. Check if this binary exists already by running the `which WebKitWebDriver` command as
-some distributions bundle it with the regular WebKit package. Other platforms may have a separate package for them, such
-as `webkit2gtk-driver` on Debian-based distributions.
-
-### Windows
-
-Make sure to grab the version of [Microsoft Edge Driver] that matches your Windows Edge version that the application is
-being built and tested on. This should almost always be the latest stable version on up-to-date Windows installs. If the
-two versions do not match, you may experience your WebDriver testing suite hanging while trying to connect.
-
-You can use the [msedgedriver-tool](https://github.com/chippers/msedgedriver-tool) to download the appropriate Microsoft Edge Driver:
-
-```powershell
-cargo install --git https://github.com/chippers/msedgedriver-tool
-& "$HOME/.cargo/bin/msedgedriver-tool.exe"
-```
-
-The download contains a binary called `msedgedriver.exe`. [`tauri-driver`] looks for that binary in the `$PATH` so make
-sure it's either available on the path or use the `--native-driver` option on [`tauri-driver`]. You may want to download this automatically as part of the CI setup process to ensure the Edge, and Edge Driver versions
-stay in sync on Windows CI machines. A guide on how to do this may be added at a later date.
-
 ## Example Applications
 
-Below are step-by-step guides to show how to create a minimal example application that
-is tested with WebDriver.
-
-If you prefer to see the result of the guide and look over a finished minimal codebase that utilizes it, you
-can look at https://github.com/tauri-apps/webdriver-example.
-
-<CardGrid>
-  <LinkCard
-    title="Selenium"
-    href="/develop/tests/webdriver/example/selenium/"
-  />
-  <LinkCard
-    title="WebdriverIO"
-    href="/develop/tests/webdriver/example/webdriverio/"
-  />
-</CardGrid>
+Complete, runnable examples that use the service live in the
+[WebdriverIO desktop-mobile repository][example fixtures].
 
 ## Continuous Integration (CI)
 
-The above examples also comes with a CI script to test with GitHub Actions, but you may still be interested in the below WebDriver CI guide as it explains the concept a bit more.
+The WebDriver CI guide explains how to run these tests under GitHub Actions and the concepts behind it.
 
 <LinkCard
   title="Continuous Integration (CI)"
   href="/develop/tests/webdriver/ci/"
+/>
+
+## Driving `tauri-driver` directly
+
+If you are not using Node.js, prefer [Selenium], or are integrating WebDriver into a custom test harness, you can drive
+[`tauri-driver`] directly instead of using the service. Driven directly, only Windows and Linux are supported on
+desktop, as macOS has no WKWebView driver tool available (use the service's embedded WebDriver server for macOS).
+
+<LinkCard
+  title="Manual WebDriver setup"
+  description="Install and drive tauri-driver yourself (Windows and Linux only)"
+  href="/develop/tests/webdriver/manual-setup/"
 />
 
 [webdriver]: https://www.w3.org/TR/webdriver/
@@ -134,7 +89,7 @@ The above examples also comes with a CI script to test with GitHub Actions, but 
 [crabnebula]: https://crabnebula.dev
 [crabnebula setup guide]: https://webdriver.io/docs/desktop-testing/tauri/crabnebula-setup
 [browser mode guide]: https://github.com/webdriverio/desktop-mobile/blob/main/packages/tauri-service/docs/browser-mode.md
+[example fixtures]: https://github.com/webdriverio/desktop-mobile/tree/main/fixtures/e2e-apps/tauri
 [selenium]: /develop/tests/webdriver/example/selenium/
 [`tauri-driver`]: https://crates.io/crates/tauri-driver
 [tauri-driver]: https://crates.io/crates/tauri-driver
-[microsoft edge driver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/

--- a/src/content/docs/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/index.mdx
@@ -7,10 +7,63 @@ sidebar:
 i18nReady: true
 ---
 
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
 [WebDriver] is a standardized interface to interact with web documents primarily intended for automated testing.
 Tauri supports the [WebDriver] interface by leveraging the native platform's [WebDriver] server underneath a
-cross-platform wrapper [`tauri-driver`]. On desktop, only Windows and Linux are supported due to macOS not having
-a WKWebView driver tool available. iOS and Android work through Appium 2, but the process is not currently streamlined.
+cross-platform wrapper [`tauri-driver`]. When driving `tauri-driver` directly, only Windows and Linux are supported
+on desktop, as macOS has no WKWebView driver tool available. iOS and Android work through Appium 2, but the process
+is not currently streamlined.
+
+## Recommended: the WebdriverIO Tauri service
+
+If you are testing with [WebdriverIO], the [`@wdio/tauri-service`] is the recommended way to test Tauri apps.
+Maintained under the WebdriverIO project, it automates the setup described on this page — installing and managing
+[`tauri-driver`], detecting your application binary, and keeping the Edge WebDriver in sync on Windows — and, unlike
+driving `tauri-driver` directly, it can also test on **macOS**. It additionally provides Tauri API access through
+`browser.tauri.execute()`, command (IPC) mocking, frontend and backend log capture, and multiremote.
+
+The quickest way to scaffold a project is the WebdriverIO starter:
+
+```shell
+npm create wdio@latest ./
+```
+
+Pick **Desktop Testing** and choose **Tauri** at the framework prompt. A minimal configuration looks like this:
+
+```typescript
+export const config: WebdriverIO.Config = {
+  services: [
+    [
+      'tauri',
+      {
+        appBinaryPath: './src-tauri/target/release/my-tauri-app',
+        driverProvider: 'embedded',
+      },
+    ],
+  ],
+};
+```
+
+These capabilities come from two small Tauri plugins you add to your app. `tauri-plugin-wdio` is required for backend
+access — `browser.tauri.execute()`, command mocking, and log capture — and `tauri-plugin-wdio-webdriver` is required to
+run the `embedded` driver provider, which serves WebDriver from inside your app instead of using an external driver and
+is how macOS is supported without a third-party service. Alternatively, the `crabnebula` provider drives [CrabNebula]'s
+fork of `tauri-driver`, which also covers macOS but needs a paid API key for it (Windows and Linux need none). See
+[Plugin Setup] and the [CrabNebula setup guide] for details.
+
+For fast, renderer-only tests there is also a **browser mode** that runs your Tauri frontend in plain Chrome against a
+Vite dev server — no Tauri binary, driver, or plugin required. It intercepts `invoke()` calls so you can mock commands
+and assert on their arguments with the same WDIO API. See the [browser mode guide].
+
+<LinkCard
+  title="WebdriverIO Tauri documentation"
+  description="Full setup, configuration, and API reference for @wdio/tauri-service"
+  href="https://webdriver.io/docs/desktop-testing/tauri"
+/>
+
+The rest of this page documents the lower-level [`tauri-driver`] setup the service builds on. Reach for it directly if
+you are not using Node.js, prefer [Selenium], or are integrating WebDriver into a custom test harness.
 
 ## System Dependencies
 
@@ -54,8 +107,6 @@ is tested with WebDriver.
 If you prefer to see the result of the guide and look over a finished minimal codebase that utilizes it, you
 can look at https://github.com/tauri-apps/webdriver-example.
 
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
-
 <CardGrid>
   <LinkCard
     title="Selenium"
@@ -77,6 +128,13 @@ The above examples also comes with a CI script to test with GitHub Actions, but 
 />
 
 [webdriver]: https://www.w3.org/TR/webdriver/
+[webdriverio]: https://webdriver.io/
+[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
+[plugin setup]: https://webdriver.io/docs/desktop-testing/tauri/plugin-setup
+[crabnebula]: https://crabnebula.dev
+[crabnebula setup guide]: https://webdriver.io/docs/desktop-testing/tauri/crabnebula-setup
+[browser mode guide]: https://github.com/webdriverio/desktop-mobile/blob/main/packages/tauri-service/docs/browser-mode.md
+[selenium]: /develop/tests/webdriver/example/selenium/
 [`tauri-driver`]: https://crates.io/crates/tauri-driver
 [tauri-driver]: https://crates.io/crates/tauri-driver
 [microsoft edge driver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/

--- a/src/content/docs/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/index.mdx
@@ -42,11 +42,15 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-Two small Tauri plugins, added to your app, make this work. `tauri-plugin-wdio` provides backend access —
-`browser.tauri.execute()`, command (IPC) mocking, and log capture. `tauri-plugin-wdio-webdriver` runs the embedded
-WebDriver server, which is what gives you macOS support without CrabNebula; it's required whenever you use the embedded
-provider (the default). See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider
-instead.
+Setting this up uses one or two small Tauri plugins, depending on what you need:
+
+- **`tauri-plugin-wdio-webdriver`** runs the embedded WebDriver server. It's required for the `embedded` provider (the
+  default) — the service drives your app through it, with no external driver, and it's how macOS is supported. You only
+  skip it if you use the `external` or `crabnebula` provider instead.
+- **`tauri-plugin-wdio`** is optional. Add it for Tauri-aware testing on top of plain WebDriver: `browser.tauri.execute()`,
+  command (IPC) mocking, and log capture.
+
+See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider.
 
 For fast, renderer-only tests there is also a **browser mode** that runs your Tauri frontend in plain Chrome against a
 Vite dev server — no Tauri binary, driver, or plugin required. It intercepts `invoke()` calls so you can mock commands

--- a/src/content/docs/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/index.mdx
@@ -42,13 +42,13 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-Setting this up uses one or two small Tauri plugins, depending on what you need:
+Setting this up uses two small Tauri plugins, both optional depending on your requirements:
 
 - **`tauri-plugin-wdio-webdriver`** runs the embedded WebDriver server. It's required for the `embedded` provider (the
-  default) — the service drives your app through it, with no external driver, and it's how macOS is supported. You only
-  skip it if you use the `external` or `crabnebula` provider instead.
-- **`tauri-plugin-wdio`** is optional. Add it for Tauri-aware testing on top of plain WebDriver: `browser.tauri.execute()`,
-  command (IPC) mocking, and log capture.
+  default) — the service drives your app through it, with no external driver, and it's how macOS is supported. You can
+  skip it if you want to use the `external` or `crabnebula` provider instead.
+- **`tauri-plugin-wdio`** enables backend access including: `browser.tauri.execute()`, command (IPC) mocking, and log
+  capture.
 
 See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider.
 

--- a/src/content/docs/develop/Tests/WebDriver/index.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/index.mdx
@@ -42,9 +42,11 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-These capabilities come from two small Tauri plugins you add to your app: `tauri-plugin-wdio` for backend access
-(`browser.tauri.execute()`, command mocking, and log capture), and `tauri-plugin-wdio-webdriver` to run the embedded
-WebDriver server. See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider.
+Two small Tauri plugins, added to your app, make this work. `tauri-plugin-wdio` provides backend access —
+`browser.tauri.execute()`, command (IPC) mocking, and log capture. `tauri-plugin-wdio-webdriver` runs the embedded
+WebDriver server, which is what gives you macOS support without CrabNebula; it's required whenever you use the embedded
+provider (the default). See [Plugin Setup] for the full steps, and the [CrabNebula setup guide] if you use that provider
+instead.
 
 For fast, renderer-only tests there is also a **browser mode** that runs your Tauri frontend in plain Chrome against a
 Vite dev server — no Tauri binary, driver, or plugin required. It intercepts `invoke()` calls so you can mock commands

--- a/src/content/docs/develop/Tests/WebDriver/manual-setup.mdx
+++ b/src/content/docs/develop/Tests/WebDriver/manual-setup.mdx
@@ -1,0 +1,87 @@
+---
+title: Manual setup
+description: Driving tauri-driver directly without the WebdriverIO Tauri service
+sidebar:
+  order: 15
+i18nReady: true
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+This page covers driving [`tauri-driver`] directly, without the [`@wdio/tauri-service`]. Reach for it if you are not
+using Node.js, prefer [Selenium], or are integrating WebDriver into a custom test harness. For most projects the service
+is the easier path — it automates everything below and additionally supports macOS. See the [WebDriver overview] to get
+started with it.
+
+When driving `tauri-driver` directly, only Windows and Linux are supported on desktop, as macOS has no WKWebView driver
+tool available. iOS and Android work through Appium 2, but the process is not currently streamlined.
+
+## System Dependencies
+
+Install the latest [`tauri-driver`] or update an existing installation by running:
+
+```shell
+cargo install tauri-driver --locked
+```
+
+Because we currently utilize the platform's native [WebDriver] server, there are some requirements for running
+[`tauri-driver`] on supported platforms.
+
+### Linux
+
+We use `WebKitWebDriver` on Linux platforms. Check if this binary exists already by running the `which WebKitWebDriver` command as
+some distributions bundle it with the regular WebKit package. Other platforms may have a separate package for them, such
+as `webkit2gtk-driver` on Debian-based distributions.
+
+### Windows
+
+Make sure to grab the version of [Microsoft Edge Driver] that matches your Windows Edge version that the application is
+being built and tested on. This should almost always be the latest stable version on up-to-date Windows installs. If the
+two versions do not match, you may experience your WebDriver testing suite hanging while trying to connect.
+
+You can use the [msedgedriver-tool](https://github.com/chippers/msedgedriver-tool) to download the appropriate Microsoft Edge Driver:
+
+```powershell
+cargo install --git https://github.com/chippers/msedgedriver-tool
+& "$HOME/.cargo/bin/msedgedriver-tool.exe"
+```
+
+The download contains a binary called `msedgedriver.exe`. [`tauri-driver`] looks for that binary in the `$PATH` so make
+sure it's either available on the path or use the `--native-driver` option on [`tauri-driver`]. You may want to download this automatically as part of the CI setup process to ensure the Edge, and Edge Driver versions
+stay in sync on Windows CI machines. A guide on how to do this may be added at a later date.
+
+## Example Applications
+
+Below are step-by-step guides to show how to create a minimal example application that
+is tested with WebDriver.
+
+If you prefer to see the result of the guide and look over a finished minimal codebase that utilizes it, you
+can look at https://github.com/tauri-apps/webdriver-example.
+
+<CardGrid>
+  <LinkCard
+    title="Selenium"
+    href="/develop/tests/webdriver/example/selenium/"
+  />
+  <LinkCard
+    title="WebdriverIO"
+    href="/develop/tests/webdriver/example/webdriverio/"
+  />
+</CardGrid>
+
+## Continuous Integration (CI)
+
+The above examples also comes with a CI script to test with GitHub Actions, but you may still be interested in the below WebDriver CI guide as it explains the concept a bit more.
+
+<LinkCard
+  title="Continuous Integration (CI)"
+  href="/develop/tests/webdriver/ci/"
+/>
+
+[webdriver]: https://www.w3.org/TR/webdriver/
+[webdriver overview]: /develop/tests/webdriver/
+[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
+[selenium]: /develop/tests/webdriver/example/selenium/
+[`tauri-driver`]: https://crates.io/crates/tauri-driver
+[tauri-driver]: https://crates.io/crates/tauri-driver
+[microsoft edge driver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/

--- a/src/content/docs/develop/Tests/index.mdx
+++ b/src/content/docs/develop/Tests/index.mdx
@@ -10,10 +10,9 @@ i18nReady: true
 Tauri offers support for both unit and integration testing utilizing a mock runtime. Under the mock runtime, native
 webview libraries are not executed. [See more about the mock runtime here].
 
-Tauri also provides support for end-to-end testing utilizing the WebDriver protocol. For [WebdriverIO] users, the
-[`@wdio/tauri-service`] is the recommended way to drive this, and it works on Windows, Linux, and macOS. The underlying
-WebDriver protocol can also be driven directly on Windows and Linux (macOS provides no desktop WebDriver client).
-[See more about WebDriver support here].
+Tauri also provides support for end-to-end testing utilizing the WebDriver protocol. [WebdriverIO Tauri testing]
+supports Windows, Linux, and macOS; the WebDriver protocol can also be driven directly on Windows and Linux, as macOS
+provides no desktop WebDriver client. [See more about WebDriver support here].
 
 We offer [tauri-action] to help run GitHub actions, but any sort of CI/CD runner can be used with Tauri as long as each
 platform has the required libraries installed to compile against.
@@ -21,5 +20,4 @@ platform has the required libraries installed to compile against.
 [See more about the mock runtime here]: /develop/tests/mocking/
 [See more about WebDriver support here]: /develop/tests/webdriver/
 [tauri-action]: https://github.com/tauri-apps/tauri-action
-[webdriverio]: https://webdriver.io/
-[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
+[webdriverio tauri testing]: https://webdriver.io/docs/desktop-testing/tauri

--- a/src/content/docs/develop/Tests/index.mdx
+++ b/src/content/docs/develop/Tests/index.mdx
@@ -10,8 +10,10 @@ i18nReady: true
 Tauri offers support for both unit and integration testing utilizing a mock runtime. Under the mock runtime, native
 webview libraries are not executed. [See more about the mock runtime here].
 
-Tauri also provides support for end-to-end testing support utilizing the WebDriver protocol. Both desktop and mobile
-work with it, except for macOS which does not provide a desktop WebDriver client. [See more about WebDriver support here].
+Tauri also provides support for end-to-end testing utilizing the WebDriver protocol. For [WebdriverIO] users, the
+[`@wdio/tauri-service`] is the recommended way to drive this, and it works on Windows, Linux, and macOS. The underlying
+WebDriver protocol can also be driven directly on Windows and Linux (macOS provides no desktop WebDriver client).
+[See more about WebDriver support here].
 
 We offer [tauri-action] to help run GitHub actions, but any sort of CI/CD runner can be used with Tauri as long as each
 platform has the required libraries installed to compile against.
@@ -19,3 +21,5 @@ platform has the required libraries installed to compile against.
 [See more about the mock runtime here]: /develop/tests/mocking/
 [See more about WebDriver support here]: /develop/tests/webdriver/
 [tauri-action]: https://github.com/tauri-apps/tauri-action
+[webdriverio]: https://webdriver.io/
+[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri

--- a/src/content/docs/develop/Tests/mocking.mdx
+++ b/src/content/docs/develop/Tests/mocking.mdx
@@ -7,15 +7,6 @@ i18nReady: true
 
 import SinceVersion from '../../../../components/SinceVersion.astro';
 
-:::note[Looking for end-to-end mocking?]
-
-This page covers **frontend mocking** with the [`@tauri-apps/api/mocks`] module, which runs under a mock runtime — your
-real webview and Rust backend are not executed. To mock Tauri commands during **end-to-end WebDriver tests**, against a
-running app or your frontend in a browser, the [`@wdio/tauri-service`] adds a Vitest-compatible `browser.tauri.mock()`
-API. See [WebDriver testing] to get started.
-
-:::
-
 When writing your frontend tests, having a "fake" Tauri environment to simulate windows or intercept IPC calls is common, so-called _mocking_.
 The [`@tauri-apps/api/mocks`] module provides some helpful tools to make this easier for you:
 
@@ -136,6 +127,14 @@ mockIPC(async (cmd, args) => {
   }
 });
 ```
+
+:::note[See also]
+
+`mockIPC` fakes `invoke` under the mock runtime — no real webview or Rust backend runs. To mock the same commands in
+**end-to-end** tests, against a running app or your frontend in a browser, [`@wdio/tauri-service`] provides an equivalent
+`browser.tauri.mock()`. See [WebDriver testing].
+
+:::
 
 ### Mocking Events
 

--- a/src/content/docs/develop/Tests/mocking.mdx
+++ b/src/content/docs/develop/Tests/mocking.mdx
@@ -7,6 +7,15 @@ i18nReady: true
 
 import SinceVersion from '../../../../components/SinceVersion.astro';
 
+:::note[Looking for end-to-end mocking?]
+
+This page covers **frontend mocking** with the [`@tauri-apps/api/mocks`] module, which runs under a mock runtime — your
+real webview and Rust backend are not executed. To mock Tauri commands during **end-to-end WebDriver tests**, against a
+running app or your frontend in a browser, the [`@wdio/tauri-service`] adds a Vitest-compatible `browser.tauri.mock()`
+API. See [WebDriver testing] to get started.
+
+:::
+
 When writing your frontend tests, having a "fake" Tauri environment to simulate windows or intercept IPC calls is common, so-called _mocking_.
 The [`@tauri-apps/api/mocks`] module provides some helpful tools to make this easier for you:
 
@@ -200,3 +209,5 @@ test('invoke', async () => {
 [`clearmocks()`]: /reference/javascript/api/namespacemocks/#clearmocks
 [vitest]: https://vitest.dev
 [Event System]: /develop/calling-frontend/#event-system
+[`@wdio/tauri-service`]: https://webdriver.io/docs/desktop-testing/tauri
+[webdriver testing]: /develop/tests/webdriver/


### PR DESCRIPTION
## What

Positions [`@wdio/tauri-service`](https://webdriver.io/docs/desktop-testing/tauri) as the recommended way to test Tauri apps with WebdriverIO, and reworks the WebDriver testing docs accordingly.

The service is maintained under the WebdriverIO project and automates the manual `tauri-driver` setup these pages currently teach — driver install/lifecycle, app-binary detection, and Edge WebDriver management on Windows — while adding **macOS** support, Tauri API access, command (IPC) mocking, log capture, and multiremote.

## Changes

- **`develop/tests/webdriver/` (overview)** — new "Recommended: the WebdriverIO Tauri service" section: the setup wizard (`npm create wdio@latest`), a minimal config, the `tauri-plugin-wdio` / `tauri-plugin-wdio-webdriver` plugin requirements, the `embedded` and `crabnebula` macOS driver providers, and browser mode. Reworded the macOS limitation so it correctly applies to driving `tauri-driver` directly, and reframed the manual guide as the lower-level setup the service builds on.
- **`develop/tests/webdriver/example/webdriverio/`** — a tip pointing readers to the service as the easier path.
- **`develop/tests/` (overview)** — names the service as the recommended WebdriverIO path.
- **`develop/tests/mocking/`** — disambiguation note: that page covers frontend mock-runtime mocking; the service provides end-to-end `browser.tauri.mock()`.

All external links were verified live.

## Context

- Implements webdriverio/desktop-mobile#30 (Tauri-side outreach / external docs).
- Companion WebdriverIO docs already merged: webdriverio/webdriverio#15235 — the `desktop-testing/tauri` pages these changes link to.

## Notes

These are `i18nReady: true` pages, so the edits will flag the translations as out of date in Lunaria tracking — expected, to be picked up by the translation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
