### PR TITLE
fix renovate and submodule updates

### DIFF
--- a/.github/workflows/refresh-releases.yml
+++ b/.github/workflows/refresh-releases.yml
@@ -81,7 +81,7 @@ jobs:
       # PR also triggers CI checks, which GITHUB_TOKEN-created PRs don't).
       - name: Open release refresh PR
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
           commit-message: 'chore: refresh release data'

--- a/.github/workflows/syncSponsorsData.yml
+++ b/.github/workflows/syncSponsorsData.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create pull request for updated docs
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}

--- a/packages/js-api-generator/build.ts
+++ b/packages/js-api-generator/build.ts
@@ -25,6 +25,8 @@ const typeDocConfigBaseOptions: Partial<TypeDocOptions | PluginOptions> = {
   theme: 'tauri-theme',
   plugin: ['typedoc-plugin-mdn-links', 'typedoc-plugin-markdown'],
   readme: 'none',
+  // the pinned typescript 5.5 cannot type-check upstream sources written for newer compilers (generic `Uint8Array` needs 5.7), typedoc only needs the syntax tree
+  skipErrorChecking: true,
   logLevel: 'Warn',
   parametersFormat: 'table',
   // typedoc-plugin-markdown options
@@ -153,9 +155,10 @@ async function generateDocs(options: Partial<TypeDocOptions>) {
 
   const project = await app.convert();
 
-  if (project) {
-    await app.generateDocs(project, outputDir);
+  if (!project) {
+    throw new Error(`typedoc conversion failed for ${options.entryPoints}, see errors above`);
   }
+  await app.generateDocs(project, outputDir);
 }
 
 // Adds frontmatter to the top of the file

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Submodule digests come from git refs, which carry no release timestamp.",
+      "matchManagers": ["git-submodules"],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Disable node/pnpm version updates",
       "matchPackageNames": ["node", "pnpm"],
       "matchDepTypes": ["engines", "packageManager"],

--- a/src/components/awesomeTauriData.ts
+++ b/src/components/awesomeTauriData.ts
@@ -38,7 +38,7 @@ export function loadAwesomeSections(readmePath: string) {
 
     const sections = new Map<string, AwesomeEntry[]>();
     root.children.forEach((header, index) => {
-      if (header.type !== 'heading' || header.depth !== 3) return;
+      if (header.type !== 'heading' || (header.depth !== 2 && header.depth !== 3)) return;
       const list = root.children[index + 1];
       if (list?.type !== 'list') return;
 


### PR DESCRIPTION
fix awesome tauri parser to accept the new format
fix that typedoc here is pinned to 5.5 but Tauri ships stuff that needs typescript >5.5, this is just to unblock until we get the starlight typedoc working

fix the minimal date for submodules
and fix the v that renovate needs for parsing the comment