### PR TITLE
Add `:` to after `API Reference`

### DIFF
--- a/src/components/PluginLinks.astro
+++ b/src/components/PluginLinks.astro
@@ -45,7 +45,7 @@ const hasApiLinks = jsApi || docsrs;
   {
     hasApiLinks && (
       <div class="flex api">
-        API Reference
+        API Reference:
         {jsApi && (
           <a href={jsApi} class="flex" target="_blank">
             <svg viewBox="0 0 256 256" aria-label="JavaScript API Reference">


### PR DESCRIPTION
Making it easier to see that this is not part of the links