### PR TITLE
 docs(plugin-notification): clarify onAction payload optionality and Android replay scope

### DIFF
--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -161,6 +161,9 @@ Actions add interactive buttons and inputs to notifications. Use them to create 
 
 Register action types to define interactive elements:
 
+<Tabs syncKey="lang">
+<TabItem label="JavaScript">
+
 ```javascript
 import { registerActionTypes } from '@tauri-apps/plugin-notification';
 
@@ -184,6 +187,36 @@ await registerActionTypes([
   },
 ]);
 ```
+
+</TabItem>
+<TabItem label="Rust">
+
+```rust
+use tauri_plugin_notification::{Action, ActionType, NotificationExt};
+
+#[cfg(mobile)]
+{
+    let action_type = ActionType::builder("messages")
+        .actions(vec![
+            Action::builder("reply", "Reply")
+                .input(true)
+                .input_button_title("Send")
+                .input_placeholder("Type your reply...")
+                .build(),
+            Action::builder("mark-read", "Mark as Read")
+                .foreground(false)
+                .build(),
+        ])
+        .build();
+
+    app.notification()
+        .register_action_types(vec![action_type])
+        .unwrap();
+}
+```
+
+</TabItem>
+</Tabs>
 
 #### Action Properties
 

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -200,15 +200,24 @@ await registerActionTypes([
 
 #### Listen for Actions
 
-Listen to user interactions with notification actions:
+Listen to user interactions with notification actions.
+
+The `onAction` payload provides the user's selected `actionId` and any text they entered into an `inputValue`. It also includes the original `notification` that triggered the action.
 
 ```javascript
 import { onAction } from '@tauri-apps/plugin-notification';
 
 await onAction((notification) => {
-  console.log('Action performed:', notification);
+  console.log('Action performed:', notification.actionId);
+  if (notification.inputValue) {
+    console.log('User entered:', notification.inputValue);
+  }
 });
 ```
+
+:::tip
+Tauri guarantees high reliability for notification actions. If the user interacts with an action before your application has loaded and registered `onAction` (such as during a cold start from a background state), the native platform queues the event. The queued actions are immediately replayed as soon as you call `onAction`.
+:::
 
 ### Attachments
 

--- a/src/content/docs/plugin/notification.mdx
+++ b/src/content/docs/plugin/notification.mdx
@@ -202,7 +202,7 @@ await registerActionTypes([
 
 Listen to user interactions with notification actions.
 
-The `onAction` payload provides the user's selected `actionId` and any text they entered into an `inputValue`. It also includes the original `notification` that triggered the action.
+The `onAction` payload provides the user's selected `actionId` and any text they entered into an `inputValue`. When available, it also includes the original `notification` that triggered the action.
 
 ```javascript
 import { onAction } from '@tauri-apps/plugin-notification';
@@ -212,11 +212,14 @@ await onAction((notification) => {
   if (notification.inputValue) {
     console.log('User entered:', notification.inputValue);
   }
+  if (notification.notification) {
+    console.log('Source notification ID:', notification.notification.id);
+  }
 });
 ```
 
 :::tip
-Tauri guarantees high reliability for notification actions. If the user interacts with an action before your application has loaded and registered `onAction` (such as during a cold start from a background state), the native platform queues the event. The queued actions are immediately replayed as soon as you call `onAction`.
+On Android, if the user interacts with an action before your application has loaded and registered `onAction` (such as during a cold start from a background state), the native layer queues the event and replays it when `onAction` is registered.
 :::
 
 ### Attachments


### PR DESCRIPTION
rebase of #3743 