### PR TITLE
fix(releases): show anchor links on overview section headings

### DIFF
--- a/packages/releases-site/generator/uiData.ts
+++ b/packages/releases-site/generator/uiData.ts
@@ -31,6 +31,7 @@ export interface HomeSummaryPackage {
 }
 
 export interface HomeSummaryRepo {
+  name: string;
   displayName: string;
   repoUrl: string;
   repoSlug: string;
@@ -86,6 +87,7 @@ export function buildHomeSummaryRepos(
   latestVersions: LatestVersionsMap
 ): HomeSummaryRepo[] {
   return repositories.map((repo) => ({
+    name: repo.name,
     displayName: repo.displayName,
     repoUrl: repo.repoUrl,
     repoSlug: repo.repoUrl.replace('https://github.com/', '').replace(/\/$/, ''),

--- a/packages/releases-site/src/components/RepoLink.astro
+++ b/packages/releases-site/src/components/RepoLink.astro
@@ -1,0 +1,30 @@
+---
+import { repositories } from '../../generator/config';
+
+interface Props {
+  name: string;
+}
+
+const repo = repositories.find((r) => r.name === Astro.props.name);
+if (!repo) {
+  throw new Error(`Unknown repository "${Astro.props.name}" (see generator/config.ts)`);
+}
+const slug = repo.repoUrl.replace('https://github.com/', '').replace(/\/$/, '');
+---
+
+<a class="repo-link" href={repo.repoUrl} target="_blank" rel="noopener noreferrer">{slug}</a>
+
+<style>
+  .repo-link {
+    margin-inline-start: 1rem;
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-sm);
+    font-weight: 400;
+    text-decoration: none;
+  }
+
+  .repo-link:hover {
+    color: var(--sl-color-text-accent);
+    text-decoration: underline;
+  }
+</style>

--- a/packages/releases-site/src/components/RepoPackages.astro
+++ b/packages/releases-site/src/components/RepoPackages.astro
@@ -4,9 +4,18 @@ import { repositories } from '../../generator/config';
 import { latestVersions } from '../../generator/generated/latestVersions';
 import { buildHomeSummaryRepos } from '../../generator/uiData';
 
-const repos = buildHomeSummaryRepos(repositories, latestVersions);
+interface Props {
+  name: string;
+}
 
-function describe(pkg: (typeof repos)[number]['packages'][number]): string {
+const repo = buildHomeSummaryRepos(repositories, latestVersions).find(
+  (r) => r.name === Astro.props.name
+);
+if (!repo) {
+  throw new Error(`Unknown repository "${Astro.props.name}" (see generator/config.ts)`);
+}
+
+function describe(pkg: (typeof repo)['packages'][number]): string {
   const pills = pkg.versions
     .map(
       ({ label, version, href }) => `<a class="version-pill" href="${href}">${label} ${version}</a>`
@@ -20,43 +29,15 @@ function describe(pkg: (typeof repos)[number]['packages'][number]): string {
 }
 ---
 
-{
-  repos.map((repo) => (
-    <section class="repo-summary">
-      <h2 id={repo.displayName.toLowerCase()}>
-        {repo.displayName}
-        <a class="repo-link" href={repo.repoUrl} target="_blank" rel="noopener noreferrer">
-          {repo.repoSlug}
-        </a>
-      </h2>
-      <CardGrid>
-        {repo.packages.map((pkg) => (
-          <LinkCard title={pkg.name} href={`/release/${pkg.name}/`} description={describe(pkg)} />
-        ))}
-      </CardGrid>
-    </section>
-  ))
-}
+<CardGrid>
+  {
+    repo.packages.map((pkg) => (
+      <LinkCard title={pkg.name} href={`/release/${pkg.name}/`} description={describe(pkg)} />
+    ))
+  }
+</CardGrid>
 
 <style>
-  .repo-summary h2 {
-    display: flex;
-    align-items: baseline;
-    gap: 1rem;
-  }
-
-  .repo-link {
-    color: var(--sl-color-gray-3);
-    font-size: var(--sl-text-sm);
-    font-weight: 400;
-    text-decoration: none;
-  }
-
-  .repo-link:hover {
-    color: var(--sl-color-text-accent);
-    text-decoration: underline;
-  }
-
   :global(.version-pill) {
     display: inline-block;
     background-color: var(--sl-color-gray-6);

--- a/packages/releases-site/src/content/docs/index.mdx
+++ b/packages/releases-site/src/content/docs/index.mdx
@@ -1,17 +1,38 @@
 ---
 title: Tauri Ecosystem Releases
 description: Release notes for the Tauri core packages and plugins
-tableOfContents: false
 editUrl: false
 prev: false
 next: false
 ---
 
-import HomeSummary from '../../components/HomeSummary.astro';
+import RepoLink from '../../components/RepoLink.astro';
+import RepoPackages from '../../components/RepoPackages.astro';
+
+{/* Section headings must stay in sync with `displayName` in generator/config.ts —
+    they are markdown so Starlight picks them up for the table of contents. */}
 
 Release notes for every package in the Tauri core ecosystem, generated from the
 upstream changelogs. Pick a package below, or explore every release at once in
 the [changelog table](/release/table/). For per-platform plugin availability,
 see the [plugin support table](/plugin/#support-table).
 
-<HomeSummary />
+## Tauri<RepoLink name="tauri" />
+
+<RepoPackages name="tauri" />
+
+## Wry<RepoLink name="wry" />
+
+<RepoPackages name="wry" />
+
+## Tao<RepoLink name="tao" />
+
+<RepoPackages name="tao" />
+
+## CTA<RepoLink name="create-tauri-app" />
+
+<RepoPackages name="create-tauri-app" />
+
+## Plugins<RepoLink name="plugins-workspace" />
+
+<RepoPackages name="plugins-workspace" />


### PR DESCRIPTION
<img width="1055" height="630" alt="image" src="https://github.com/user-attachments/assets/a380949f-455a-46e4-8c10-0895fd37e7b3" />


now we can link individual sections