### PR TITLE
Adjust code block colors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -430,7 +430,19 @@ export default defineConfig({
       },
       customCss: ['./src/styles/custom.scss'],
       expressiveCode: {
-        styleOverrides: { borderRadius: '0.5rem' },
+        styleOverrides: {
+          codePaddingBlock: '1rem',
+          codePaddingInline: '1.35rem',
+          borderRadius: '0.5rem',
+          // borderWidth: '0',
+          textMarkers: {
+            borderLuminance: '66',
+            backgroundOpacity: '25%',
+          },
+          frames: {
+            editorActiveTabIndicatorHeight: '0',
+          },
+        },
       },
       locales,
       lastUpdated: true,

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -10,7 +10,7 @@
   --sl-hue-blue: 187;
   --sl-color-blue-low: hsl(var(--sl-hue-blue), 71%, 15%);
   --sl-color-blue: #24c8db;
-  --sl-color-blue-high: hsl(var(--sl-hue-blue), 71%, 90%);
+  --sl-color-blue-high: hsl(var(--sl-hue-blue), 85%, 80%);
   --sl-hue-accent: var(--sl-hue-blue);
   --sl-color-accent-low: var(--sl-color-blue-low);
   --sl-color-accent: var(--sl-color-blue);
@@ -35,6 +35,7 @@
   --sl-color-accent-high: oklch(70% 0.15 253);
 
   --sl-color-gray-2: hsl(224, 14%, 16%);
+  --sl-color-gray-5: hsl(224, 10%, 85%);
 
   // Same as the `--sl-color-accent` hue
   --sl-hue-blue: 209;


### PR DESCRIPTION
- Made dark mode theme color more saturated (addressing https://github.com/tauri-apps/tauri-docs/pull/3905#issuecomment-4763246780)
- Made code block borders slightly lighter on light mode
- Slightly increased code block paddings to match the `expressiveCode` defaults
- Reduced text markers background opacity from 50% to 25%
- Removed active tab indicator since we only ever have one tab

Before

<img width="1190" height="915" alt="image" src="https://github.com/user-attachments/assets/8ce27ab0-b74e-4bd3-98ed-498776a183de" />

After

<img width="1187" height="931" alt="image" src="https://github.com/user-attachments/assets/8576b29f-a577-4b90-98fa-193c46b467b0" />

---

Before

<img width="2560" height="1217" alt="image" src="https://github.com/user-attachments/assets/22cc628d-694c-4193-896d-1b47dd2fb553" />

After

<img width="2560" height="1219" alt="image" src="https://github.com/user-attachments/assets/49e3da94-6731-460f-98c6-5709e7856eaa" />
