### PR TITLE
Fix scrolling the page while mobile menu open

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
   },
   "[mdx]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -25,8 +25,12 @@ article.card {
   border-radius: 0.5rem;
 }
 
-body {
-  overflow-y: scroll;
+// A small hack to avoid scroll bar layout shifts,
+// a mirror of https://github.com/withastro/starlight/blob/56860717dcb8f70a8438b5970967bdff4826a640/packages/starlight/components/MobileMenuToggle.astro#L101-L105
+@media (width > 50rem) {
+  [data-search-modal-open] {
+    overflow: auto;
+  }
 }
 
 figcaption {


### PR DESCRIPTION
Removed the 

```css
body {
  overflow-y: scroll;
}
```

instead just fix the `data-search-modal-open` layout shift