### PR TITLE
Move profiles to root Cargo.toml

### DIFF
--- a/src/content/docs/concept/size.mdx
+++ b/src/content/docs/concept/size.mdx
@@ -19,7 +19,7 @@ Dependent on whether you use the stable or nightly Rust toolchain the options av
 <TabItem label="Stable">
 
 ```toml
-# src-tauri/Cargo.toml
+# Cargo.toml
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.
 
@@ -36,7 +36,7 @@ strip = true # Ensures debug symbols are removed.
 <TabItem label="Nightly">
 
 ```toml
-# src-tauri/Cargo.toml
+# Cargo.toml
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.
 rustflags = ["-Zthreads=8"] # Better compile performance.


### PR DESCRIPTION
Profiles should be specified at the workspace root, not in sub-crates.

- Build warning:
  ```
  warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
  package:   <PROJECT_DIR>/src-tauri/Cargo.toml
  workspace: <PROJECT_DIR>/Cargo.toml
  ```
- [Rust docs](https://doc.rust-lang.org/cargo/reference/workspaces.html): "_The [...] `[profile.*]` section in `Cargo.toml` are only recognized in the root manifest, and ignored in member crates’ manifests._"

