### PR TITLE
i18n(zh-cn): fix untranslated index

### DIFF
--- a/src/content/docs/zh-cn/index.mdx
+++ b/src/content/docs/zh-cn/index.mdx
@@ -33,7 +33,7 @@ import Cta from '@fragments/cta.mdx';
 </div>
 
 <div class="lp-cta-card">
-  <Card title="Create a Project" icon="rocket">
+  <Card title="创建项目" icon="rocket">
     <Cta />
   </Card>
 </div>


### PR DESCRIPTION
#### Description

- Translate missing title on `zh-cn/index.mdx`.