### PR TITLE
i18n(ja) Update: index.mdx & from-tauri-1.mdx in /migrate/ section

### DIFF
--- a/src/content/docs/ja/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/ja/start/migrate/from-tauri-1.mdx
@@ -137,7 +137,7 @@ Tauri 1.0 から Tauri 2.0 への変更内容の概要は以下のとおりで�
 - `api::http` モジュールは削除されました。代わりに「`tauri-plugin-http`」を使用して下さい。《[移行処置の説明はこちら](#http-プラグインへの移行)》
 - `api::ip` モジュールは書き直され、「`tauri::ipc`」に移動しました。新しい API群、特に `tauri::ipc::Channel` を確認してください。
 - `api::path` モジュール機能と `tauri::PathResolved` は 「`tauri::Manager::path`」へ移動しました。《[移行処置の説明はこちら](#tauri-manager-への-path-の移行)》
-- `api::process::Command`、`tauri::api::shell` および `tauri::Manager::shell_scope` の各 API は削除されました。代わりに 「`tauri-plugin-shell`」を使用してください。《[移行処置の説明はこちら](#Shell-プラグインへの移行)》
+- `api::process::Command`、`tauri::api::shell` および `tauri::Manager::shell_scope` の各 API は削除されました。代わりに 「`tauri-plugin-shell`」を使用してください。《[移行処置の説明はこちら](#shell-プラグインへの移行)》
 - `api::process::current_binary` および `tauri::api::process::restart` は 「`tauri::process`」へ移動しました。
 - `api::version` モジュールは削除されました。代わりに「[semver crate](https://docs.rs/semver/latest/semver/)」《英語サイト》 を使用して下さい。
 - `App::clipboard_manager` および `AppHandle::clipboard_manager` は削除されました。代わりに「`tauri-plugin-clipboard`」を使用してください。《[移行処置の説明はこちら](#clipboard-プラグインへの移行)》

--- a/src/content/docs/ja/start/migrate/from-tauri-1.mdx
+++ b/src/content/docs/ja/start/migrate/from-tauri-1.mdx
@@ -7,12 +7,19 @@ sidebar:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import CommandTabs from '@components/CommandTabs.astro';
+import TranslationNote from '@components/i18n/TranslationNote.astro';
 
 ここでは、Tauri 1.0 アプリケーションを Tauri 2.0 にアップグレードする手順を説明します。
 
 ## モバイル向けの準備
 
-Tauri のモバイル・インターフェイスは、そのプロジェクトが共有ライブラリを出力するようにしなければなりません。既存のアプリケーションをモバイル向けに変更する場合には、デスクトップ実行可能ファイルとともにそのようなライブラリ・ファイルを生成するようにクレートを変更する必要があります。
+Tauri のモバイル・インターフェイスでは、あなたのプロジェクトが共有ライブラリを出力する必要があります。既にあるアプリケーションをモバイル向けにする場合には、デスクトップ用実行可能ファイルとともに同様のアーティファクト（ファイル）を生成するようにクレートを変更しなければなりません。
+
+<TranslationNote lang="ja">
+
+**アーティファクト**　artifact。 プログラム開発過程で生み出される「成果物」を指す言葉。ソースコードやプログラム関連文書。
+
+</TranslationNote>
 
 1. ライブラリを生成するために Cargo マニフェストを変更します。以下のブロックを追加します：
 
@@ -50,7 +57,13 @@ fn main() {
 
 ## 自動移行
 
-Tauri v2 CLI には、移行作業の大部分を自動化する `migrate` コマンドが含まれており、移行完了に役立ちます。
+:::danger
+
+以下のコマンドは、この「アップグレート・ガイド」の代わりになるものではありません！　以下のコマンドを利用するかどうかにかかわらず、ページ**全体**を読み通してください。
+
+:::
+
+Tauri v2 CLI には、移行作業の大部分を自動化する「`migrate` コマンド」が含まれており、移行作業を完了するのに役立ちます。
 
 <CommandTabs
   npm="npm install @tauri-apps/cli@latest
@@ -63,7 +76,7 @@ Tauri v2 CLI には、移行作業の大部分を自動化する `migrate` コ�
     cargo tauri migrate'
 />
 
-`migrate` コマンドの詳細については、[コマンドライン・インターフェース・リファレンス](/ja/reference/cli/#migrate) を参照してください。
+「`migrate` コマンド」の詳細については、「[コマンドライン・インターフェース・リファレンス](/ja/reference/cli/#migrate)」の章を参照してください。
 
 ## 変更の概要
 
@@ -72,34 +85,34 @@ Tauri 1.0 から Tauri 2.0 への変更内容の概要は以下のとおりで�
 ### Tauri の設定
 
 - `package > productName` と `package > version` をトップレベル・オブジェクトへ移動。
-- バイナリ名が自動的には `productName` と一致するように変更されなくなったため、`productName` と一致するトップレベル・オブジェクトに `mainBinaryName` 文字列を追加する必要があります。
+- バイナリ名の `productName` に合わせた自動的な名前変更が行なわれなくなったため、`productName` と一致するトップレベル・オブジェクトに `mainBinaryName` 文字列を追加する必要があります。
 - `package` を削除。
-- `tauri` key を `app` に改称。
-- `tauri > allowlist` を削除。[許可の移行](#許可の移行) を参照。
-- `tauri > allowlist > protocol > assetScope` を `app > security > assetProtocol > scope` へ移動。
-- `tauri > cli` を `plugins > cli` へ移動。
-- `tauri > windows > fileDropEnabled` を `app > windows > dragDropEnabled` に改称。
+- `tauri` key を「`app`」に改称。
+- `tauri > allowlist` を削除。下記「[アクセス権の移行](#アクセス権の移行)」を参照。
+- `tauri > allowlist > protocol > assetScope` を「`app > security > assetProtocol > scope`」へ移動。「`enable`」、「グロブ・パターン」、「`requireLiteralLeadingDot`」、「ダイナミック・パス」については「[アセット・プロトコル・スコープ](/ja/security/asset-protocol/)」の章を参照。
+- `tauri > cli` を「`plugins > cli`」へ移動。
+- `tauri > windows > fileDropEnabled` を「`app > windows > dragDropEnabled`」に改称。
 - `tauri > updater > active` を削除。
 - `tauri > updater > dialog` を削除。
-- `tauri > updater` を `plugins > updater` へ移動。
-- `bundle > createUpdaterArtifacts` を追加。アプリ・アップデーターを使用する場合には設定する必要があります。
-  - すでに配布されている v1 アプリをアップグレードする場合は、これを `v1compatible` に設定してください。詳しくは [アップデーター・ガイド](/ja/plugin/updater/) を参照してください。
-- `tauri > systemTray` を `app > trayIcon` に改称。
-- `tauri > pattern` を `app > security > pattern` へ移動。
+- `tauri > updater` を「`plugins > updater`」へ移動。
+- 「`bundle > createUpdaterArtifacts`」を追加。アプリ・アップデーターを使用する場合には設定する必要があります。
+  - すでに配布されている v1 アプリをアップグレードする場合は、この項目を「`v1compatible`」に設定してください。詳しくは「[アップデーター・ガイド](/ja/plugin/updater/)」の章を参照してください。
+- `tauri > systemTray` を「`app > trayIcon`」に改称。
+- `tauri > pattern` を「`app > security > pattern`」へ移動。
 - `tauri > bundle` をトップレベルへ移動。
 - `tauri > bundle > identifier` をトップレベル・オブジェクトへ移動。
-- `tauri > bundle > dmg` を `bundle > macOS > dmg` へ移動。
-- `tauri > bundle > deb` を `bundle > linux > deb` へ移動。
-- `tauri > bundle > appimage` を `bundle > linux > appimage` へ移動。
-- `tauri > bundle > macOS > license` を削除。代わりに `bundle > licenseFile` を使用して下さい。
-- `tauri > bundle > windows > wix > license` を削除。代わりに `bundle > licenseFile` を使用して下さい。
-- `tauri > bundle > windows > nsis > license` を削除。代わりに `bundle > licenseFile` を使用して下さい。
-- `tauri > bundle > windows > webviewFixedRuntimePath` を削除。代わりに `bundle > windows > webviewInstallMode` を使用して下さい。
-- `build > withGlobalTauri` を `app > withGlobalTauri` へ移動。
-- `build > distDir` を `frontendDist` に改称。
-- `build > devPath` を `devUrl` に改称。
+- `tauri > bundle > dmg` を「`bundle > macOS > dmg`」へ移動。
+- `tauri > bundle > deb` を「`bundle > linux > deb`」へ移動。
+- `tauri > bundle > appimage` を「`bundle > linux > appimage`」へ移動。
+- `tauri > bundle > macOS > license` を削除。代わりに「`bundle > licenseFile`」を使用して下さい。
+- `tauri > bundle > windows > wix > license` を削除。代わりに「`bundle > licenseFile`」を使用して下さい。
+- `tauri > bundle > windows > nsis > license` を削除。代わりに「`bundle > licenseFile`」を使用して下さい。
+- `tauri > bundle > windows > webviewFixedRuntimePath` を削除。代わりに「`bundle > windows > webviewInstallMode`」を使用して下さい。
+- `build > withGlobalTauri` を「`app > withGlobalTauri`」へ移動。
+- `build > distDir` を「`frontendDist`」に改称。
+- `build > devPath` を「`devUrl`」に改称。
 
-[Tauri 2.0 設定 API レファレンス](/ja/reference/config/)
+詳しくは「[Tauri 2.0 設定 API レファレンス](/ja/reference/config/)」の章を参照してください。
 
 ### Cargo の新機能
 
@@ -108,56 +121,56 @@ Tauri 1.0 から Tauri 2.0 への変更内容の概要は以下のとおりで�
 ### 削除された Cargo 機能
 
 - reqwest-client:　現時点で「reqwest」のみが有効なクライアントです。
-- reqwest-native-tls-vendored:　代わりに `native-tls-vendored` を使用して下さい。
-- process-command-api:　代わりに `shell` プラグインを使用して下さい（以下の項目で使用法を確認してください）。
-- shell-open-api:　代わりに `shell` プラグインを使用して下さい（以下の項目で使用法を確認してください）。
-- windows7-compat:　`notification` プラグインへ移動。
+- reqwest-native-tls-vendored:　代わりに「`native-tls-vendored`」を使用して下さい。
+- process-command-api:　代わりに「`shell` プラグイン」を使用して下さい（使用方法は [下記の項目](#shell-プラグインへの移行) で確認してください）。
+- shell-open-api:　代わりに「`shell` プラグイン」を使用して下さい（使用方法は [下記の項目](#shell-プラグインへの移行) で確認してください）。
+- windows7-compat:　「`notification` プラグイン」へ移動。
 - updater:　「Updater（アップデーター）」は現在プラグインになっています。
-- linux-protocol-headers:　「webkit2gtk」最小化版をアップグレードし、デフォルトで有効化されるようになりました。
-- system-tray:　`tray-icon` に改称。
+- linux-protocol-headers:　「webkit2gtk」最小化版がアップグレードされたので、デフォルトで有効化されるようになりました。
+- system-tray:　「`tray-icon`」に改称。
 
 ### Rust クレートの変更点
 
-- `api` モジュールは削除されました。各 API モジュールは、「Tauri プラグイン」にある移行先を参照してください。
-- `api::dialog` モジュールは削除されました。代わりに `tauri-plugin-dialog` を使用して下さい。 [移行先](#dialog-プラグインの移行)
-- `api::file` モジュールは削除されました。代わりに、Rust の [`std::fs`](https://doc.rust-lang.org/std/fs/) を使用して下さい。
-- `api::http` モジュールは削除されました。代わりに `tauri-plugin-http` を使用して下さい。 [移行先](#http-プラグインの移行)
-- `api::ip` モジュールは書き直され、`tauri::ipc` に移動しました。新しい API群、特に `tauri::ipc::Channel` を確認してください。
-- `api::path` モジュール機能と `tauri::PathResolved` は `tauri::Manager::path` へ移動しました。 [移行先](#path-to-tauri-manager-の移行)
-- `api::process::Command`、`tauri::api::shell` および `tauri::Manager::shell_scope` の各 API は削除されました。代わりに `tauri-plugin-shell` を使用してください。 [移行先](#Shell プラグインの移行)
-- `api::process::current_binary` および `tauri::api::process::restart` は `tauri::process` へ移動しました。
-- `api::version` モジュールは削除されました。代わりに [semver crate](https://docs.rs/semver/latest/semver/) を使用して下さい。
-- `App::clipboard_manager` および `AppHandle::clipboard_manager` は削除されました。代わりに `tauri-plugin-clipboard` を使用してください。 [移行先](#clipboard-プラグインの移行)
-- `App::get_cli_matches` は削除されました。代わりに `tauri-plugin-cli` を使用して下さい。 [移行先](#cli-プラグインの移行)
-- `App::global_shortcut_manager` および `AppHandle::global_shortcut_manager` は削除されました。代わりに `tauri-plugin-global-shortcut` を使用して下さい。 [移行先](#global-shortcut-プラグインの移行)
+- `api` モジュールは削除されました。各 API モジュールは、「Tauri プラグイン」を参照してください。
+- `api::dialog` モジュールは削除されました。代わりに「`tauri-plugin-dialog`」を使用して下さい。《[移行処置の説明はこちら](#dialog-プラグインへの移行)》
+- `api::file` モジュールは削除されました。代わりに、Rust の「[`std::fs`](https://doc.rust-lang.org/std/fs/)」を使用して下さい。
+- `api::http` モジュールは削除されました。代わりに「`tauri-plugin-http`」を使用して下さい。《[移行処置の説明はこちら](#http-プラグインへの移行)》
+- `api::ip` モジュールは書き直され、「`tauri::ipc`」に移動しました。新しい API群、特に `tauri::ipc::Channel` を確認してください。
+- `api::path` モジュール機能と `tauri::PathResolved` は 「`tauri::Manager::path`」へ移動しました。《[移行処置の説明はこちら](#tauri-manager-への-path-の移行)》
+- `api::process::Command`、`tauri::api::shell` および `tauri::Manager::shell_scope` の各 API は削除されました。代わりに 「`tauri-plugin-shell`」を使用してください。《[移行処置の説明はこちら](#Shell-プラグインへの移行)》
+- `api::process::current_binary` および `tauri::api::process::restart` は 「`tauri::process`」へ移動しました。
+- `api::version` モジュールは削除されました。代わりに「[semver crate](https://docs.rs/semver/latest/semver/)」《英語サイト》 を使用して下さい。
+- `App::clipboard_manager` および `AppHandle::clipboard_manager` は削除されました。代わりに「`tauri-plugin-clipboard`」を使用してください。《[移行処置の説明はこちら](#clipboard-プラグインへの移行)》
+- `App::get_cli_matches` は削除されました。代わりに「`tauri-plugin-cli`」を使用して下さい。《[移行処置の説明はこちら](#cli-プラグインへの移行)》
+- `App::global_shortcut_manager` および `AppHandle::global_shortcut_manager` は削除されました。代わりに「`tauri-plugin-global-shortcut`」を使用して下さい。《[移行処置の説明はこちら](#global-shortcut-プラグインへの移行)》
 - `Manager::fs_scope` は削除されました。「ファイル・システム・スコープ」は `tauri_plugin_fs::FsExt` 経由でアクセス可能です。
 - `Plugin::PluginApi` は、プラグイン設定を2番目の引数として受け取るようになりました。
-- `Plugin::setup_with_config` は削除されました。代わりに最新の `tauri::Plugin::PluginApi` を使用して下さい。
-- `scope::ipc::RemoteDomainAccessScope::enable_tauri_api` および `scope::ipc::RemoteDomainAccessScope::enables_tauri_api` は削除されました。代わりに `scope::ipc::RemoteDomainAccessScope::add_plugin` 経由で各コア・プラグインを個々に有効化してください。
-- `scope::IpcScope` は削除されました。代わりに `scope::ipc::Scope` を使用してください。
-- `scope::FsScope`、`scope::GlobPattern` および `scope::FsScopeEvent` は削除されました。それぞれ、`scope::fs::Scope`、`scope::fs::Pattern` および `scope::fs::Event` を使用して下さい。
-- `updater` モジュールは削除されました。代わりに `tauri-plugin-updater` を使用して下さい。[移行先](#updater-プラグインの移行)
-- `Env.args` フィールドは削除されました。代わりに `Env.args_os` フィールドを使用して下さい。
-- `Menu`、`MenuEvent`、`CustomMenuItem`、`Submenu`、`WindowMenuEvent`、`MenuItem` および `Builder::on_menu_event` の各 API は削除されました。[移行先](#menu-モジュールの移行)
-- `SystemTray`、`SystemTrayHandle`、`SystemTrayMenu`、`SystemTrayMenuItemHandle`、`SystemTraySubmenu`、`MenuEntry` および `SystemTrayMenuItem` の各 API は削除されました。[移行先](#tray-icon-モジュールの移行)
+- `Plugin::setup_with_config` は削除されました。代わりに最新の 「`tauri::Plugin::PluginApi`」を使用して下さい。
+- `scope::ipc::RemoteDomainAccessScope::enable_tauri_api` および `scope::ipc::RemoteDomainAccessScope::enables_tauri_api` は削除されました。代わりに `scope::ipc::RemoteDomainAccessScope::add_plugin` 経由で各コア・プラグインをそれぞれ個別に有効化してください。
+- `scope::IpcScope` は削除されました。代わりに「`scope::ipc::Scope`」を使用してください。
+- `scope::FsScope`、`scope::GlobPattern` および `scope::FsScopeEvent` は削除されました。それぞれ、「`scope::fs::Scope`」、「`scope::fs::Pattern`」 および 「`scope::fs::Event`」 を使用して下さい。
+- `updater` モジュールは削除されました。代わりに `tauri-plugin-updater` を使用して下さい。《[移行処置の説明はこちら](#updater-プラグインへの移行)》
+- `Env.args` フィールドは削除されました。代わりに「`Env.args_os`」フィールドを使用して下さい。
+- `Menu`、`MenuEvent`、`CustomMenuItem`、`Submenu`、`WindowMenuEvent`、`MenuItem` および `Builder::on_menu_event` の各 API は削除されました。《[移行処置の説明はこちら](#menu-モジュールへの移行)》
+- `SystemTray`、`SystemTrayHandle`、`SystemTrayMenu`、`SystemTrayMenuItemHandle`、`SystemTraySubmenu`、`MenuEntry` および `SystemTrayMenuItem` の各 API は削除されました。《[移行処置の説明はこちら](#tray-icon-モジュールへの移行)》
 
 ### JavaScript API の変更点
 
 `@tauri-apps/api` パッケージは、コア以外のモジュールを提供しなくなりました。これまでの `tauri` (現行では `core`)、`path`、`event`、`window` の各モジュールのみがエクスポートされます。その他はすべてプラグインに移動されました。
 
-- `@tauri-apps/api/tauri` モジュールは `@tauri-apps/api/core` に改称されました。[移行先](#コアモジュールの移行)
-- `@tauri-apps/api/cli` モジュールは削除されました。代わりに `@tauri-apps/plugin-cli` を使用して下さい。[移行先](#cli-プラグインの移行)
-- `@tauri-apps/api/clipboard` モジュールは削除されました。代わりに `@tauri-apps/plugin-clipboard` を使用して下さい。[移行先](#clipboard-プラグインの移行)
-- `@tauri-apps/api/dialog` モジュールは削除されました。代わりに `@tauri-apps/plugin-dialog` を使用して下さい。[移行先](#dialog-プラグインの移行)
-- `@tauri-apps/api/fs` モジュールは削除されました。代わりに `@tauri-apps/plugin-fs` を使用して下さい。[移行先](#file-system-プラグインの移行)
-- `@tauri-apps/api/global-shortcut` モジュールは削除されました。代わりに `@tauri-apps/plugin-global-shortcut` を使用して下さい。[移行先](#global-shortcut-プラグインの移行)
-- `@tauri-apps/api/http` モジュールは削除されました。代わりに `@tauri-apps/plugin-http` を使用してください。[移行先](#http-プラグインの移行)
-- `@tauri-apps/api/os` モジュールは削除されました。代わりに `@tauri-apps/plugin-os` を使用して下さい。[移行先](#os-プラグインの移行)
-- `@tauri-apps/api/notification` モジュールは削除されました。代わりに `@tauri-apps/plugin-notification` を使用して下さい。[移行先](#notification-プラグインの移行)
-- `@tauri-apps/api/process` モジュールは削除されました。代わりに `@tauri-apps/plugin-process` を使用して下さい。[移行先](#process-プラグインの移行)
-- `@tauri-apps/api/shell` モジュールは削除されました。代わりに `@tauri-apps/plugin-shell` を使用して下さい。[移行先](#shell-プラグインの移行)
-- `@tauri-apps/api/updater` モジュールは削除されました。代わりに `@tauri-apps/plugin-updater` を使用してください。[移行先](#updater-プラグインの移行)
-- `@tauri-apps/api/window` モジュールは `@tauri-apps/api/webviewWindow` に改称されました。[移行先](#新しい-window-api-への移行)
+- `@tauri-apps/api/tauri` モジュールは「`@tauri-apps/api/core`」に改称されました。《[移行処置の説明はこちら](#コアモジュールへの移行)》
+- `@tauri-apps/api/cli` モジュールは削除されました。代わりに「`@tauri-apps/plugin-cli`」を使用して下さい。《[移行処置の説明はこちら](#cli-プラグインへの移行)》
+- `@tauri-apps/api/clipboard` モジュールは削除されました。代わりに「`@tauri-apps/plugin-clipboard`」を使用して下さい。《[移行処置の説明はこちら](#clipboard-プラグインへの移行)》
+- `@tauri-apps/api/dialog` モジュールは削除されました。代わりに「`@tauri-apps/plugin-dialog`」を使用して下さい。《[移行処置の説明はこちら](#dialog-プラグインへの移行)》
+- `@tauri-apps/api/fs` モジュールは削除されました。代わりに「`@tauri-apps/plugin-fs`」を使用して下さい。《[移行処置の説明はこちら](#file-system-プラグインへの移行)》
+- `@tauri-apps/api/global-shortcut` モジュールは削除されました。代わりに「`@tauri-apps/plugin-global-shortcut`」を使用して下さい。《[移行処置の説明はこちら](#global-shortcut-プラグインへの移行)》
+- `@tauri-apps/api/http` モジュールは削除されました。代わりに「`@tauri-apps/plugin-http`」を使用してください。《[移行処置の説明はこちら](#http-プラグインへの移行)》
+- `@tauri-apps/api/os` モジュールは削除されました。代わりに「`@tauri-apps/plugin-os`」を使用して下さい。《[移行処置の説明はこちら](#os-プラグインへの移行)》
+- `@tauri-apps/api/notification` モジュールは削除されました。代わりに「`@tauri-apps/plugin-notification`」を使用して下さい。《[移行処置の説明はこちら](#notification-プラグインへの移行)》
+- `@tauri-apps/api/process` モジュールは削除されました。代わりに「`@tauri-apps/plugin-process`」を使用して下さい。《[移行処置の説明はこちら](#process-プラグインへの移行)》
+- `@tauri-apps/api/shell` モジュールは削除されました。代わりに「`@tauri-apps/plugin-shell`」を使用して下さい。《[移行処置の説明はこちら](#shell-プラグインへの移行)》
+- `@tauri-apps/api/updater` モジュールは削除されました。代わりに「`@tauri-apps/plugin-updater`」を使用してください。《[移行処置の説明はこちら](#updater-プラグインへの移行)》
+- `@tauri-apps/api/window` モジュールは「`@tauri-apps/api/webviewWindow`」に改称されました。《[移行処置の説明はこちら](#新しい-window-api-への移行)》
 
 バージョン 1 のプラグインは、`@tauri-apps/plugin-<plugin-name>` として公開されています。これは、以前には git から `tauri-plugin-<plugin-name>-api` として入手可能だったものです。
 
@@ -185,39 +198,41 @@ Tauri CLI によって読み書きされる環境変数のほとんどは、整�
 
 「イベント・システム」は、より使いやすくなるように再設計されました。イベント・ソースにではなく、イベント・ターゲットに依拠する、より簡潔な実装になっています。
 
-- `emit` 機能は、すべてのイベント・リスナーにイベントを発するようになりました。
-- 特定のターゲットにイベントを発生させる、新しい `emit_to` 機能を追加しました。
-- `emit_filter` は、ウィンドウではなく、[`EventTarget`](https://docs.rs/tauri/2.0.0/tauri/event/enum.EventTarget.html) に基づいてフィルタリングするようになりました。
-- `listen_global` を `listen_any` に改称。フィルターやターゲットに関係なく、すべてのイベントの応答を待機するようになりました。
+- 「`emit` 機能」は、すべてのイベント・リスナーにイベントを発するようになりました。
+- 特定のターゲットにイベントを発生させる、新しい「`emit_to`/`emitTo` 機能」が追加されました。
+- 「`emit_filter`」は、ウィンドウではなく、「[`EventTarget`](https://docs.rs/tauri/2.0.0/tauri/event/enum.EventTarget.html)」に基づいてフィルタリングするようになりました。
+- `listen_global` を「`listen_any`」に改称。フィルターやターゲットに関係なく、すべてのイベントの応答を待機（リッスン）するようになりました。
+- JavaScript： `event.listen()` は `listen_any` と同様の動作をします。`Options` でターゲットが設定されていない限り、フィルターやターゲットに関係なくすべてのイベントを応答待機（リッスン）します。
+- JavaScript： `WebviewWindow.listen`などは、それぞれの`EventTarget`に発信されたイベントのみ応答待機（リッスン）します。
 
 ### マルチウェブビューのサポート
 
 Tauri バージョン 2 では、現在、`unstable` 機能フラグの下に置かれている「マルチウェブビュー multiwebview」へのサポートが導入されました。
-この機能を導入するため、Rust の `Window` 型を `WebviewWindow` へ、Manager の `get_window` 機能を `get_webview_window` へ、それぞれ改称しました。
+この機能を導入するため、Rust の `Window` 型は「`WebviewWindow`」に、Manager の `get_window` 機能は「`get_webview_window`」に、それぞれ改称されました。
 
-`WebviewWindow` JS API タイプは、`@tauri-apps/api/window` ではなく、`@tauri-apps/api/webviewWindow` から再エクスポートされるようになりました。
+`WebviewWindow` JS API タイプは、`@tauri-apps/api/window` ではなく、「`@tauri-apps/api/webviewWindow`」から再エクスポートされるようになりました。
 
 ### Windows での新しい配信元 URL
 
-Windows では、本番公開アプリのフロントエンド・ファイルは、`https://tauri.localhost` ではなく `http://tauri.localhost` でホストされるようになりました。このため、バージョン 1 で `dangerousUseHttpScheme` が使用されていない限り、「IndexedDB」、「LocalStorage」、および 「Cookies」はリセットされます。これを防ぐには、`app > windows > useHttpsScheme` を `true` に設定するか、`WebviewWindowBuilder::use_https_scheme` を使用して `https` 方式を引き続き使用してください。
+Windows では、本番公開アプリのフロントエンド・ファイルは、`https://tauri.localhost` ではなく「`http://tauri.localhost`」でホストされるようになりました。このため、バージョン 1 で `dangerousUseHttpScheme` が使用されていない限り、「IndexedDB」、「LocalStorage」、および 「Cookies」はリセットされます。これを防ぐには、`app > windows > useHttpsScheme` を「`true` に設定」するか、`WebviewWindowBuilder::use_https_scheme` を使用して `https` 方式を引き続き使用してください。
 
 ## 移行手順の詳細
 
-Tauri 1.0 アプリを Tauri 2.0 に移行する場合に発生する可能性のある一般的な流れです。
+Tauri 1.0 アプリを Tauri 2.0 に移行する場合に発生する可能性のある一般的な移行処理の流れです。
 
-### コア・モジュールの移行
+### コア・モジュールへの移行
 
-`@tauri-apps/api/tauri` モジュールは、 `@tauri-apps/api/core` に改称されています。
-ここでの作業は、モジュール・インポート時の名称を変更するだけです:
+`@tauri-apps/api/tauri` モジュールは、 「`@tauri-apps/api/core`」に改称されています。
+ここでの作業は、モジュール・インポート文を変更するだけです:
 
 ```diff
 - import { invoke } from "@tauri-apps/api/tauri"
 + import { invoke } from "@tauri-apps/api/core"
 ```
 
-### CLI プラグインの移行
+### CLI プラグインへの移行
 
-Rust の `App::get_cli_matches` および JavaScript の `@tauri-apps/api/cli` API削除されました。代わりにプラグインの `@tauri-apps/plugin-cli` を使用して下さい：
+Rust の `App::get_cli_matches` API と JavaScript の `@tauri-apps/api/cli` API は削除されました。代わりに「`@tauri-apps/plugin-cli` プラグイン」を使用して下さい：
 
 1. Cargo に依存関係を追加します：
 
@@ -227,7 +242,7 @@ Rust の `App::get_cli_matches` および JavaScript の `@tauri-apps/api/cli` A
 tauri-plugin-cli = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -271,9 +286,9 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Clipboard プラグインの移行
+### Clipboard プラグインへの移行
 
-Rust の `App::clipboard_manager` と `AppHandle::clipboard_manager`、および JavaScript の `@tauri-apps/api/clipboard` API は削除されました。代わりに `@tauri-apps/plugin-clipboard-manager` プラグインを使用して下さい：
+Rust の `App::clipboard_manager` API と `AppHandle::clipboard_manager` API、および JavaScript の `@tauri-apps/api/clipboard` API は削除されました。代わりに「`@tauri-apps/plugin-clipboard-manager` プラグイン」を使用して下さい：
 
 ```toml
 [dependencies]
@@ -324,11 +339,11 @@ tauri::Builder::default()
 </TabItem>
 </Tabs>
 
-### Dialog プラグインの移行
+### Dialog プラグインへの移行
 
-Rust の `tauri::api::dialog` および JavaScript の `@tauri-apps/api/dialog` API は削除されました。代わりに `@tauri-apps/plugin-dialog` プラグインを使用してください：
+Rust の `tauri::api::dialog` API と JavaScript の `@tauri-apps/api/dialog` API は削除されました。代わりに「`@tauri-apps/plugin-dialog` プラグイン」を使用してください：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -336,7 +351,7 @@ Rust の `tauri::api::dialog` および JavaScript の `@tauri-apps/api/dialog` 
 tauri-plugin-dialog = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -378,8 +393,8 @@ tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
     .setup(|app| {
         app.dialog().file().pick_file(|file_path| {
-            // do something with the optional file path here
-            // the file path is `None` if the user closed the dialog
+            // ここにオプションのファイルパスを使った処理を記述
+            // ユーザーがダイアログを閉じた場合、ファイルパスは「None」になります
         });
 
         app.dialog().message("Tauri is Awesome!").show();
@@ -390,11 +405,11 @@ tauri::Builder::default()
 </TabItem>
 </Tabs>
 
-### File System プラグインの移行
+### File System プラグインへの移行
 
-Rust の `App::get_cli_matches` および `@tauri-apps/api/fs` API は削除されました。代わりに、Rust には [`std::fs`](https://doc.rust-lang.org/std/fs/) を、JavaScript には `@tauri-apps/plugin-fs` プラグインを使用してください：
+Rust の `App::get_cli_matches` API と JavaScript の `@tauri-apps/api/fs` API は削除されました。代わりに、Rust には「[`std::fs`](https://doc.rust-lang.org/std/fs/)」を、JavaScript には「`@tauri-apps/plugin-fs` プラグイン」を使用してください：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -402,7 +417,7 @@ Rust の `App::get_cli_matches` および `@tauri-apps/api/fs` API は削除さ�
 tauri-plugin-fs = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -430,28 +445,28 @@ await mkdir('db', { baseDir: BaseDirectory.AppLocalData });
 
 いくつかの関数と型が改称または削除されています：
 
-- `Dir` enum エイリアス（列挙型・別名）は削除されました。 `BaseDirectory` を使用して下さい。
+- `Dir` enum エイリアス（列挙型・別名）は削除されました。「`BaseDirectory`」を使用して下さい。
 - `FileEntry`、`FsBinaryFileOption`、`FsDirOptions`、`FsOptions`、`FsTextFileOption`、および `BinaryFileContents` のインターフェースと型エイリアスは削除され、各関数に適した新しいインターフェースに置き換えられました。
-- `createDir` は `mkdir` に改称されました。
-- `readBinaryFile` は `readFile` に改称されました。
-- `removeDir` は削除され、`remove` に置き換えられました。
-- `removeFile` は削除され、`remove` に置き換えられました。
-- `renameFile` は削除され、`rename` に置き換えられました。
-- `writeBinaryFile` は `writeFile` に改称されました。
+- `createDir` は「`mkdir`」に改称されました。
+- `readBinaryFile` は「`readFile`」に改称されました。
+- `removeDir` は削除され、「`remove`」に置き換えられました。
+- `removeFile` は削除され、「`remove`」に置き換えられました。
+- `renameFile` は削除され、「`rename`」に置き換えられました。
+- `writeBinaryFile` は「`writeFile`」に改称されました。
 
 </TabItem>
 <TabItem label="Rust">
 
-Rust の [`std::fs`](https://doc.rust-lang.org/std/fs/) 関数を使用して下さい。
+Rust では [`std::fs`](https://doc.rust-lang.org/std/fs/) 関数を使用して下さい。
 
 </TabItem>
 </Tabs>
 
-### Global Shortcut プラグインの移行
+### Global Shortcut プラグインへの移行
 
-Rust の `App::global_shortcut_manager` と `AppHandle::global_shortcut_manager` および JavaScript の `@tauri-apps/api/global-shortcut` API は削除されました。代わりに `@tauri-apps/plugin-global-shortcut` プラグインを使用して下さい：
+Rust の `App::global_shortcut_manager` API と `AppHandle::global_shortcut_manager` API、および JavaScript の `@tauri-apps/api/global-shortcut` API は削除されました。代わりに「`@tauri-apps/plugin-global-shortcut`」プラグインを使用して下さい：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -460,7 +475,7 @@ Rust の `App::global_shortcut_manager` と `AppHandle::global_shortcut_manager`
 tauri-plugin-global-shortcut = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -502,9 +517,9 @@ tauri::Builder::default()
         .build(),
     )
     .setup(|app| {
-        // register a global shortcut
-        // on macOS, the Cmd key is used
-        // on Windows and Linux, the Ctrl key is used
+        // グローバルショートカットを登録
+        // macOS では、Cmd キーが用いられます
+        // Windows と Linux では、 Ctrl キーが用いられます
         app.global_shortcut().register("CmdOrCtrl+Y")?;
         Ok(())
     })
@@ -513,11 +528,11 @@ tauri::Builder::default()
 </TabItem>
 </Tabs>
 
-### HTTP プラグインの移行
+### HTTP プラグインへの移行
 
-Rust の `tauri::api::http` および JavaScript の `@tauri-apps/api/http` API は削除されました。代わりに `@tauri-apps/plugin-http` プラグイン を使用して下さい。
+Rust の `tauri::api::http` および JavaScript の `@tauri-apps/api/http` API は削除されました。代わりに「`@tauri-apps/plugin-http` プラグイン」を使用して下さい。
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -525,7 +540,7 @@ Rust の `tauri::api::http` および JavaScript の `@tauri-apps/api/http` API 
 tauri-plugin-http = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -574,16 +589,16 @@ tauri::Builder::default()
     })
 ```
 
-HTTP プラグインは [reqwest](https://docs.rs/reqwest/latest/reqwest/) を再エクスポートします。詳細については「reqwest」のドキュメントを確認して下さい。
+HTTP プラグインは「reqwest」を再エクスポートします。詳細については [reqwest](https://docs.rs/reqwest/latest/reqwest/) のドキュメント《英語版》を確認して下さい。
 
 </TabItem>
 </Tabs>
 
-### Notification プラグインの移行
+### Notification プラグインへの移行
 
-Rust の `tauri::api::notification` および JavaScript の `@tauri-apps/api/notification` API は削除されました。代わりに `@tauri-apps/plugin-notification` プラグインを使用して下さい：
+Rust の `tauri::api::notification` API および JavaScript の `@tauri-apps/api/notification` API は削除されました。代わりに「`@tauri-apps/plugin-notification` プラグイン」を使用して下さい：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -591,7 +606,7 @@ Rust の `tauri::api::notification` および JavaScript の `@tauri-apps/api/no
 tauri-plugin-notification = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -645,13 +660,13 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Menu モジュールの移行
+### Menu モジュールへの移行
 
 Rust の `Menu` API は `tauri::menu` モジュールに移動され、[muda クレート](https://github.com/tauri-apps/muda) を使用するようにリファクタリング（最適化）されました。
 
 #### `tauri::menu::MenuBuilder` の使用
 
-`tauri::Menu` ではなく、`tauri::menu::MenuBuilder` を使用して下さい。このコンストラクターは、引数として Manager インスタンス（`App`、`AppHandle`、`WebviewWindow` のいずれか）を受け取ることに注意してください。
+`tauri::Menu` ではなく、「`tauri::menu::MenuBuilder`」を使用して下さい。このコンストラクターは、引数として Manager インスタンス（`App`、`AppHandle`、`WebviewWindow` のいずれか）を受け取ることに注意してください。
 
 ```rust
 use tauri::menu::MenuBuilder;
@@ -674,7 +689,7 @@ tauri::Builder::default()
 
 #### `tauri::menu::PredefinedMenuItem` の使用
 
-`tauri::MenuItem` ではなく、`tauri::menu::PredefinedMenuItem` を使用して下さい。
+`tauri::MenuItem` ではなく、「`tauri::menu::PredefinedMenuItem`」を使用して下さい。
 
 ```rust
 use tauri::menu::{MenuBuilder, PredefinedMenuItem};
@@ -687,12 +702,12 @@ tauri::Builder::default()
 ```
 
 :::tip
-メニュー・ビルダーには、定義済みメニュー項目を追加可能な専用メソッドが用意されているため、`.item(&PredefinedMenuItem::copy(app, None)?)` の代わりに `.copy()` を呼び出すことができます。
+メニュー・ビルダーには、定義済みメニュー項目を追加可能な専用メソッドが用意されているため、`.item(&PredefinedMenuItem::copy(app, None)?)` の代わりに「`.copy()`」を呼び出すことができます。
 :::
 
 #### `tauri::menu::MenuItemBuilder` の使用
 
-`tauri::CustomMenuItem` の代わりに `tauri::menu::MenuItemBuilder` を使用します：
+`tauri::CustomMenuItem` の代わりに「`tauri::menu::MenuItemBuilder`」を使用します：
 
 ```rust
 use tauri::menu::MenuItemBuilder;
@@ -706,7 +721,7 @@ tauri::Builder::default()
 
 #### `tauri::menu::SubmenuBuilder` の使用
 
-`tauri::Submenu` の代わりに `tauri::menu::SubmenuBuilder` を使用します：
+`tauri::Submenu` の代わりに「`tauri::menu::SubmenuBuilder`」を使用します：
 
 ```rust
 use tauri::menu::{MenuBuilder, SubmenuBuilder};
@@ -723,11 +738,11 @@ tauri::Builder::default()
     })
 ```
 
-`tauri::Builder::menu` は、メニューを構築するために Manager インスタンスが必要であるため、クロージャを受け取るようになりました。詳しくは、[ドキュメント（関連文書）](https://docs.rs/tauri/2.0.0/tauri/struct.Builder.html#method.menu) を参照して下さい。
+`tauri::Builder::menu` は、メニュー処理に Manager インスタンスの構築を必要とするため、「クロージャ closure」を受け取ります。詳しくは、[ドキュメント（関連文書）《英語版》](https://docs.rs/tauri/2.0.0/tauri/struct.Builder.html#method.menu) を参照して下さい。
 
 #### Menu Events（メニュー・イベント）
 
-Rust の `tauri::Builder::on_menu_event` API は削除されました。代わりに `tauri::App::on_menu_event` または `tauri::AppHandle::on_menu_event` を使用して下さい：
+Rust の `tauri::Builder::on_menu_event` API は削除されました。代わりに「`tauri::App::on_menu_event`」または「`tauri::AppHandle::on_menu_event`」を使用して下さい：
 
 ```rust
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder};
@@ -751,18 +766,18 @@ tauri::Builder::default()
     })
 ```
 
-注意：　どのメニュー項目が選択されたのかを確認する方法には二通りあります。ひとつは「項目」をイベント・ハンドラー・クロージャーに移動して ID を比較するやりかた、もうひとつは「項目」を `with_id` コンストラクターを通してカスタム ID を定義し、その ID 文字列を用いて比較するやりかたです。ご注意下さい。
+注意：　どのメニュー項目が選択されたのかを確認する方法には二通りあることに注意してください。ひとつは「項目」をイベント・ハンドラー・クロージャーに移動して ID を比較するやりかた、もうひとつは「項目」を `with_id` コンストラクターを通してカスタム ID を定義し、その ID 文字列を用いて比較するやりかたです。
 
 :::tip
 メニュー項目はメニュー間で共有でき、メニュー・イベントは、メニューやウィンドウではなく、メニュー項目にバインドされます。
 メニュー項目が選択された際にすべてのリスナーがトリガーされないようにしたい場合には、メニュー項目を共有せず、代わりに専用のインスタンスを使用してください。これにより、`tauri::WebviewWindow/WebviewWindowBuilder::on_menu_event` クロージャーに移動できます。
 :::
 
-### OS プラグインの移行
+### OS プラグインへの移行
 
-Rust の `tauri::api::os` および JavaScript の `@tauri-apps/api/os` API は削除されました。代わりに `@tauri-apps/plugin-os` プラグインを使用して下さい：
+Rust の `tauri::api::os` API と JavaScript の `@tauri-apps/api/os` API は削除されました。代わりに「`@tauri-apps/plugin-os` プラグイン」を使用して下さい：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -770,7 +785,7 @@ Rust の `tauri::api::os` および JavaScript の `@tauri-apps/api/os` API は�
 tauri-plugin-os = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -813,11 +828,11 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Process プラグインの移行
+### Process プラグインへの移行
 
-Rust の `tauri::api::process` および JavaScript の `@tauri-apps/api/process` API は削除されました。代わりに `@tauri-apps/plugin-process` プラグイン を使用して下さい：
+Rust の `tauri::api::process` API および JavaScript の `@tauri-apps/api/process` API は削除されました。代わりに「`@tauri-apps/plugin-process` プラグイン」を使用して下さい：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -825,7 +840,7 @@ Rust の `tauri::api::process` および JavaScript の `@tauri-apps/api/process
 tauri-plugin-process = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -860,9 +875,9 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
-            // exit the app with a status code
+            // ステータス・コードを表示してアプリを終了
             app.handle().exit(1);
-            // restart the app
+            // アプリを再起動
             app.handle().restart();
             Ok(())
         })
@@ -872,11 +887,11 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Shell プラグインの移行
+### Shell プラグインへの移行
 
-Rust の `tauri::api::shell` および JavaScript の `@tauri-apps/api/shell` API は削除されました。代わりに `@tauri-apps/plugin-shell` プラグインを使用して下さい：
+Rust の `tauri::api::shell` API および JavaScript の `@tauri-apps/api/shell` API は削除されました。代わりに「`@tauri-apps/plugin-shell` プラグイン」を使用して下さい：
 
-1. Cargo へ依存関係を追加します：
+1. Cargo へ依存関係を追加：
 
 ```toml
 # Cargo.toml
@@ -884,7 +899,7 @@ Rust の `tauri::api::shell` および JavaScript の `@tauri-apps/api/shell` AP
 tauri-plugin-shell = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -999,27 +1014,27 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Tray Icon モジュールの移行
+### Tray Icon モジュールへの移行
 
 Rust の `SystemTray` API は表記の一貫性確保のために `TrayIcon` に改称されています。新しい API は、Rust の「`tray` モジュール」で参照できます。
 
 #### `tauri::tray::TrayIconBuilder` の使用
 
-`tauri::SystemTray` の代わりに `tauri::tray::TrayIconBuilder` を使用して下さい。
+`tauri::SystemTray` の代わりに「`tauri::tray::TrayIconBuilder`」を使用して下さい。
 
 ```rust
 let tray = tauri::tray::TrayIconBuilder::with_id("my-tray").build(app)?;
 ```
 
-詳しくは [TrayIconBuilder](https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html) の項を参照して下さい。
+詳しくは [TrayIconBuilder《英語版文書》](https://docs.rs/tauri/2.0.0/tauri/tray/struct.TrayIconBuilder.html) の項を参照して下さい。
 
-#### Menu の移行
+#### Menu への移行
 
-`tauri::SystemTrayMenu` ではなく `tauri::menu::Menu` を、`tauri::SystemTraySubmenu` ではなく `tauri::menu::Submenu` を、そして　`tauri::SystemTrayMenuItem` の代わりには `tauri::menu::PredefinedMenuItem` を使用して下さい。
+`tauri::SystemTrayMenu` ではなく「`tauri::menu::Menu`」を、`tauri::SystemTraySubmenu` ではなく「`tauri::menu::Submenu`」を、そして　`tauri::SystemTrayMenuItem` の代わりには「`tauri::menu::PredefinedMenuItem`」を使用して下さい。
 
 #### Tray Events（トレイ・イベント）
 
-`tauri::SystemTray::on_event` は `tauri::tray::TrayIconBuilder::on_menu_event` と `tauri::tray::TrayIconBuilder::on_tray_icon_event` とに分割されました：
+`tauri::SystemTray::on_event` は「`tauri::tray::TrayIconBuilder::on_menu_event`」と「`tauri::tray::TrayIconBuilder::on_tray_icon_event`」とに分割されました：
 
 ```rust
 use tauri::{
@@ -1060,20 +1075,24 @@ tauri::Builder::default()
     })
 ```
 
-### Updater プラグインの移行
+### Updater プラグインへの移行
 
-自動更新チェック機能を備えた組み込みダイアログは削除されました。代わりに、Rust および JavaScript API を使用し、更新のチェックおよびインストールを行なってください。
+:::caution[デフォルト動作の変更]
 
-Rust の `tauri::updater` および JavaScript の `@tauri-apps/api-updater` API は削除されました。`@tauri-apps/plugin-updater` を使用してカスタム・アップデーター・ターゲットを設定するには：
+自動更新チェック機能を備えた組み込みダイアログは削除されました。代わりに、Rust API および JavaScript API を使用して、更新のチェックおよびインストールを行なうようにしてください。これを行なわないと、あなたのユーザーが今後のアップデートを受け取ることができなくなります！
 
-1. Cargo へ依存関係を追加します：
+:::
+
+Rust の `tauri::updater` API および JavaScript の `@tauri-apps/api-updater` API は削除されました。「`@tauri-apps/plugin-updater`」を使用してカスタム・アップデーター・ターゲットを設定するには：
+
+1. Cargo へ依存関係を追加：
 
 ```toml
 [dependencies]
 tauri-plugin-updater = "2"
 ```
 
-2. JavaScript または Rust のプロジェクトで使用します：
+2. JavaScript または Rust のプロジェクトでの使用：
 
 <Tabs syncKey="lang">
 <TabItem label="JavaScript">
@@ -1103,7 +1122,7 @@ if (update?.available) {
   console.log(`Update to ${update.version} available! Date: ${update.date}`);
   console.log(`Release notes: ${update.body}`);
   await update.downloadAndInstall();
-  // requires the `process` plugin
+  // `process`プラグインが必要です
   await relaunch();
 }
 ```
@@ -1146,9 +1165,9 @@ fn main() {
 </TabItem>
 </Tabs>
 
-### Path to Tauri Manager の移行
+### Tauri Manager への Path の移行
 
-Rust の `tauri::api::path` モジュール機能および `tauri::PathResolver` は `tauri::Manager::path` に移動されました：
+Rust の `tauri::api::path` モジュール機能および `tauri::PathResolver` は「`tauri::Manager::path`」に移動されました：
 
 ```rust
 use tauri::{path::BaseDirectory, Manager};
@@ -1165,9 +1184,9 @@ tauri::Builder::default()
 
 ### 新しい Window API への移行
 
-Rust 関連では、`Window` の名称が `WebviewWindow` に、そのビルダー名 `WindowBuilder` が `WebviewWindowBuilder` に、`WindowUrl` の名称が `WebviewUrl` に変更されました。
+Rust 関連では、`Window` の名称が「`WebviewWindow`」に、そのビルダー名 `WindowBuilder` が「`WebviewWindowBuilder`」に、`WindowUrl` の名称が「`WebviewUrl`」に変更されました。
 
-さらには、上位の「ウィンドウ 親 API」をサポートするために、`Manager::get_window` 関数は `get_webview_window`に、ウィンドウズの `parent_window` API が `parent_raw` に改称されています。
+さらには、上位の「ウィンドウ 親 API」をサポートするために、`Manager::get_window` 関数は「`get_webview_window`」に、ウィンドウズの `parent_window` API が「`parent_raw`」に改称されています。
 
 JavaScript 関連では、`WebviewWindow` クラスが `@tauri-apps/api/webviewWindow` パスにエクスポートされるようになりました。
 
@@ -1175,34 +1194,33 @@ JavaScript 関連では、`WebviewWindow` クラスが `@tauri-apps/api/webviewW
 
 ### 埋め込み追加ファイルの移行（リソース）
 
-JavaScript 関連では、[File System プラグインの移行](#file-system-プラグインの移行) を実行することを忘れないでください。
-さらに、[許可の移行](#許可の移行) の項で、「バージョン 1」許可リストに加えられた変更の内容にも注意してください。
+JavaScript 関連では、[File System プラグインへの移行](#file-system-プラグインへの移行) を忘れずに実施してください。
+さらに、下記の [アクセス権の移行](#アクセス権の移行) の項で、「バージョン 1」許可リストに加えられた変更内容にも注意してください。
 
-Rust 関連では、[Path to Tauri Manger の移行](#path-to-tauri-manager-の移行) の説明内容を必ず実行してください。
+Rust 関連では、[Tauri Manger への Path の移行](#tauri-manager-への-path-の移行) を必ず実行してください。
 
 ### 埋め込み外部バイナリの移行（サイドカー・コンテナ）
 
-Tauri バージョン 1（v1）では、外部バイナリとその引数は許可リストで定義されていました。バージョン 2（v2）では、新しい許可システムを使用します。詳細については、[許可の移行](#許可の移行) を参照してください。
+Tauri バージョン 1（v1）では、外部バイナリとその引数はアクセス許可リストで定義されていました。バージョン 2（v2）では、新しいアクセス許可システムを使用します。詳細については、[アクセス権の移行](#アクセス権の移行) の項を参照してください。
 
-JavaScript 関連では、[Shell プラグインの移行](#shell-プラグインの移行) の内容を必ず実行して下さい。
+JavaScript 関連では、[Shell プラグインへの移行](#shell-プラグインへの移行) を必ず実行して下さい。
 
-Rust 関連では、`tauri::api::process` API が削除されています。代わりに `tauri_plugin_shell::ShellExt` および `tauri_plugin_shell::process::CommandEvent` API を使用してください。使用法については、[外部バイナリの埋め込み](/ja/develop/sidecar/#rust-から実行する) ガイドを参照して下さい。
+Rust 関連では、`tauri::api::process` API が削除されています。代わりに「
+`tauri_plugin_shell::ShellExt` API」および「`tauri_plugin_shell::process::CommandEvent` API」を使用してください。使用法については、「[外部バイナリの埋め込み](/ja/develop/sidecar/#rust-から実行する)」ガイドの章を参照して下さい。
 
-「process-command-api」機能フラグは バージョン 2（v2）で削除されました。そのため、外部バイナリの実行に、この機能を Tauri 構成で定義する必要がなくなりました。
+「process-command-api」機能フラグは バージョン 2（v2）で削除されましたので、外部バイナリの実行に際して、この機能を Tauri 設定で定義しておく必要がなくなりました。
 
-### 許可の移行
+### アクセス権の移行
 
-バージョン 1 の許可リスト（「v1 許可リスト」）は、全く新しい許可システムに書き直されました。これにより、個々のプラグインで機能し、「マルチウィンドウ」と「リモート URL サポート」で、より柔軟な設定が可能になりました。
-この新しい許可システムはアクセス制御リスト (ACL) のように機能し、コマンドの許可／拒否、特定のウィンドウとドメインのセットへの許可割り当て、アクセス範囲の定義などを行なえます。
+バージョン 1 のアクセス許可リスト（「v1 許可リスト」）は、全く新しいアクセス許可システムに書き直されました。これにより、個々のプラグインで機能し、「マルチウィンドウ」と「リモート URL サポート」で、より柔軟な設定が可能になりました。
+この新しいアクセス許可システムは「アクセス制御リスト（ACL）」のように機能し、コマンドの許可／拒否、特定のウィンドウやドメインの組合せに対する許可割り当て、アクセス範囲の定義などが行なえます。
 
-アプリへの許可を設定するには、`src-tauri/capabilities` フォルダ内に「機能ファイル（capability file）」を作成します。そうすると、Tauri があなたに代わって他のすべてを自動的に設定します。
+自分のアプリへのアクセス権を設定するには、`src-tauri/capabilities` フォルダ内に「機能設定ファイル（capability file）」を作成します。すると、Tauri があなたに代わって他のすべてを自動的に設定します。
 
-`migrate` CLI コマンドは、v1 許可リストを自動的に解析し、関連する機能ファイルを生成します。
+`migrate` CLI コマンドは、「v1 許可リスト」を自動的に解析し、関連する機能設定ファイルを生成します。
 
-許可と機能の詳細については、[セキュリティ関連文書](/ja/security/)を参照してください。
+アクセス許可と機能の詳細については、「[セキュリティ関連文書](/ja/security/)」を参照してください。
 
 <div style="text-align: right;">
-  【※ この日本語版は、「Nov 13, 2024 英語版」に基づいています】
-  <br />
-  Doc-JP 2.00.00
+  【※ この日本語版は、「Jun 15, 2026 英語版」に基づいています】
 </div>

--- a/src/content/docs/ja/start/migrate/index.mdx
+++ b/src/content/docs/ja/start/migrate/index.mdx
@@ -3,6 +3,7 @@ title: アップグレード ＆ 移行
 sidebar:
   label: Overview
   order: 10
+i18nReady: true
 ---
 
 Tauri 1.0 からのアップグレードや、他のフレームワークから移行するための一般的なシナリオと手順について説明します。
@@ -23,7 +24,5 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 </CardGrid>
 
 <div style="text-align: right;">
-  【※ この日本語版は、「Oct 01, 2024 英語版」に基づいています】
-  <br />
-  Doc-JP 2.00.00
+  【※ この日本語版は、「Feb 22, 2025 英語版」に基づいています】
 </div>


### PR DESCRIPTION
#### Description

"i18n(ja): Update two ja files in /start/migrate/ section -->
- start/migrate/index.mdx file:
  - add: `i18nReady` flag 
- start/migrate/from-tauri-1.mdx file:
  - Reflected changes in PR#3889 such as addition of `:::danger:::` & `:::caution:::` tags
  - Brushed-up/rephrased ja texts for better readability.

EOM
