### PR TITLE
docs(create-project): add vite.config.ts step to ignore src-tauri fro…

### DIFF
--- a/src/content/docs/start/create-project.mdx
+++ b/src/content/docs/start/create-project.mdx
@@ -204,7 +204,21 @@ The following example assumes you are creating a new project. If you've already 
 
         This will create a `src-tauri` directory in your project with the necessary Tauri configuration files.
 
-    5. Verify your Tauri app is working by running the development server:
+    5. Configure the `server.watch.ignored` option in `vite.config.ts` to prevent Vite from watching the `src-tauri` directory:
+
+        ```js title="vite.config.ts"
+        import { defineConfig } from "vite";
+
+        export default defineConfig({
+          server: {
+            watch: {
+              ignored: ["**/src-tauri/**"],
+            },
+          },
+        });
+        ```
+
+    6. Verify your Tauri app is working by running the development server:
 
         <CommandTabs
             npm="npx tauri dev"

--- a/src/content/docs/zh-cn/start/create-project.mdx
+++ b/src/content/docs/zh-cn/start/create-project.mdx
@@ -204,7 +204,21 @@ import CommandTabs from '@components/CommandTabs.astro';
 
         这将在你的项目中创建一个 `src-tauri` 目录，其中包含 Tauri 所需的配置文件。
 
-    5. 通过运行开发服务器来验证你的 Tauri 应用是否正常工作：
+    5. 在 `vite.config.ts` 中配置 `server.watch.ignored` 选项，避免 Vite 监听 `src-tauri` 目录：
+
+        ```js title="vite.config.ts"
+        import { defineConfig } from "vite";
+
+        export default defineConfig({
+          server: {
+            watch: {
+              ignored: ["**/src-tauri/**"],
+            },
+          },
+        });
+        ```
+
+    6. 通过运行开发服务器来验证你的 Tauri 应用是否正常工作：
 
         <CommandTabs
             npm="npx tauri dev"


### PR DESCRIPTION
…m Vite watch

- Add step 5 to configure server.watch.ignored in vite.config.ts
- Renumber original step 5 to step 6
- Sync changes between English and Chinese docs

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
<!-- Translators, try to follow this pattern when naming your PRs:
"i18n(language code): (short description)" -->
- What does this PR change? Give us a brief description. <!-- If it's an update try adding the commits as reference -->
- Closes # <!-- Add an issue number if this PR will close it or remove it. -->

<!--
Here's what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don't hesitate to ask any questions if you're not sure what these mean!

2. In a few minutes, you'll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don't worry if this takes a day or two.

4. Reach out to us on Discord with any questions along the way:
   https://discord.com/invite/tauri
-->
