### PR TITLE
docs: remove duplicated words in plugin pages

### DIFF
--- a/src/content/docs/plugin/file-system.mdx
+++ b/src/content/docs/plugin/file-system.mdx
@@ -724,7 +724,7 @@ To apply a scope to any `fs` command, use the `fs:scope` permission:
 ```
 
 To apply a scope to a specific `fs` command,
-use the the object form of permissions `{ "identifier": string, "allow"?: [], "deny"?: [] }`:
+use the object form of permissions `{ "identifier": string, "allow"?: [], "deny"?: [] }`:
 
 ```json title="src-tauri/capabilities/default.json" {7-18}
 {

--- a/src/content/docs/plugin/single-instance.mdx
+++ b/src/content/docs/plugin/single-instance.mdx
@@ -136,7 +136,7 @@ Here's a guide that shows how to declare the needed permissions to enable the Si
 
 The Single Instance plugin will publish a service named `org.{id}.SingleInstance`.
 
-`{id}` will be the `identifier` from your `tauri.conf.json` file, but with with dots (`.`) and dashes (`-`) replaced by underline (`_`).
+`{id}` will be the `identifier` from your `tauri.conf.json` file, but with dots (`.`) and dashes (`-`) replaced by underline (`_`).
 
 For example, if your identifier is `net.mydomain.MyApp`:
 


### PR DESCRIPTION
## Summary

Remove duplicated words in plugin documentation pages.

| File | Fix |
|------|-----|
| src/content/docs/plugin/single-instance.mdx | "with with" → "with" |
| src/content/docs/plugin/file-system.mdx | "the the" → "the" |

## Test plan

- [x] Verified each duplicated word was present before editing
- [x] Residual scan clean on changed files
