### PR TITLE
bump plugins-workspace submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev:setup:submodules": "git submodule update --init",
     "dev:setup:tauri": "pnpm install -C packages/tauri/packages/api --ignore-workspace --no-frozen-lockfile",
-    "dev:setup:plugins-workspace": "pnpm -C packages/plugins-workspace install",
+    "dev:setup:plugins-workspace": "pnpm -C packages/plugins-workspace install --pm-on-fail=ignore",
     "dev:setup": "pnpm dev:setup:submodules && pnpm dev:setup:tauri && pnpm dev:setup:plugins-workspace && pnpm build:compatibility-table",
     "sync:sponsors": "pnpm --filter fetch-sponsors run build sponsors",
     "sync:contributors": "pnpm --filter fetch-sponsors run build contributors",


### PR DESCRIPTION
lemme first check if it builds


I guess we need https://github.com/tauri-apps/tauri-docs/pull/4078/commits/9e51c07ecccdd45e402a8bd24079b41d2069da57 to ignore versions, without it we'd need the same exactly version on both repos