### PR TITLE
[i18nIgnore] docs: fix a/an article errors

### DIFF
--- a/src/content/docs/develop/calling-frontend.mdx
+++ b/src/content/docs/develop/calling-frontend.mdx
@@ -66,7 +66,7 @@ fn login(app: AppHandle, user: String, password: String) {
 ```
 
 It is also possible to trigger an event to a list of webviews by calling [Emitter#emit_filter].
-In the following example we emit a open-file event to the main and file-viewer webviews:
+In the following example we emit an open-file event to the main and file-viewer webviews:
 
 ```rust title="src-tauri/src/lib.rs"
 use tauri::{AppHandle, Emitter, EventTarget};

--- a/src/content/docs/security/future.mdx
+++ b/src/content/docs/security/future.mdx
@@ -52,7 +52,7 @@ We are planning to further support and implement related features in the future.
 
 In Tauri's current threat model and boundaries we are not able to add more
 security constraints to the WebView itself and since it is the biggest part of
-our stack which is written in an memory unsafe language, we are planning to research and
+our stack which is written in a memory unsafe language, we are planning to research and
 consider ways to further sandbox and isolate the webview processes.
 
 Inbuilt and external sandboxing methods will be evaluated to reduce attack impact

--- a/src/content/docs/security/scope.mdx
+++ b/src/content/docs/security/scope.mdx
@@ -109,7 +109,7 @@ permissions = ["scope-applocaldata-recursive", "deny-default"]
 ```
 
 These scopes can be either used for all commands, by extending the global scope of the plugin,
-or for only selected commands when they are used in combination with a enabled command inside a permission.
+or for only selected commands when they are used in combination with an enabled command inside a permission.
 
 Reasonable read only file access to files in the `APPLOCALDATA` could look like this:
 


### PR DESCRIPTION
Three spots in the docs use the wrong indefinite article. The choice between "a" and "an" follows the sound of the next word, so this corrects each:

- `develop/calling-frontend.mdx`: "we emit a open-file event" to "an open-file event"
- `security/future.mdx`: "written in an memory unsafe language" to "a memory unsafe language"
- `security/scope.mdx`: "in combination with a enabled command" to "an enabled command"

Text only, no code or output changes.
