### PR TITLE
docs: fix typos in several guides

### DIFF
--- a/src/content/docs/develop/Debug/neovim.mdx
+++ b/src/content/docs/develop/Debug/neovim.mdx
@@ -43,7 +43,7 @@ dap.configurations.rust= {
 }
 ```
 
-This setup will ask you to point to the Tauri App binary you want to debug each time you lanuch the debugger.
+This setup will ask you to point to the Tauri App binary you want to debug each time you launch the debugger.
 
 Optionally, you can setup `nvim-dap-ui` plugin to toggle debugger view automatically each time debugging session starts and stops:
 

--- a/src/content/docs/learn/sidecar-nodejs.mdx
+++ b/src/content/docs/learn/sidecar-nodejs.mdx
@@ -78,7 +78,7 @@ Without the plugin being initialized and configured the example won't work.
 
     Now we can start writing JavaScript code that will be executed by our Tauri application.
 
-    In this example we will process a command from the command line argmuents and write output to stdout,
+    In this example we will process a command from the command line arguments and write output to stdout,
     which means our process will be short lived and only handle a single command at a time.
     If your application must be long lived, consider using alternative inter-process communication systems.
 

--- a/src/content/docs/security/capabilities.mdx
+++ b/src/content/docs/security/capabilities.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 ---
 
 Tauri provides application and plugin developers with a capabilities system,
-to granually enable and constrain the core exposure to the application frontend running in the
+to granularly enable and constrain the core exposure to the application frontend running in the
 system WebView.
 
 Capabilities define which [permissions](/security/permissions/)
@@ -192,7 +192,7 @@ _What does it protect against?_
 Depending on the permissions and capabilities it is able to:
 
 - Minimize impact of frontend compromise
-- Prevent or reduce (accidential) exposure of local system interfaces and data
+- Prevent or reduce (accidental) exposure of local system interfaces and data
 - Prevent or reduce possible privilege escalation from frontend to backend/system
 
 _What does it **not** protect against?_

--- a/src/content/docs/security/lifecycle.mdx
+++ b/src/content/docs/security/lifecycle.mdx
@@ -120,10 +120,10 @@ If you are working like the majority of developers, using source code version co
 service providers is an essential step during development.
 
 To ensure that your source code can not be modified by unauthorized actors it is important
-to understand and correctly set up up access control for your source code version control system.
+to understand and correctly set up access control for your source code version control system.
 
 Also, consider requiring all (regular) contributors to sign their commits to prevent situations where malicious
-commits are attributed to non-compromised or non-maliocious contributors.
+commits are attributed to non-compromised or non-malicious contributors.
 
 ## Buildtime Threats
 


### PR DESCRIPTION
#### Description

Fixes a few typos in the English docs (misspellings and one duplicated word):

- `security/capabilities.mdx`: "granually" to "granularly", "accidential" to "accidental"
- `security/lifecycle.mdx`: "set up up" to "set up", "maliocious" to "malicious"
- `learn/sidecar-nodejs.mdx`: "argmuents" to "arguments"
- `develop/Debug/neovim.mdx`: "lanuch" to "launch"

Content and behavior are unchanged.
