### PR TITLE
feat(releases): inline changelogs

### DIFF
--- a/packages/releases-site/generator/config.ts
+++ b/packages/releases-site/generator/config.ts
@@ -51,6 +51,9 @@ export function shouldBuildReleases(): boolean {
 export const corePageSlug = 'core';
 export const corePrereleasesSlug = 'core/prereleases';
 
+/** how many minor series a landing page carries in full; older ones stay on its all-versions page */
+export const indexInlineSeriesCount = 6;
+
 export function resolveBranch(repo: Repository): string {
   return repo.branch || 'dev';
 }

--- a/packages/releases-site/generator/groupedPage.ts
+++ b/packages/releases-site/generator/groupedPage.ts
@@ -19,7 +19,9 @@ export type CoreRelease = {
   entries: CoreEntry[];
 };
 
-export type CoreGroup = { series: string; releases: CoreRelease[] };
+export type SeriesGroup<T> = { series: string; releases: T[] };
+
+export type CoreGroup = SeriesGroup<CoreRelease>;
 
 const CORE_PACKAGES = ['tauri', '@tauri-apps/api', 'tauri-cli', '@tauri-apps/cli'];
 
@@ -53,9 +55,7 @@ export function buildCoreGroups(releasesByPackage: Map<string, ReleaseWithDate[]
 
 /** sorting alone will not group these: `2.0.1-beta.2` ranks between `2.0.1` and `2.0.0`,
  * splitting tauri-bundler's stable 2.0 run in two */
-export function groupBySeries<T extends { version: string }>(
-  releases: T[]
-): { series: string; releases: T[] }[] {
+export function groupBySeries<T extends { version: string }>(releases: T[]): SeriesGroup<T>[] {
   const bySeries = new Map<string, T[]>();
   for (const release of releases) {
     const series = seriesOf(release.version);

--- a/packages/releases-site/generator/pageGenerator.ts
+++ b/packages/releases-site/generator/pageGenerator.ts
@@ -16,8 +16,7 @@ import { parseAndSortChangelog } from './scripts/parse.ts';
 import {
   getAllVersionsHead,
   renderSeriesHead,
-  renderReleaseHead,
-  renderReleaseNotes,
+  renderRelease,
   writeCorePage,
   writeCorePrereleasesPage,
   writePackageIndex,
@@ -95,7 +94,11 @@ function buildReleasesByPackage(packageData: PackageData): ReleasesByPackage {
     if (!data.changelogs) {
       console.warn(`missing changelog ${packageName}`);
     }
-    const releases = withReleaseDates(parseAndSortChangelog(data.changelogs), data);
+    // escaped once here so no renderer escapes its own copy, which would show the
+    // entities verbatim
+    const releases = escapeReleaseNotes(
+      withReleaseDates(parseAndSortChangelog(data.changelogs), data)
+    );
     if (releases.length === 0) {
       console.warn(`missing releases ${packageName}`);
     }
@@ -123,6 +126,7 @@ async function writePageData(
     mkdirSync(workingDir, { recursive: true });
 
     const releases = releasesByPackage.get(packageName) ?? [];
+    const groups = groupBySeries(releases);
     const config = packageConfigs.get(packageName);
     const changelogUrl = config?.changelogUrl;
 
@@ -131,6 +135,7 @@ async function writePageData(
       description: config?.pkg.description,
       externalLinks: buildExternalLinks(config),
       releases,
+      groups,
       workingDir,
     });
 
@@ -138,15 +143,13 @@ async function writePageData(
 
     allVersionsStream.write(getAllVersionsHead(packageName, changelogUrl));
 
-    for (const group of groupBySeries(releases)) {
+    for (const group of groups) {
       allVersionsStream.write(`\n\n${renderSeriesHead(group.series)}`);
 
       for (const release of group.releases) {
         const { version, notes, dateLabel } = release;
-        const rawMd = escapeChangelogMarkdown(notes);
 
-        const head = renderReleaseHead(3, version, dateLabel);
-        allVersionsStream.write(`\n\n${[head, renderReleaseNotes(rawMd)].join('\n\n')}`);
+        allVersionsStream.write(`\n\n${renderRelease(release)}`);
 
         const releaseUrl = config
           ? buildGitHubReleaseUrl(config.repo, config.pkg, version)
@@ -155,7 +158,7 @@ async function writePageData(
         writeVersionPage({
           packageName,
           version,
-          notes: rawMd,
+          notes,
           releaseDateLabel: dateLabel,
           githubReleaseUrl: releaseUrl,
           workingDir,
@@ -225,6 +228,10 @@ async function writeTableData(
   stream.write(']\n}');
   stream.end();
   await finished(stream);
+}
+
+function escapeReleaseNotes(releases: ReleaseWithDate[]): ReleaseWithDate[] {
+  return releases.map((release) => ({ ...release, notes: escapeChangelogMarkdown(release.notes) }));
 }
 
 function withReleaseDates(releases: Release[], data: PackageData[string]): ReleaseWithDate[] {

--- a/packages/releases-site/generator/scripts/parse.ts
+++ b/packages/releases-site/generator/scripts/parse.ts
@@ -32,16 +32,33 @@ function parseChangelog(changelog: string): Array<{ version: string; notes: stri
     .filter((r): r is { version: string; notes: string } => r !== null);
 }
 
+// tauri-cli's changelog heads two sections `## \[2.0.0-rc.9]`. Both are that release:
+// left apart they write the same page, and the first section's notes never ship
+function foldRepeatedVersions(releases: Release[]): Release[] {
+  const byVersion = new Map<string, Release>();
+  for (const release of releases) {
+    const kept = byVersion.get(release.version);
+    if (kept) {
+      kept.notes = `${kept.notes}\n\n${release.notes}`;
+    } else {
+      byVersion.set(release.version, release);
+    }
+  }
+  return [...byVersion.values()];
+}
+
 export function parseAndSortChangelog(changelog: string): Release[] {
   // rcompare throws on anything that isn't valid semver (e.g. an upstream
   // "## [Unreleased]" heading), which would break every build until fixed.
-  const releases = parseChangelog(changelog).filter(({ version }) => {
+  const parsed = parseChangelog(changelog).filter(({ version }) => {
     if (!semverValid(version)) {
       console.warn(`skipping non-semver changelog heading: "${version}"`);
       return false;
     }
     return true;
   });
+
+  const releases = foldRepeatedVersions(parsed);
 
   releases.sort((a, b) => {
     return rcompare(a.version, b.version);

--- a/packages/releases-site/generator/scripts/writePage.ts
+++ b/packages/releases-site/generator/scripts/writePage.ts
@@ -286,7 +286,12 @@ export function writePackageIndex(params: {
     'next: false',
   ]);
 
-  const header = renderPageLinks(externalLinks);
+  const allVersionsHref = `${basePath}/${packageName}/all-versions/`;
+
+  const header = renderPageLinks([
+    ...externalLinks,
+    { label: 'Full changelog', href: allVersionsHref, align: 'end' },
+  ]);
 
   const versionList = releases
     .map(({ version, dateLabel }) => {
@@ -300,7 +305,8 @@ export function writePackageIndex(params: {
     header,
     ...(description ? [description] : []),
     renderInlineChangelog(groups),
-    `[Full changelog](${basePath}/${packageName}/all-versions/)`,
+    '## Full Changelog',
+    `[${packageName} full changelog](${allVersionsHref})`,
     '## Version List',
     versionList,
   ]

--- a/packages/releases-site/generator/scripts/writePage.ts
+++ b/packages/releases-site/generator/scripts/writePage.ts
@@ -1,11 +1,23 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { basePath, corePageSlug, corePrereleasesSlug, note, versionPageHref } from '../config.ts';
-import { demoteNotesHeadings, type CoreGroup, type CoreRelease } from '../groupedPage.ts';
-import { escapeChangelogMarkdown } from '../utils.ts';
+import {
+  basePath,
+  corePageSlug,
+  corePrereleasesSlug,
+  indexInlineSeriesCount,
+  note,
+  versionPageHref,
+} from '../config.ts';
+import {
+  demoteNotesHeadings,
+  type CoreGroup,
+  type CoreRelease,
+  type SeriesGroup,
+} from '../groupedPage.ts';
 
-export type VersionListEntry = {
+export type IndexRelease = {
   version: string;
+  notes: string;
   dateLabel?: string;
 };
 
@@ -71,6 +83,10 @@ export function renderSeriesHead(series: string): string {
 /** changelog categories are `###`; demoting them to h5 here is what custom.scss targets */
 export function renderReleaseNotes(notes: string): string {
   return ['<div class="release-notes">', demoteNotesHeadings(notes, 2), '</div>'].join('\n\n');
+}
+
+export function renderRelease({ version, notes, dateLabel }: IndexRelease): string {
+  return [renderReleaseHead(3, version, dateLabel), renderReleaseNotes(notes)].join('\n\n');
 }
 
 /**
@@ -146,11 +162,9 @@ function renderCoreRelease(release: CoreRelease): string {
   const head = renderReleaseHead(3, release.version, release.dateLabel);
 
   const bodies = release.entries.map((entry) => {
-    const notes = escapeChangelogMarkdown(entry.notes);
     // repeats the heading above, but earns a unique anchor id; styled back out of the way
     const heading = `#### ${entry.pkgLabel} <small class="package-version">${entry.version}</small>`;
-    // blank lines keep the markdown between the tags parsed as markdown
-    return ['<div class="package-block">', heading, renderReleaseNotes(notes), '</div>'].join(
+    return ['<div class="package-block">', heading, renderReleaseNotes(entry.notes), '</div>'].join(
       '\n\n'
     );
   });
@@ -235,22 +249,38 @@ function writeGroupedPage(params: {
   writeFileSync(file, content);
 }
 
-/**
- * write the per-package landing page listing all versions
- */
+/** the newest series, wrapped out of the search index because landing pages are the
+ * only release pages pagefind indexes and a package should be found by its name,
+ * not by a changelog line */
+function renderInlineChangelog(groups: SeriesGroup<IndexRelease>[]): string {
+  const sections = groups
+    .slice(0, indexInlineSeriesCount)
+    .flatMap((group) => [renderSeriesHead(group.series), ...group.releases.map(renderRelease)]);
+
+  if (sections.length === 0) {
+    return '';
+  }
+
+  return ['<div data-pagefind-ignore>', ...sections, '</div>'].join('\n\n');
+}
+
 export function writePackageIndex(params: {
   packageName: string;
   description?: string;
   externalLinks: PageLink[];
-  releases: VersionListEntry[];
+  releases: IndexRelease[];
+  groups: SeriesGroup<IndexRelease>[];
   workingDir: string;
 }): void {
-  const { packageName, description, externalLinks, releases, workingDir } = params;
+  const { packageName, description, externalLinks, releases, groups, workingDir } = params;
 
   const frontmatter = frontmatterBlock([
     `title: ${yaml(packageName)}`,
     `description: ${yaml(description ?? `${packageName} releases`)}`,
     `slug: ${yaml(packageName)}`,
+    'tableOfContents:',
+    '  minHeadingLevel: 2',
+    '  maxHeadingLevel: 3',
     'editUrl: false',
     'prev: false',
     'next: false',
@@ -269,8 +299,9 @@ export function writePackageIndex(params: {
     frontmatter,
     header,
     ...(description ? [description] : []),
+    renderInlineChangelog(groups),
     `[Full changelog](${basePath}/${packageName}/all-versions/)`,
-    '## Versions',
+    '## Version List',
     versionList,
   ]
     .filter(Boolean)


### PR DESCRIPTION
there are some followup optimization on the code considering the migration from .md to .astro I guess there's a better way to process the data

https://github.com/tauri-apps/tauri-docs/pull/4048#discussion_r3741817068
https://deploy-preview-4048--tauri-v2.netlify.app/release/tauri-cli/